### PR TITLE
Update `main` branch with latest rustdoc v22 changes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - rustdoc-v*
 
 env:
   RUST_BACKTRACE: 1
@@ -97,7 +98,7 @@ jobs:
       - should-publish
       - ci-everything
       - pre-publish-checks
-    if: needs.should-publish.outputs.is_new_version == 'yes' && github.ref == 'refs/heads/main'
+    if: needs.should-publish.outputs.is_new_version == 'yes' && startsWith(github.ref, 'refs/heads/rustdoc-v')
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,9 +525,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall_core"
-version = "0.0.4"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd142498d675fdc85c48c9f008a6774d6c50cba14c4b45fc2aa3bf83976e31a"
+checksum = "d7c60dc46ba3399b3a6a82fc3258989a8d906e2c8974e9b20e2c293c7616ac2f"
 dependencies = [
  "async-graphql-parser",
  "async-graphql-value",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "22.1.0"
+version = "22.2.0"
 dependencies = [
  "rustdoc-types",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "22.0.0"
+version = "22.1.0"
 dependencies = [
  "rustdoc-types",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustfall-rustdoc-adapter"
-version = "22.1.0"
+version = "22.2.0"
 edition = "2021"
 authors = ["Predrag Gruevski <obi1kenobi82@gmail.com>"]
 license = "Apache-2.0 OR MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "./README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-trustfall_core = "0.0.4"
+trustfall_core = "0.0.7"
 rustdoc-types = "0.18.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustfall-rustdoc-adapter"
-version = "22.0.0"
+version = "22.1.0"
 edition = "2021"
 authors = ["Predrag Gruevski <obi1kenobi82@gmail.com>"]
 license = "Apache-2.0 OR MIT"

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -441,6 +441,17 @@ interface FunctionLike {
   const: Boolean!
   unsafe: Boolean!
   async: Boolean!
+
+  # own edges
+  parameter: [FunctionParameter!]
+}
+
+"""
+A function parameter.
+https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.FnDecl.html
+"""
+type FunctionParameter {
+  name: String!
 }
 
 """
@@ -465,6 +476,9 @@ type Function implements Item & FunctionLike & Importable {
   # edges from Item
   span: Span
   attribute: [Attribute!]
+
+  # edges from FunctionLike
+  parameter: [FunctionParameter!]
 
   # edges from Importable
   importable_path: [ImportablePath!]
@@ -493,6 +507,9 @@ type Method implements Item & FunctionLike {
   # edge from Item
   span: Span
   attribute: [Attribute!]
+
+  # edges from FunctionLike
+  parameter: [FunctionParameter!]
 }
 
 """


### PR DESCRIPTION
Development on specific rustdoc versions proceeds on their own branches titled `rustdoc-v<X>` where `<X>` is the rustdoc version number. Consider the `main` branch as a floating pointer to the most recent rustdoc version's adapter and surrounding code. As new versions of rustdoc are released, we'll check out new branches for them from `main` and they'll continue to be maintained on the branch for their own version.