### PR TITLE
Release v22.4.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "22.3.0"
+version = "22.4.0"
 dependencies = [
  "rustdoc-types",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustfall-rustdoc-adapter"
-version = "22.3.0"
+version = "22.4.0"
 edition = "2021"
 authors = ["Predrag Gruevski <obi1kenobi82@gmail.com>"]
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
- Release v22.1.0.
- Allow publishing from "rustdoc-v" prefixed branches.
- Add function parameters (#4) (#6)
- Release v22.2.0. (#10)
- Update v22 adapter with trustfall_core v0.1.1. (#12)
- New schema for attributes (#5) (#17)
- Added unsafe parameter to trait (#19)
- Release v22.4.0.
