### PR TITLE
Release v16.4.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "16.3.0"
+version = "16.4.0"
 dependencies = [
  "rustdoc-types",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustfall-rustdoc-adapter"
-version = "16.3.0"
+version = "16.4.0"
 edition = "2021"
 authors = ["Predrag Gruevski <obi1kenobi82@gmail.com>"]
 license = "Apache-2.0 OR MIT"

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -499,6 +499,14 @@ fn get_raw_type_property(token: &Token, field_name: &str) -> FieldValue {
     }
 }
 
+fn get_trait_property(token: &Token, field_name: &str) -> FieldValue {
+    let trait_token = token.as_trait().expect("token was not a Trait");
+    match field_name {
+        "unsafe" => trait_token.is_unsafe.into(),
+        _ => unreachable!("Trait property {field_name}"),
+    }
+}
+
 fn get_implemented_trait_property(token: &Token, field_name: &str) -> FieldValue {
     let (path, _) = token
         .as_implemented_trait()
@@ -629,6 +637,11 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                 "AttributeMetaItem" => Box::new(data_contexts.map(move |ctx| {
                     property_mapper(ctx, field_name.as_ref(), get_attribute_meta_item_property)
                 })),
+                "Trait" => {
+                    Box::new(data_contexts.map(move |ctx| {
+                        property_mapper(ctx, field_name.as_ref(), get_trait_property)
+                    }))
+                }
                 "ImplementedTrait" => Box::new(data_contexts.map(move |ctx| {
                     property_mapper(ctx, field_name.as_ref(), get_implemented_trait_property)
                 })),

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -389,7 +389,7 @@ type Trait implements Item & Importable {
   visibility_limit: String!
 
   # own properties
-  variants_stripped: Boolean!
+  unsafe: Boolean!
 
   # edges from Item
   span: Span


### PR DESCRIPTION
- Add rustdoc v16 Trustfall adapter.
- Reformat code.
- Re-export the Crate type from rustdoc-types.
- Fix cargo metadata.
- Publish new versions from GitHub Actions.
- Ensure scripts are executable.
- Fix typo.
- Added first, untested code
- First nonworking test
- Changed the adapter
- Changed one error message
- Replaced a return with unreachable
- Adapt v21 rustdoc adapter changes to v16 rustdoc.
- Release v16.1.
- Allow publishing from "rustdoc-v" prefixed branches.
- Add function parameters (#4) (#7)
- Release v16.2.0. (#8)
- Update v16 adapter with trustfall_core v0.1.1. (#14)
- New schema for attributes (#5) (#16)
- Added unsafe parameter to trait (#19)
- Release v16.4.0.
