### PR TITLE
Support omitting defaulted generic parameters.

### DIFF
--- a/test_crates/pub_generic_type_alias_added_defaults/Cargo.toml
+++ b/test_crates/pub_generic_type_alias_added_defaults/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "pub_generic_type_alias_added_defaults"
 version = "0.1.0"
 edition = "2021"

--- a/test_crates/pub_generic_type_alias_omitted_default/Cargo.toml
+++ b/test_crates/pub_generic_type_alias_omitted_default/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 publish = false
-name = "infinite_indirect_recursive_reexport"
+name = "pub_generic_type_alias_omitted_default"
 version = "0.1.0"
 edition = "2021"
 

--- a/test_crates/pub_generic_type_alias_omitted_default/src/lib.rs
+++ b/test_crates/pub_generic_type_alias_omitted_default/src/lib.rs
@@ -1,0 +1,55 @@
+//! This package exports the following:
+//! - `inner::DefaultConst`
+//! - `inner::DefaultType`
+//! - `inner::ConstOnly`
+//! - `inner::TypeOnly`
+//! - `OmittedConst`
+//! - `OmittedType`
+//! - `NonGenericConst`
+//! - `NonGenericType`
+//!
+//! Typedefs that remove a generic parameter and rely on the underlying type's default value
+//! change the semantics of the type, since that default cannot be overriden anymore.
+//! The typedef cannot be treated as a re-export of the underlying type.
+
+pub mod inner {
+    pub struct DefaultConst<'a, T, const N: usize = 5> {
+        _marker: std::marker::PhantomData<&'a [T; N]>,
+    }
+
+    pub struct DefaultType<'a, const N: usize, T = i64> {
+        _marker: std::marker::PhantomData<&'a [T; N]>,
+    }
+
+    pub struct ConstOnly<const N: usize = 5> {
+        _marker: std::marker::PhantomData<[i64; N]>,
+    }
+
+    pub struct TypeOnly<T = i64> {
+        _marker: std::marker::PhantomData<T>,
+    }
+}
+
+// The following types aren't semantically equivalent to the underlying types,
+// so we consider them as separate typedefs rather than pure re-exports.
+//
+// They are not equivalent because they *don't allow any other value* for
+// the generic parameter that contains a default. For example, one can't write:
+// ```rust
+// fn f(value: OmittedType<'a, N, T = ()>) {}
+// ```
+// whereas the equivalent is possible with the underlying type:
+// ```rust
+// fn f(value: DefaultType<'a, N, T = ()>) {}
+// ```
+
+pub type OmittedConst<'a, T> = crate::inner::DefaultConst<'a, T>;
+
+pub type OmittedType<'a, const N: usize> = crate::inner::DefaultType<'a, N>;
+
+// The following types also aren't semantically equivalent, for the same reason as above.
+// They just show that typedefs can be non-generic even if the underlying type is generic.
+
+pub type NonGenericConst = crate::inner::ConstOnly;
+
+pub type NonGenericType = crate::inner::TypeOnly;

--- a/test_crates/pub_generic_type_alias_reexport/Cargo.toml
+++ b/test_crates/pub_generic_type_alias_reexport/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "pub_generic_type_alias_reexport"
 version = "0.1.0"
 edition = "2021"

--- a/test_crates/pub_generic_type_alias_same_signature_but_not_equivalent/Cargo.toml
+++ b/test_crates/pub_generic_type_alias_same_signature_but_not_equivalent/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "pub_generic_type_alias_same_signature_but_not_equivalent"
 version = "0.1.0"
 edition = "2021"

--- a/test_crates/pub_generic_type_alias_shuffled_order/Cargo.toml
+++ b/test_crates/pub_generic_type_alias_shuffled_order/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "pub_generic_type_alias_shuffled_order"
 version = "0.1.0"
 edition = "2021"

--- a/test_crates/pub_inside_pub_crate_mod/Cargo.toml
+++ b/test_crates/pub_inside_pub_crate_mod/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "pub_inside_pub_crate_mod"
 version = "0.1.0"
 edition = "2021"

--- a/test_crates/pub_type_alias_of_composite_type/Cargo.toml
+++ b/test_crates/pub_type_alias_of_composite_type/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "pub_type_alias_of_composite_type"
 version = "0.1.0"
 edition = "2021"

--- a/test_crates/pub_type_alias_of_type_alias/Cargo.toml
+++ b/test_crates/pub_type_alias_of_type_alias/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "pub_type_alias_of_type_alias"
 version = "0.1.0"
 edition = "2021"

--- a/test_crates/pub_type_alias_shuffled_order/Cargo.toml
+++ b/test_crates/pub_type_alias_shuffled_order/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "pub_type_alias_shuffled_order"
 version = "0.1.0"
 edition = "2021"


### PR DESCRIPTION
Resolve the issue raised in https://github.com/libp2p/rust-libp2p/pull/3401#issuecomment-1409381365
