### PR TITLE
Add `explicit_reexport_of_matching_names` test case.

### DIFF
--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -1302,7 +1302,7 @@ mod tests {
         fn explicit_reexport_of_matching_names() {
             let test_crate = "explicit_reexport_of_matching_names";
             let expected_items = btreemap! {
-                "Foo" => (3, btreeset![
+                "Foo" => (2, btreeset![
                     "explicit_reexport_of_matching_names::Bar",
                     "explicit_reexport_of_matching_names::Foo",
                     "explicit_reexport_of_matching_names::nested::Foo",

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -1297,5 +1297,19 @@ mod tests {
 
             assert_duplicated_exported_items_match(test_crate, &expected_items);
         }
+
+        #[test]
+        fn explicit_reexport_of_matching_names() {
+            let test_crate = "explicit_reexport_of_matching_names";
+            let expected_items = btreemap! {
+                "Foo" => (3, btreeset![
+                    "explicit_reexport_of_matching_names::Bar",
+                    "explicit_reexport_of_matching_names::Foo",
+                    "explicit_reexport_of_matching_names::nested::Foo",
+                ]),
+            };
+
+            assert_duplicated_exported_items_match(test_crate, &expected_items);
+        }
     }
 }

--- a/test_crates/explicit_reexport_of_matching_names/Cargo.toml
+++ b/test_crates/explicit_reexport_of_matching_names/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "explicit_reexport_of_matching_names"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/test_crates/explicit_reexport_of_matching_names/src/lib.rs
+++ b/test_crates/explicit_reexport_of_matching_names/src/lib.rs
@@ -1,0 +1,30 @@
+//! In Rust, type names and value names (including both `fn` and `const`) have different,
+//! mutually-disjoint namespaces. It's allowed for those namespaces to have matching names.
+//! When the name is used, the surrounding context determines whether it's resolved
+//! to the value or to the type by that name.
+//!
+//! For the love of all that is good in the world,
+//! please *do not* actually write code like this.
+//! This is peak "do as I say, not as I do" territory.
+//!
+//! This package exports the following:
+//! - the function `Foo`, also as `Bar` and `nested::Foo`
+//! - the type `Foo`, also as `Bar` and `nested::Foo`
+
+pub mod nested {
+    pub struct Foo {}
+
+    #[allow(non_snake_case)]
+    pub fn Foo() {}
+}
+
+pub use nested::Foo;
+pub use Foo as Bar;
+
+// Proof that both the type and the function are visible.
+// Not exported.
+#[allow(dead_code)]
+fn proof() -> Bar {
+    Bar();
+    Bar {}
+}


### PR DESCRIPTION
Test case for rustdoc JSON underlying bug: https://github.com/rust-lang/rust/issues/107677