### PR TITLE
Add `explicit_reexport_of_matching_names` test case. (#72)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,6 +498,7 @@ dependencies = [
  "serde",
  "serde_json",
  "trustfall",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ itertools = "0.10.5"
 serde_json = "1.0.85"
 serde = { version = "1.0.145", features = ["derive"] }
 maplit = "1.0.2"
+version_check = "0.9.4"

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -1300,16 +1300,23 @@ mod tests {
 
         #[test]
         fn explicit_reexport_of_matching_names() {
-            let test_crate = "explicit_reexport_of_matching_names";
-            let expected_items = btreemap! {
-                "Foo" => (2, btreeset![
-                    "explicit_reexport_of_matching_names::Bar",
-                    "explicit_reexport_of_matching_names::Foo",
-                    "explicit_reexport_of_matching_names::nested::Foo",
-                ]),
-            };
+            if version_check::is_min_version("1.69.0").unwrap_or(true) {
+                let test_crate = "explicit_reexport_of_matching_names";
+                let expected_items = btreemap! {
+                    "Foo" => (2, btreeset![
+                        "explicit_reexport_of_matching_names::Bar",
+                        "explicit_reexport_of_matching_names::Foo",
+                        "explicit_reexport_of_matching_names::nested::Foo",
+                    ]),
+                };
 
-            assert_duplicated_exported_items_match(test_crate, &expected_items);
+                assert_duplicated_exported_items_match(test_crate, &expected_items);
+            } else {
+                eprintln!(
+                    "skipping 'explicit_reexport_of_matching_names' test due to Rust {:?}",
+                    version_check::Version::read(),
+                );
+            }
         }
     }
 }

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -1317,7 +1317,8 @@ mod tests {
                     std::io::stderr(),
                     "skipping 'explicit_reexport_of_matching_names' test due to Rust {:?}",
                     version_check::Version::read(),
-                ).expect("write failed");
+                )
+                .expect("write failed");
             }
         }
     }

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -1312,10 +1312,12 @@ mod tests {
 
                 assert_duplicated_exported_items_match(test_crate, &expected_items);
             } else {
-                eprintln!(
+                use std::io::Write;
+                writeln!(
+                    std::io::stderr(),
                     "skipping 'explicit_reexport_of_matching_names' test due to Rust {:?}",
                     version_check::Version::read(),
-                );
+                ).expect("write failed");
             }
         }
     }

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -1297,5 +1297,19 @@ mod tests {
 
             assert_duplicated_exported_items_match(test_crate, &expected_items);
         }
+
+        #[test]
+        fn explicit_reexport_of_matching_names() {
+            let test_crate = "explicit_reexport_of_matching_names";
+            let expected_items = btreemap! {
+                "Foo" => (2, btreeset![
+                    "explicit_reexport_of_matching_names::Bar",
+                    "explicit_reexport_of_matching_names::Foo",
+                    "explicit_reexport_of_matching_names::nested::Foo",
+                ]),
+            };
+
+            assert_duplicated_exported_items_match(test_crate, &expected_items);
+        }
     }
 }

--- a/test_crates/explicit_reexport_of_matching_names/Cargo.toml
+++ b/test_crates/explicit_reexport_of_matching_names/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "explicit_reexport_of_matching_names"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/test_crates/explicit_reexport_of_matching_names/src/lib.rs
+++ b/test_crates/explicit_reexport_of_matching_names/src/lib.rs
@@ -1,0 +1,30 @@
+//! In Rust, type names and value names (including both `fn` and `const`) have different,
+//! mutually-disjoint namespaces. It's allowed for those namespaces to have matching names.
+//! When the name is used, the surrounding context determines whether it's resolved
+//! to the value or to the type by that name.
+//!
+//! For the love of all that is good in the world,
+//! please *do not* actually write code like this.
+//! This is peak "do as I say, not as I do" territory.
+//!
+//! This package exports the following:
+//! - the function `Foo`, also as `Bar` and `nested::Foo`
+//! - the type `Foo`, also as `Bar` and `nested::Foo`
+
+pub mod nested {
+    pub struct Foo {}
+
+    #[allow(non_snake_case)]
+    pub fn Foo() {}
+}
+
+pub use nested::Foo;
+pub use Foo as Bar;
+
+// Proof that both the type and the function are visible.
+// Not exported.
+#[allow(dead_code)]
+fn proof() -> Bar {
+    Bar();
+    Bar {}
+}


### PR DESCRIPTION
Originally needed to be reverted since Rust 1.68 stable doesn't pass the new test case, even though it uses the rustdoc v24 JSON format.

That test is now conditionally enabled only on Rust 1.69+ versions.