### PR TITLE
cp rustdoc v21 a622ff0bd15e410493e26c891feba4afab9681af

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall"
-version = "0.3.4"
+version = "0.4.0-beta.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d08b46bc8870b30f46d288a48cce399f30d08a39b36ab50489eacb851bb81c85"
+checksum = "cbca5cde4e5f80224282cff66037c68100f874f72c28452728b2eaeb0e04b3c1"
 dependencies = [
  "anyhow",
  "trustfall_core",
@@ -502,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall_core"
-version = "0.3.3"
+version = "0.4.0-beta.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7af71d1100b656a92610b4286ed59d06a1ec175f0933cbe208929456fb7854cb"
+checksum = "20be4c037e871b44c4b584fb4876cc5490e250fcec45f049903dda1a04ae4cd1"
 dependencies = [
  "async-graphql-parser",
  "async-graphql-value",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "./README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-trustfall = "0.3.4"
+trustfall = "0.4.0-beta"
 rustdoc-types = "0.17.0"
 
 [dev-dependencies]

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -7,8 +7,8 @@ use rustdoc_types::{
 use trustfall::{
     provider::{
         resolve_coercion_with, resolve_neighbors_with, resolve_property_with, Adapter,
-        ContextIterator, ContextOutcomeIterator, EdgeParameters, QueryInfo, Typename,
-        VertexIterator,
+        ContextIterator, ContextOutcomeIterator, EdgeParameters, ResolveEdgeInfo, ResolveInfo,
+        Typename, VertexIterator,
     },
     FieldValue, Schema,
 };
@@ -541,7 +541,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
         &mut self,
         edge_name: &Arc<str>,
         _parameters: &EdgeParameters,
-        _query_info: &QueryInfo,
+        _query_info: &ResolveInfo,
     ) -> VertexIterator<'a, Self::Vertex> {
         match edge_name.as_ref() {
             "Crate" => Box::new(std::iter::once(Vertex::new_crate(
@@ -564,7 +564,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
         contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &Arc<str>,
         property_name: &Arc<str>,
-        _query_info: &QueryInfo,
+        _query_info: &ResolveInfo,
     ) -> ContextOutcomeIterator<'a, Self::Vertex, FieldValue> {
         if property_name.as_ref() == "__typename" {
             Box::new(contexts.map(|ctx| match ctx.active_vertex() {
@@ -654,7 +654,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
         parameters: &EdgeParameters,
-        _query_info: &QueryInfo,
+        _query_info: &ResolveEdgeInfo,
     ) -> ContextOutcomeIterator<'a, Self::Vertex, VertexIterator<'a, Self::Vertex>> {
         match type_name.as_ref() {
             "CrateDiff" => match edge_name.as_ref() {
@@ -1122,7 +1122,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
         contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &Arc<str>,
         coerce_to_type: &Arc<str>,
-        _query_info: &QueryInfo,
+        _query_info: &ResolveInfo,
     ) -> ContextOutcomeIterator<'a, Self::Vertex, bool> {
         let coerce_to_type = coerce_to_type.clone();
         match type_name.as_ref() {


### PR DESCRIPTION
- Fix cargo metadata.
- Publish new versions from GitHub Actions.
- Ensure scripts are executable.
- Fix typo.
- Added first, untested code
- First nonworking test
- Changed the adapter
- Changed one error message
- Replaced a return with unreachable
- Release v21.1.0.
- Allow publishing from "rustdoc-v" prefixed branches.
- Add function parameters (#4)
- Release v21.2.0. (#9)
- Update v21 adapter with trustfall_core v0.1.1. (#13)
- New schema for attributes (#5)
- Release v21.4.0. (#22)
- Use the Swatinem/rust-cache@v2 action for caching. (#29)
- Add fields to Variant interface (#31)
- Support renaming re-exports, glob re-exports, and type aliases used as renames. (#34) (#38)
- Release v21.5.0. (#43)
- Rely on the test crates instead of the manually-generated file. (#50)
- Support omitting defaulted generic parameters. (#52) (#55)
- Release v21.5.1. (#59)
- Add a test case where a type and a value have the same name. (#60) (#61)
- Remove extraneous `println!()` statements and release v21.5.2. (#65)
- Clippy deny print statements. (#66) (#67)
- Add `renaming_reexport_of_reexport` test crate. (#70) (#73)
- Extract a function for testing re-exports with matching names. (#71) (#76)
- Fix error message text. (#79) (#80)
- Don't fetch dependency info when reporting the current crate version. (#87)
- Begin renaming items to match Trustfall v0.3 conventions. (#91)
- Use the new helpers in Trustfall v0.3. (#97)
- Make required jobs actually required. (#103) (#104)
- Release v21.6.0. (#110)
- Switch to dtolnay's Rust toolchain action, remove `::set-output` uses. (#112)
- Eliminate the last actions-rs Actions dependencies. (#116)
- Port to Trustfall v0.4.0 APIs. (#119)
