### PR TITLE
Use ergonomic Trustfall helpers for property resolution. (#124)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -59,9 +59,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bitflags"
@@ -71,27 +71,33 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -101,9 +107,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -116,16 +122,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.3"
+name = "codespan-reporting"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
 dependencies = [
  "libc",
 ]
@@ -141,10 +157,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.10.5"
+name = "cxx"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn 2.0.13",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.13",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -152,15 +212,15 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -174,22 +234,33 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.50"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd911b35d940d2bd0bea0f9100068e5b97b51a1cbe13d13382f132e0365257a0"
+checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
+ "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "winapi",
+ "windows",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
 ]
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -207,15 +278,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.3"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -228,9 +299,18 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.133"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "log"
@@ -274,15 +354,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "pest"
-version = "2.3.1"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb779fcf4bb850fbbb0edc96ff6cf34fd90c4b1a112ce042653280d9a7364048"
+checksum = "7b1403e8401ad5dedea73c626b99758535b342502f8d1e361f4a2dd952749122"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -290,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.3.1"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502b62a6d0245378b04ffe0a7fb4f4419a4815fce813bd8a0ec89a56e07d67b1"
+checksum = "be99c4c1d2fc2769b1d00239431d711d08f6efedcecb8b6e30707160aee99c15"
 dependencies = [
  "pest",
  "pest_generator",
@@ -300,51 +380,51 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.3.1"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451e629bf49b750254da26132f1a5a9d11fd8a95a3df51d15c4abd1ba154cb6c"
+checksum = "e56094789873daa36164de2e822b3888c6ae4b4f9da555a1103587658c805b1e"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.3.1"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcec162c71c45e269dfc3fc2916eaeb97feab22993a21bcce4721d08cd7801a6"
+checksum = "6733073c7cff3d8459fda0e42f13a047870242aed8b509fe98000928975f359e"
 dependencies = [
  "once_cell",
  "pest",
- "sha1",
+ "sha2",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.53"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -353,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "ron"
@@ -379,35 +459,41 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "scratch"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
 dependencies = [
  "itoa",
  "ryu",
@@ -415,10 +501,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.5"
+name = "sha2"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -427,18 +513,18 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.101"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -446,30 +532,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.36"
+name = "syn"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a99cb8c4b9a8ef0e7907cd3b617cc8dc04d571c4e73c8ae403d80ac160bb122"
+checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.36"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a891860d3c8d66fec8e73ddb3765f90082374dbaaa833407b904a94f1a7eb43"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
  "wasi",
@@ -527,14 +633,14 @@ checksum = "486543a0d60e041e8fdf8595a8a0686173ad0071d07e11d8c228750ab28767df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-trie"
@@ -544,9 +650,15 @@ checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.4"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "version_check"
@@ -562,9 +674,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -572,24 +684,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -597,22 +709,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "winapi"
@@ -631,7 +743,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -5,9 +5,9 @@ use rustdoc_types::{
 };
 use trustfall::{
     provider::{
-        resolve_coercion_with, resolve_neighbors_with, resolve_property_with, Adapter,
-        ContextIterator, ContextOutcomeIterator, EdgeParameters, ResolveEdgeInfo, ResolveInfo,
-        Typename, VertexIterator,
+        accessor_property, field_property, resolve_coercion_with, resolve_neighbors_with,
+        resolve_property_with, Adapter, ContextIterator, ContextOutcomeIterator, EdgeParameters,
+        ResolveEdgeInfo, ResolveInfo, Typename, VertexIterator,
     },
     FieldValue, Schema,
 };
@@ -209,16 +209,16 @@ impl<'a> Vertex<'a> {
         }
     }
 
-    fn as_struct_item(&self) -> Option<(&'a Item, &'a Struct)> {
+    fn as_struct(&self) -> Option<&'a Struct> {
         self.as_item().and_then(|item| match &item.inner {
-            rustdoc_types::ItemEnum::Struct(s) => Some((item, s)),
+            rustdoc_types::ItemEnum::Struct(s) => Some(s),
             _ => None,
         })
     }
 
-    fn as_struct_field_item(&self) -> Option<(&'a Item, &'a Type)> {
+    fn as_struct_field(&self) -> Option<&'a Type> {
         self.as_item().and_then(|item| match &item.inner {
-            rustdoc_types::ItemEnum::StructField(s) => Some((item, s)),
+            rustdoc_types::ItemEnum::StructField(s) => Some(s),
             _ => None,
         })
     }
@@ -333,185 +333,274 @@ impl<'a> From<&'a Span> for VertexKind<'a> {
     }
 }
 
-fn get_crate_property(crate_vertex: &Vertex, field_name: &str) -> FieldValue {
-    let crate_item = crate_vertex.as_crate().expect("vertex was not a Crate");
-    match field_name {
-        "root" => crate_item.root.0.clone().into(),
-        "crate_version" => crate_item.crate_version.clone().into(),
-        "includes_private" => crate_item.includes_private.into(),
-        "format_version" => crate_item.format_version.into(),
-        _ => unreachable!("Crate property {field_name}"),
-    }
-}
-
-fn get_item_property(item_vertex: &Vertex, field_name: &str) -> FieldValue {
-    let item = item_vertex.as_item().expect("vertex was not an Item");
-    match field_name {
-        "id" => item.id.0.clone().into(),
-        "crate_id" => item.crate_id.into(),
-        "name" => item.name.clone().into(),
-        "docs" => item.docs.clone().into(),
-        "attrs" => item.attrs.clone().into(),
-        "visibility_limit" => match &item.visibility {
-            rustdoc_types::Visibility::Public => "public".into(),
-            rustdoc_types::Visibility::Default => "default".into(),
-            rustdoc_types::Visibility::Crate => "crate".into(),
-            rustdoc_types::Visibility::Restricted { parent: _, path } => {
-                format!("restricted ({path})").into()
-            }
-        },
-        _ => unreachable!("Item property {field_name}"),
-    }
-}
-
-fn get_struct_property(item_vertex: &Vertex, field_name: &str) -> FieldValue {
-    let (_, struct_item) = item_vertex
-        .as_struct_item()
-        .expect("vertex was not a Struct");
-    match field_name {
-        "struct_type" => match struct_item.kind {
-            rustdoc_types::StructKind::Plain { .. } => "plain",
-            rustdoc_types::StructKind::Tuple(..) => "tuple",
-            rustdoc_types::StructKind::Unit => "unit",
+fn resolve_crate_property<'a>(
+    contexts: ContextIterator<'a, Vertex<'a>>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, Vertex<'a>, FieldValue> {
+    match property_name {
+        "root" => resolve_property_with(
+            contexts,
+            field_property!(as_crate, root, { root.0.clone().into() }),
+        ),
+        "crate_version" => {
+            resolve_property_with(contexts, field_property!(as_crate, crate_version))
         }
-        .into(),
-        "fields_stripped" => match struct_item.kind {
-            rustdoc_types::StructKind::Plain {
-                fields_stripped, ..
-            } => fields_stripped.into(),
-            _ => FieldValue::Null,
-        },
-        _ => unreachable!("Struct property {field_name}"),
+        "includes_private" => {
+            resolve_property_with(contexts, field_property!(as_crate, includes_private))
+        }
+        "format_version" => {
+            resolve_property_with(contexts, field_property!(as_crate, format_version))
+        }
+        _ => unreachable!("Crate property {property_name}"),
     }
 }
 
-fn get_span_property(item_vertex: &Vertex, field_name: &str) -> FieldValue {
-    let span = item_vertex.as_span().expect("vertex was not a Span");
-    match field_name {
-        "filename" => span
-            .filename
-            .to_str()
-            .expect("non-representable path")
-            .into(),
-        "begin_line" => (span.begin.0 as u64).into(),
-        "begin_column" => (span.begin.1 as u64).into(),
-        "end_line" => (span.end.0 as u64).into(),
-        "end_column" => (span.end.1 as u64).into(),
-        _ => unreachable!("Span property {field_name}"),
+fn resolve_item_property<'a>(
+    contexts: ContextIterator<'a, Vertex<'a>>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, Vertex<'a>, FieldValue> {
+    match property_name {
+        "id" => resolve_property_with(
+            contexts,
+            field_property!(as_item, id, { id.0.clone().into() }),
+        ),
+        "crate_id" => resolve_property_with(contexts, field_property!(as_item, crate_id)),
+        "name" => resolve_property_with(contexts, field_property!(as_item, name)),
+        "docs" => resolve_property_with(contexts, field_property!(as_item, docs)),
+        "attrs" => resolve_property_with(contexts, field_property!(as_item, attrs)),
+        "visibility_limit" => resolve_property_with(contexts, |vertex| {
+            let item = vertex.as_item().expect("not an item");
+            match &item.visibility {
+                rustdoc_types::Visibility::Public => "public".into(),
+                rustdoc_types::Visibility::Default => "default".into(),
+                rustdoc_types::Visibility::Crate => "crate".into(),
+                rustdoc_types::Visibility::Restricted { parent: _, path } => {
+                    format!("restricted ({path})").into()
+                }
+            }
+        }),
+        _ => unreachable!("Item property {property_name}"),
     }
 }
 
-fn get_enum_property(item_vertex: &Vertex, field_name: &str) -> FieldValue {
-    let enum_item = item_vertex.as_enum().expect("vertex was not an Enum");
-    match field_name {
-        "variants_stripped" => enum_item.variants_stripped.into(),
-        _ => unreachable!("Enum property {field_name}"),
+fn resolve_struct_property<'a>(
+    contexts: ContextIterator<'a, Vertex<'a>>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, Vertex<'a>, FieldValue> {
+    match property_name {
+        "struct_type" => resolve_property_with(contexts, |vertex| {
+            let struct_vertex = vertex.as_struct().expect("not a struct");
+            match struct_vertex.kind {
+                rustdoc_types::StructKind::Plain { .. } => "plain",
+                rustdoc_types::StructKind::Tuple(..) => "tuple",
+                rustdoc_types::StructKind::Unit => "unit",
+            }
+            .into()
+        }),
+        "fields_stripped" => resolve_property_with(contexts, |vertex| {
+            let struct_vertex = vertex.as_struct().expect("not a struct");
+            match struct_vertex.kind {
+                rustdoc_types::StructKind::Plain {
+                    fields_stripped, ..
+                } => fields_stripped.into(),
+                _ => FieldValue::Null,
+            }
+        }),
+        _ => unreachable!("Struct property {property_name}"),
     }
 }
 
-fn get_path_property(vertex: &Vertex, field_name: &str) -> FieldValue {
-    let path_vertex = vertex.as_path().expect("vertex was not a Path");
-    match field_name {
-        "path" => path_vertex.into(),
-        _ => unreachable!("Path property {field_name}"),
+fn resolve_span_property<'a>(
+    contexts: ContextIterator<'a, Vertex<'a>>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, Vertex<'a>, FieldValue> {
+    match property_name {
+        "filename" => resolve_property_with(
+            contexts,
+            field_property!(as_span, filename, {
+                filename.to_str().expect("non-representable path").into()
+            }),
+        ),
+        "begin_line" => resolve_property_with(
+            contexts,
+            field_property!(as_span, begin, { (begin.0 as u64).into() }),
+        ),
+        "begin_column" => resolve_property_with(
+            contexts,
+            field_property!(as_span, begin, { (begin.1 as u64).into() }),
+        ),
+        "end_line" => resolve_property_with(
+            contexts,
+            field_property!(as_span, end, { (end.0 as u64).into() }),
+        ),
+        "end_column" => resolve_property_with(
+            contexts,
+            field_property!(as_span, end, { (end.1 as u64).into() }),
+        ),
+        _ => unreachable!("Span property {property_name}"),
     }
 }
 
-fn get_importable_path_property(vertex: &Vertex, field_name: &str) -> FieldValue {
-    let path_vertex = vertex
-        .as_importable_path()
-        .expect("vertex was not an ImportablePath");
-    match field_name {
-        "path" => path_vertex
-            .iter()
-            .map(|x| x.to_string())
-            .collect::<Vec<_>>()
-            .into(),
-        "visibility_limit" => "public".into(),
-        _ => unreachable!("ImportablePath property {field_name}"),
+fn resolve_enum_property<'a>(
+    contexts: ContextIterator<'a, Vertex<'a>>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, Vertex<'a>, FieldValue> {
+    match property_name {
+        "variants_stripped" => {
+            resolve_property_with(contexts, field_property!(as_enum, variants_stripped))
+        }
+        _ => unreachable!("Enum property {property_name}"),
     }
 }
 
-fn get_function_like_property(vertex: &Vertex, field_name: &str) -> FieldValue {
-    let function = vertex.as_function().expect("not a function");
-
-    match field_name {
-        "const" => function.header.const_.into(),
-        "async" => function.header.async_.into(),
-        "unsafe" => function.header.unsafe_.into(),
-        _ => unreachable!("FunctionLike property {field_name}"),
+fn resolve_path_property<'a>(
+    contexts: ContextIterator<'a, Vertex<'a>>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, Vertex<'a>, FieldValue> {
+    match property_name {
+        "path" => resolve_property_with(contexts, |vertex| {
+            vertex.as_path().expect("not a path").into()
+        }),
+        _ => unreachable!("Path property {property_name}"),
     }
 }
 
-fn get_function_parameter_property(vertex: &Vertex, field_name: &str) -> FieldValue {
-    let function_parameter_vertex = vertex
-        .as_function_parameter()
-        .expect("vertex was not a FunctionParameter");
-
-    match field_name {
-        "name" => function_parameter_vertex.into(),
-        _ => unreachable!("FunctionParameter property {field_name}"),
+fn resolve_importable_path_property<'a>(
+    contexts: ContextIterator<'a, Vertex<'a>>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, Vertex<'a>, FieldValue> {
+    match property_name {
+        "path" => resolve_property_with(contexts, |vertex| {
+            vertex
+                .as_importable_path()
+                .expect("not an importable path")
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .into()
+        }),
+        "visibility_limit" => resolve_property_with(contexts, |_| "public".into()),
+        _ => unreachable!("ImportablePath property {property_name}"),
     }
 }
 
-fn get_impl_property(vertex: &Vertex, field_name: &str) -> FieldValue {
-    let impl_vertex = vertex.as_impl().expect("vertex was not an Impl");
-    match field_name {
-        "unsafe" => impl_vertex.is_unsafe.into(),
-        "negative" => impl_vertex.negative.into(),
-        "synthetic" => impl_vertex.synthetic.into(),
-        _ => unreachable!("Impl property {field_name}"),
+fn resolve_function_like_property<'a>(
+    contexts: ContextIterator<'a, Vertex<'a>>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, Vertex<'a>, FieldValue> {
+    match property_name {
+        "const" => resolve_property_with(
+            contexts,
+            field_property!(as_function, header, { header.const_.into() }),
+        ),
+        "async" => resolve_property_with(
+            contexts,
+            field_property!(as_function, header, { header.async_.into() }),
+        ),
+        "unsafe" => resolve_property_with(
+            contexts,
+            field_property!(as_function, header, { header.unsafe_.into() }),
+        ),
+        _ => unreachable!("FunctionLike property {property_name}"),
     }
 }
 
-fn get_attribute_property(vertex: &Vertex, field_name: &str) -> FieldValue {
-    let attribute = vertex.as_attribute().expect("vertex was not an Attribute");
-    match field_name {
-        "raw_attribute" => attribute.raw_attribute().into(),
-        "is_inner" => attribute.is_inner.into(),
-        _ => unreachable!("Attribute property {field_name}"),
+fn resolve_function_parameter_property<'a>(
+    contexts: ContextIterator<'a, Vertex<'a>>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, Vertex<'a>, FieldValue> {
+    match property_name {
+        "name" => resolve_property_with(contexts, |vertex| {
+            vertex
+                .as_function_parameter()
+                .expect("not a function parameter")
+                .into()
+        }),
+        _ => unreachable!("FunctionParameter property {property_name}"),
     }
 }
 
-fn get_attribute_meta_item_property(vertex: &Vertex, field_name: &str) -> FieldValue {
-    let meta_item = vertex
-        .as_attribute_meta_item()
-        .expect("vertex was not an AttributeMetaItem");
-    match field_name {
-        "raw_item" => meta_item.raw_item.into(),
-        "base" => meta_item.base.into(),
-        "assigned_item" => meta_item.assigned_item.into(),
-        _ => unreachable!("Attribute property {field_name}"),
+fn resolve_impl_property<'a>(
+    contexts: ContextIterator<'a, Vertex<'a>>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, Vertex<'a>, FieldValue> {
+    match property_name {
+        "unsafe" => resolve_property_with(contexts, field_property!(as_impl, is_unsafe)),
+        "negative" => resolve_property_with(contexts, field_property!(as_impl, negative)),
+        "synthetic" => resolve_property_with(contexts, field_property!(as_impl, synthetic)),
+        _ => unreachable!("Impl property {property_name}"),
     }
 }
 
-fn get_raw_type_property(vertex: &Vertex, field_name: &str) -> FieldValue {
-    let type_vertex = vertex.as_raw_type().expect("vertex was not a RawType");
-    match field_name {
-        "name" => match type_vertex {
-            rustdoc_types::Type::ResolvedPath(path) => (&path.name).into(),
-            rustdoc_types::Type::Primitive(name) => name.into(),
-            _ => unreachable!("unexpected RawType vertex content: {type_vertex:?}"),
-        },
-        _ => unreachable!("RawType property {field_name}"),
+fn resolve_attribute_property<'a>(
+    contexts: ContextIterator<'a, Vertex<'a>>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, Vertex<'a>, FieldValue> {
+    match property_name {
+        "raw_attribute" => {
+            resolve_property_with(contexts, accessor_property!(as_attribute, raw_attribute))
+        }
+        "is_inner" => resolve_property_with(contexts, field_property!(as_attribute, is_inner)),
+        _ => unreachable!("Attribute property {property_name}"),
     }
 }
 
-fn get_trait_property(vertex: &Vertex, field_name: &str) -> FieldValue {
-    let trait_vertex = vertex.as_trait().expect("vertex was not a Trait");
-    match field_name {
-        "unsafe" => trait_vertex.is_unsafe.into(),
-        _ => unreachable!("Trait property {field_name}"),
+fn resolve_attribute_meta_item_property<'a>(
+    contexts: ContextIterator<'a, Vertex<'a>>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, Vertex<'a>, FieldValue> {
+    match property_name {
+        "raw_item" => {
+            resolve_property_with(contexts, field_property!(as_attribute_meta_item, raw_item))
+        }
+        "base" => resolve_property_with(contexts, field_property!(as_attribute_meta_item, base)),
+        "assigned_item" => resolve_property_with(
+            contexts,
+            field_property!(as_attribute_meta_item, assigned_item),
+        ),
+        _ => unreachable!("AttributeMetaItem property {property_name}"),
     }
 }
 
-fn get_implemented_trait_property(vertex: &Vertex, field_name: &str) -> FieldValue {
-    let (path, _) = vertex
-        .as_implemented_trait()
-        .expect("vertex was not a ImplementedTrait");
-    match field_name {
-        "name" => (&path.name).into(),
-        _ => unreachable!("ImplementedTrait property {field_name}"),
+fn resolve_raw_type_property<'a>(
+    contexts: ContextIterator<'a, Vertex<'a>>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, Vertex<'a>, FieldValue> {
+    match property_name {
+        "name" => resolve_property_with(contexts, |vertex| {
+            let type_vertex = vertex.as_raw_type().expect("not a RawType");
+            match type_vertex {
+                rustdoc_types::Type::ResolvedPath(path) => path.name.clone().into(),
+                rustdoc_types::Type::Primitive(name) => name.clone().into(),
+                _ => unreachable!("unexpected RawType vertex content: {type_vertex:?}"),
+            }
+        }),
+        _ => unreachable!("RawType property {property_name}"),
+    }
+}
+
+fn resolve_trait_property<'a>(
+    contexts: ContextIterator<'a, Vertex<'a>>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, Vertex<'a>, FieldValue> {
+    match property_name {
+        "unsafe" => resolve_property_with(contexts, field_property!(as_trait, is_unsafe)),
+        _ => unreachable!("Trait property {property_name}"),
+    }
+}
+
+fn resolve_implemented_trait_property<'a>(
+    contexts: ContextIterator<'a, Vertex<'a>>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, Vertex<'a>, FieldValue> {
+    match property_name {
+        "name" => resolve_property_with(contexts, |vertex| {
+            let (path, _) = vertex
+                .as_implemented_trait()
+                .expect("not an ImplementedTrait");
+            path.name.clone().into()
+        }),
+        _ => unreachable!("Trait property {property_name}"),
     }
 }
 
@@ -522,7 +611,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
         &mut self,
         edge_name: &Arc<str>,
         _parameters: &EdgeParameters,
-        _query_info: &ResolveInfo,
+        _resolve_info: &ResolveInfo,
     ) -> VertexIterator<'a, Self::Vertex> {
         match edge_name.as_ref() {
             "Crate" => Box::new(std::iter::once(Vertex::new_crate(
@@ -545,7 +634,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
         contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &Arc<str>,
         property_name: &Arc<str>,
-        _query_info: &ResolveInfo,
+        _resolve_info: &ResolveInfo,
     ) -> ContextOutcomeIterator<'a, Self::Vertex, FieldValue> {
         if property_name.as_ref() == "__typename" {
             Box::new(contexts.map(|ctx| match ctx.active_vertex() {
@@ -556,14 +645,9 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                 None => (ctx, FieldValue::Null),
             }))
         } else {
-            let property_name = property_name.clone();
             match type_name.as_ref() {
-                "Crate" => resolve_property_with(contexts, move |vertex| {
-                    get_crate_property(vertex, property_name.as_ref())
-                }),
-                "Item" => resolve_property_with(contexts, move |vertex| {
-                    get_item_property(vertex, property_name.as_ref())
-                }),
+                "Crate" => resolve_crate_property(contexts, property_name),
+                "Item" => resolve_item_property(contexts, property_name),
                 "ImplOwner" | "Struct" | "StructField" | "Enum" | "Variant" | "PlainVariant"
                 | "TupleVariant" | "StructVariant" | "Trait" | "Function" | "Method" | "Impl"
                     if matches!(
@@ -572,57 +656,31 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                     ) =>
                 {
                     // properties inherited from Item, accesssed on Item subtypes
-                    resolve_property_with(contexts, move |vertex| {
-                        get_item_property(vertex, property_name.as_ref())
-                    })
+                    resolve_item_property(contexts, property_name)
                 }
-                "Struct" => resolve_property_with(contexts, move |vertex| {
-                    get_struct_property(vertex, property_name.as_ref())
-                }),
-                "Enum" => resolve_property_with(contexts, move |vertex| {
-                    get_enum_property(vertex, property_name.as_ref())
-                }),
-                "Span" => resolve_property_with(contexts, move |vertex| {
-                    get_span_property(vertex, property_name.as_ref())
-                }),
-                "Path" => resolve_property_with(contexts, move |vertex| {
-                    get_path_property(vertex, property_name.as_ref())
-                }),
-                "ImportablePath" => resolve_property_with(contexts, move |vertex| {
-                    get_importable_path_property(vertex, property_name.as_ref())
-                }),
+                "Struct" => resolve_struct_property(contexts, property_name),
+                "Enum" => resolve_enum_property(contexts, property_name),
+                "Span" => resolve_span_property(contexts, property_name),
+                "Path" => resolve_path_property(contexts, property_name),
+                "ImportablePath" => resolve_importable_path_property(contexts, property_name),
                 "FunctionLike" | "Function" | "Method"
                     if matches!(property_name.as_ref(), "const" | "unsafe" | "async") =>
                 {
-                    resolve_property_with(contexts, move |vertex| {
-                        get_function_like_property(vertex, property_name.as_ref())
-                    })
+                    resolve_function_like_property(contexts, property_name)
                 }
-                "FunctionParameter" => resolve_property_with(contexts, move |vertex| {
-                    get_function_parameter_property(vertex, property_name.as_ref())
-                }),
-                "Impl" => resolve_property_with(contexts, move |vertex| {
-                    get_impl_property(vertex, property_name.as_ref())
-                }),
-                "Attribute" => resolve_property_with(contexts, move |vertex| {
-                    get_attribute_property(vertex, property_name.as_ref())
-                }),
-                "AttributeMetaItem" => resolve_property_with(contexts, move |vertex| {
-                    get_attribute_meta_item_property(vertex, property_name.as_ref())
-                }),
-                "Trait" => resolve_property_with(contexts, move |vertex| {
-                    get_trait_property(vertex, property_name.as_ref())
-                }),
-                "ImplementedTrait" => resolve_property_with(contexts, move |vertex| {
-                    get_implemented_trait_property(vertex, property_name.as_ref())
-                }),
+                "FunctionParameter" => resolve_function_parameter_property(contexts, property_name),
+                "Impl" => resolve_impl_property(contexts, property_name),
+                "Attribute" => resolve_attribute_property(contexts, property_name),
+                "AttributeMetaItem" => {
+                    resolve_attribute_meta_item_property(contexts, property_name)
+                }
+                "Trait" => resolve_trait_property(contexts, property_name),
+                "ImplementedTrait" => resolve_implemented_trait_property(contexts, property_name),
                 "RawType" | "ResolvedPathType" | "PrimitiveType"
                     if matches!(property_name.as_ref(), "name") =>
                 {
                     // fields from "RawType"
-                    resolve_property_with(contexts, move |vertex| {
-                        get_raw_type_property(vertex, property_name.as_ref())
-                    })
+                    resolve_raw_type_property(contexts, property_name)
                 }
                 _ => unreachable!("resolve_property {type_name} {property_name}"),
             }
@@ -635,7 +693,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
         parameters: &EdgeParameters,
-        _query_info: &ResolveEdgeInfo,
+        _resolve_info: &ResolveEdgeInfo,
     ) -> ContextOutcomeIterator<'a, Self::Vertex, VertexIterator<'a, Self::Vertex>> {
         match type_name.as_ref() {
             "CrateDiff" => match edge_name.as_ref() {
@@ -785,8 +843,8 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                     // Relies on the fact that only structs and enums can have impls,
                     // so we know that the vertex must represent either a struct or an enum.
                     let impl_ids = vertex
-                        .as_struct_item()
-                        .map(|(_, s)| &s.impls)
+                        .as_struct()
+                        .map(|s| &s.impls)
                         .or_else(|| vertex.as_enum().map(|e| &e.impls))
                         .expect("vertex was neither a struct nor an enum");
 
@@ -825,8 +883,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                     let previous_crate = self.previous_crate;
                     resolve_neighbors_with(contexts, move |vertex| {
                         let origin = vertex.origin;
-                        let (_, struct_item) =
-                            vertex.as_struct_item().expect("vertex was not a Struct");
+                        let struct_item = vertex.as_struct().expect("vertex was not a Struct");
 
                         let item_index = match origin {
                             Origin::CurrentCrate => &current_crate.inner.index,
@@ -932,9 +989,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
             "StructField" => match edge_name.as_ref() {
                 "raw_type" => resolve_neighbors_with(contexts, move |vertex| {
                     let origin = vertex.origin;
-                    let (_, field_type) = vertex
-                        .as_struct_field_item()
-                        .expect("not a StructField vertex");
+                    let field_type = vertex.as_struct_field().expect("not a StructField vertex");
                     Box::new(std::iter::once(origin.make_raw_type_vertex(field_type)))
                 }),
                 _ => {
@@ -1124,7 +1179,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
         contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &Arc<str>,
         coerce_to_type: &Arc<str>,
-        _query_info: &ResolveInfo,
+        _resolve_info: &ResolveInfo,
     ) -> ContextOutcomeIterator<'a, Self::Vertex, bool> {
         let coerce_to_type = coerce_to_type.clone();
         match type_name.as_ref() {


### PR DESCRIPTION
* Port to Trustfall v0.4.0 APIs.

* Migrate the straightforward property resolvers to new approach.

* Migrate the less-obvious property resolvers.

* Rename method parameter to `resolve_info`.
