### PR TITLE
fix function and method dichotomy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "22.6.1"
+version = "22.6.2"
 dependencies = [
  "anyhow",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustfall-rustdoc-adapter"
-version = "22.6.1"
+version = "22.6.2"
 edition = "2021"
 authors = ["Predrag Gruevski <obi1kenobi82@gmail.com>"]
 license = "Apache-2.0 OR MIT"

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -498,18 +498,33 @@ fn resolve_function_like_property<'a>(
     property_name: &str,
 ) -> ContextOutcomeIterator<'a, Vertex<'a>, FieldValue> {
     match property_name {
-        "const" => resolve_property_with(
-            contexts,
-            field_property!(as_function, header, { header.const_.into() }),
-        ),
-        "async" => resolve_property_with(
-            contexts,
-            field_property!(as_function, header, { header.async_.into() }),
-        ),
-        "unsafe" => resolve_property_with(
-            contexts,
-            field_property!(as_function, header, { header.unsafe_.into() }),
-        ),
+        "const" => resolve_property_with(contexts, |vertex| {
+            let header = vertex.as_function().map(|f| &f.header).unwrap_or_else(|| {
+                vertex
+                    .as_method()
+                    .map(|m| &m.header)
+                    .expect("vertex was neither a Function nor a Method")
+            });
+            header.const_.into()
+        }),
+        "async" => resolve_property_with(contexts, |vertex| {
+            let header = vertex.as_function().map(|f| &f.header).unwrap_or_else(|| {
+                vertex
+                    .as_method()
+                    .map(|m| &m.header)
+                    .expect("vertex was neither a Function nor a Method")
+            });
+            header.async_.into()
+        }),
+        "unsafe" => resolve_property_with(contexts, |vertex| {
+            let header = vertex.as_function().map(|f| &f.header).unwrap_or_else(|| {
+                vertex
+                    .as_method()
+                    .map(|m| &m.header)
+                    .expect("vertex was neither a Function nor a Method")
+            });
+            header.unsafe_.into()
+        }),
         _ => unreachable!("FunctionLike property {property_name}"),
     }
 }


### PR DESCRIPTION
- Update v22 adapter with trustfall_core v0.1.1. (#12)
- New schema for attributes (#5) (#17)
- Added unsafe parameter to trait (#19)
- Release v22.4.0. (#20)
- Add fields to Variant interface (#25)
- Use the Swatinem/rust-cache@v2 action for caching. (#28)
- Support renaming re-exports, glob re-exports, and type aliases used as renames. (#34) (#39)
- Release v22.5.0. (#42)
- Run CI tests on Rust 1.66 as well. (#44)
- Rely on the test crates instead of the manually-generated file. (#48)
- Support omitting defaulted generic parameters. (#52) (#54)
- Release v22.5.1. (#58)
- Add a test case where a type and a value have the same name. (#60) (#62)
- Remove extraneous `println!()` statements. (#64)
- Clippy deny print statements. (#66) (#68)
- Add `renaming_reexport_of_reexport` test crate. (#70) (#74)
- Extract a function for testing re-exports with matching names. (#71) (#77)
- Fix error message text. (#79) (#81)
- Don't fetch dependency info when reporting the current crate version. (#88)
- Begin renaming items to match Trustfall v0.3 conventions. (#92)
- Use the new helpers in Trustfall v0.3. (#96)
- Make required jobs actually required. (#103) (#105)
- Release v22.6.0. (#109)
- Switch to dtolnay's Rust toolchain action, remove `::set-output` uses. (#113)
- Eliminate the last actions-rs Actions dependencies. (#117)
- Port to Trustfall v0.4.0 APIs. (#19) (#122)
- Use ergonomic Trustfall helpers for property resolution. (#124) (#127)
- Move test utils to their own file. (#132) (#134)
- Use `&self` instead of `&mut self` in `impl Adapter`. (#128) (#130)
- Reuse test_util helper to deduplicate test code. (#136) (#138)
- Release v22.6.1. (#146)
- feat: Add method edge to Trait vertex (#140) (#142)
- Release 22.6.2 with fix for function-method rustdoc v22 dichotomy.
