### PR TITLE
Speed up item, impl, method lookups with new Trustfall optimizations API. (#159)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d327f64a9d7d5cbbffe6c147503c16dbee69a1f51ef9b36aa8503af50f7c512"
+checksum = "f01f301b16b328066ec169203c3887bf77bab926b46b590bb34727a1bba19ad7"
 dependencies = [
  "anyhow",
  "trustfall_core",
@@ -608,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall_core"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a24fb8dfedc8c838389949a8657db5746b6a3a5d20b211cfa0320fe7e86b4d0"
+checksum = "50c066668e1bf52a8a82f686340bd4444ed04503105c6c0d559e64d3622958f7"
 dependencies = [
  "async-graphql-parser",
  "async-graphql-value",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "./README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-trustfall = "0.4.0-beta.1"
+trustfall = "0.4.0-beta.3"
 rustdoc-types = "0.19.0"
 
 [dev-dependencies]

--- a/src/adapter/optimizations/impl_lookup.rs
+++ b/src/adapter/optimizations/impl_lookup.rs
@@ -1,0 +1,214 @@
+use std::collections::HashMap;
+
+use rustdoc_types::{Id, Item};
+use trustfall::{
+    provider::{
+        resolve_neighbors_with, CandidateValue, ContextIterator, ContextOutcomeIterator,
+        ResolveEdgeInfo, VertexInfo, VertexIterator,
+    },
+    FieldValue,
+};
+
+use crate::{indexed_crate::ImplEntry, IndexedCrate};
+
+use super::super::{origin::Origin, vertex::Vertex, RustdocAdapter};
+
+/// Resolve the `ImplOwner.impl` and `ImplOwner.inherent_impl` edges.
+pub(crate) fn resolve_owner_impl<'a>(
+    adapter: &RustdocAdapter<'a>,
+    contexts: ContextIterator<'a, Vertex<'a>>,
+    edge_name: &str,
+    resolve_info: &ResolveEdgeInfo,
+) -> ContextOutcomeIterator<'a, Vertex<'a>, VertexIterator<'a, Vertex<'a>>> {
+    let current_crate = adapter.current_crate;
+    let previous_crate = adapter.previous_crate;
+    let inherent_impls_only = match edge_name {
+        "inherent_impl" => true,
+        "impl" => false,
+        _ => unreachable!("unexpected edge name: {edge_name}"),
+    };
+
+    // Check if the `method` edge is used next at the destination.
+    if let Some(method_vertex_info) = resolve_info
+        .destination()
+        .first_edge("method")
+        .as_ref()
+        .map(|e| e.destination())
+    {
+        // Try to use information about the `method` vertex to speed up the query.
+        resolve_owner_impl_based_on_method_info(
+            adapter,
+            contexts,
+            current_crate,
+            previous_crate,
+            inherent_impls_only,
+            method_vertex_info,
+        )
+    } else {
+        // We don't seem to be looking up methods. No fast path available.
+        resolve_neighbors_with(contexts, move |vertex| {
+            resolve_owner_impl_slow_path(vertex, current_crate, previous_crate, inherent_impls_only)
+        })
+    }
+}
+
+fn resolve_owner_impl_based_on_method_info<'a>(
+    adapter: &RustdocAdapter<'a>,
+    contexts: ContextIterator<'a, Vertex<'a>>,
+    current_crate: &'a IndexedCrate<'a>,
+    previous_crate: Option<&'a IndexedCrate<'a>>,
+    inherent_impls_only: bool,
+    method_vertex_info: &impl VertexInfo,
+) -> ContextOutcomeIterator<'a, Vertex<'a>, VertexIterator<'a, Vertex<'a>>> {
+    // Is the method's `name` property required to be some value, either statically or dynamically?
+    // If so, we can use an index to look up a specific item directly.
+    //
+    // There's no advantage in our implementation between knowing values
+    // statically vs dynamically, so we check the dynamic case first since
+    // it might be more specific.
+    if let Some(resolver) = method_vertex_info.dynamically_required_property("name") {
+        resolver.resolve_with(adapter, contexts, move |vertex, candidate| {
+            resolve_impl_based_on_method_name_candidate(
+                vertex,
+                current_crate,
+                previous_crate,
+                inherent_impls_only,
+                candidate,
+            )
+        })
+    } else if let Some(candidate) = method_vertex_info.statically_required_property("name") {
+        let candidate = candidate.cloned();
+        resolve_neighbors_with(contexts, move |vertex| {
+            resolve_impl_based_on_method_name_candidate(
+                vertex,
+                current_crate,
+                previous_crate,
+                inherent_impls_only,
+                candidate.clone(),
+            )
+        })
+    } else {
+        // The methods are not looked up by name. None of the fast paths are available.
+        resolve_neighbors_with(contexts, move |vertex| {
+            resolve_owner_impl_slow_path(vertex, current_crate, previous_crate, inherent_impls_only)
+        })
+    }
+}
+
+fn resolve_impl_based_on_method_name_candidate<'a>(
+    vertex: &Vertex<'a>,
+    current_crate: &'a IndexedCrate<'a>,
+    previous_crate: Option<&'a IndexedCrate<'a>>,
+    inherent_impls_only: bool,
+    method_name: CandidateValue<FieldValue>,
+) -> VertexIterator<'a, Vertex<'a>> {
+    let origin = vertex.origin;
+    let impl_index = match origin {
+        Origin::CurrentCrate => current_crate
+            .impl_index
+            .as_ref()
+            .expect("no impl index present"),
+        Origin::PreviousCrate => previous_crate
+            .expect("no previous crate provided")
+            .impl_index
+            .as_ref()
+            .expect("no impl index provided"),
+    };
+
+    let item_id = &vertex.as_item().expect("not an item").id;
+    match method_name {
+        CandidateValue::Impossible => Box::new(std::iter::empty()),
+        CandidateValue::Single(value) => {
+            let method_name = value.as_str().expect("method name was not a string");
+            resolve_impl_based_on_method_name(
+                origin,
+                impl_index,
+                inherent_impls_only,
+                item_id,
+                method_name,
+            )
+        }
+        CandidateValue::Multiple(values) => Box::new(values.into_iter().flat_map(move |value| {
+            let method_name = value.as_str().expect("method name was not a string");
+            resolve_impl_based_on_method_name(
+                origin,
+                impl_index,
+                inherent_impls_only,
+                item_id,
+                method_name,
+            )
+        })),
+        _ => {
+            // fall through to slow path
+            resolve_owner_impl_slow_path(vertex, current_crate, previous_crate, inherent_impls_only)
+        }
+    }
+}
+
+fn resolve_impl_based_on_method_name<'a>(
+    origin: Origin,
+    impl_index: &'a HashMap<ImplEntry<'a>, Vec<(&'a Item, &'a Item)>>,
+    inherent_impls_only: bool,
+    item_id: &Id,
+    method_name: &str,
+) -> VertexIterator<'a, Vertex<'a>> {
+    if let Some(method_ids) = impl_index.get(&(item_id, method_name)) {
+        Box::new(method_ids.iter().filter_map(move |(impl_item, _)| {
+            let impl_content = match &impl_item.inner {
+                rustdoc_types::ItemEnum::Impl(imp) => imp,
+                _ => unreachable!(
+                    "\
+the `impl_index` returned a value where the `impl_item` was not an impl: {impl_item:?}"
+                ),
+            };
+            if !inherent_impls_only || impl_content.trait_.is_none() {
+                Some(origin.make_item_vertex(impl_item))
+            } else {
+                None
+            }
+        }))
+    } else {
+        Box::new(std::iter::empty())
+    }
+}
+
+fn resolve_owner_impl_slow_path<'a>(
+    vertex: &Vertex<'a>,
+    current_crate: &'a IndexedCrate<'a>,
+    previous_crate: Option<&'a IndexedCrate<'a>>,
+    inherent_impls_only: bool,
+) -> VertexIterator<'a, Vertex<'a>> {
+    let origin = vertex.origin;
+    let item_index = match origin {
+        Origin::CurrentCrate => &current_crate.inner.index,
+        Origin::PreviousCrate => {
+            &previous_crate
+                .expect("no previous crate provided")
+                .inner
+                .index
+        }
+    };
+
+    // Get the IDs of all the impl blocks.
+    // Relies on the fact that only structs and enums can have impls,
+    // so we know that the vertex must represent either a struct or an enum.
+    let impl_ids = vertex
+        .as_struct()
+        .map(|s| &s.impls)
+        .or_else(|| vertex.as_enum().map(|e| &e.impls))
+        .expect("vertex was neither a struct nor an enum");
+
+    Box::new(impl_ids.iter().filter_map(move |item_id| {
+        let next_item = item_index.get(item_id);
+        next_item.and_then(|next_item| match &next_item.inner {
+            rustdoc_types::ItemEnum::Impl(imp) => {
+                if !inherent_impls_only || imp.trait_.is_none() {
+                    Some(origin.make_item_vertex(next_item))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        })
+    }))
+}

--- a/src/adapter/optimizations/item_lookup.rs
+++ b/src/adapter/optimizations/item_lookup.rs
@@ -1,0 +1,127 @@
+use rustdoc_types::Item;
+use trustfall::{
+    provider::{
+        resolve_neighbors_with, CandidateValue, ContextIterator, ContextOutcomeIterator,
+        ResolveEdgeInfo, VertexInfo, VertexIterator,
+    },
+    FieldValue,
+};
+
+use super::super::{origin::Origin, vertex::Vertex, RustdocAdapter};
+
+use crate::IndexedCrate;
+
+pub(crate) fn resolve_crate_items<'a>(
+    adapter: &RustdocAdapter<'a>,
+    contexts: ContextIterator<'a, Vertex<'a>>,
+    resolve_info: &ResolveEdgeInfo,
+) -> ContextOutcomeIterator<'a, Vertex<'a>, VertexIterator<'a, Vertex<'a>>> {
+    // Is the `importable_path` edge being resolved in a subsequent step?
+    if let Some(neighbor_info) = resolve_info
+        .destination()
+        .first_edge("importable_path")
+        .as_ref()
+        .map(|x| x.destination())
+    {
+        // Is the `path` value within that edge known, either statically or dynamically?
+        // If so, we can use an index to look up a specific item directly.
+        //
+        // There's no advantage in our implementation between knowing values
+        // statically vs dynamically, so we check the dynamic case first since
+        // it might be more specific.
+        if let Some(dynamic_value) = neighbor_info.dynamically_required_property("path") {
+            return dynamic_value.resolve_with(adapter, contexts, |vertex, candidate| {
+                let crate_vertex = vertex.as_indexed_crate().expect("vertex was not a Crate");
+                let origin = vertex.origin;
+                resolve_items_by_importable_path(crate_vertex, origin, candidate)
+            });
+        } else if let Some(path_value) = neighbor_info.statically_required_property("path") {
+            let path_value = path_value.cloned();
+            return resolve_neighbors_with(contexts, move |vertex| {
+                let crate_vertex = vertex.as_indexed_crate().expect("vertex was not a Crate");
+                let origin = vertex.origin;
+                resolve_items_by_importable_path(crate_vertex, origin, path_value.clone())
+            });
+        }
+    }
+
+    resolve_neighbors_with(contexts, |vertex| {
+        let crate_vertex = vertex.as_indexed_crate().expect("vertex was not a Crate");
+        let origin = vertex.origin;
+        resolve_items_slow_path(crate_vertex, origin)
+    })
+}
+
+fn resolve_items_by_importable_path<'a>(
+    crate_vertex: &'a IndexedCrate,
+    origin: Origin,
+    importable_path: CandidateValue<FieldValue>,
+) -> VertexIterator<'a, Vertex<'a>> {
+    match importable_path {
+        CandidateValue::Impossible => Box::new(std::iter::empty()),
+        CandidateValue::Single(value) => {
+            resolve_items_by_importable_path_field_value(crate_vertex, origin, &value)
+        }
+        CandidateValue::Multiple(values) => Box::new(values.into_iter().flat_map(move |value| {
+            resolve_items_by_importable_path_field_value(crate_vertex, origin, &value)
+        })),
+        _ => {
+            // fall through to slow path
+            resolve_items_slow_path(crate_vertex, origin)
+        }
+    }
+}
+
+fn resolve_items_by_importable_path_field_value<'a>(
+    crate_vertex: &'a IndexedCrate,
+    origin: Origin,
+    value: &FieldValue,
+) -> VertexIterator<'a, Vertex<'a>> {
+    let path_components: Vec<&str> = value
+        .as_slice()
+        .expect("ImportablePath.path was not a list")
+        .iter()
+        .map(|x| x.as_str().unwrap())
+        .collect();
+    if let Some(items) = crate_vertex
+        .imports_index
+        .as_ref()
+        .expect("crate's imports_index was never constructed")
+        .get(path_components.as_slice())
+    {
+        resolve_item_vertices(origin, items.iter().copied())
+    } else {
+        // No such items found.
+        Box::new(std::iter::empty())
+    }
+}
+
+fn resolve_items_slow_path<'a>(
+    crate_vertex: &'a IndexedCrate,
+    origin: Origin,
+) -> VertexIterator<'a, Vertex<'a>> {
+    resolve_item_vertices(origin, crate_vertex.inner.index.values())
+}
+
+fn resolve_item_vertices<'a>(
+    origin: Origin,
+    items: impl Iterator<Item = &'a Item> + 'a,
+) -> VertexIterator<'a, Vertex<'a>> {
+    Box::new(
+        items
+            .filter(|item| {
+                // Filter out item types that are not currently supported.
+                matches!(
+                    item.inner,
+                    rustdoc_types::ItemEnum::Struct(..)
+                        | rustdoc_types::ItemEnum::StructField(..)
+                        | rustdoc_types::ItemEnum::Enum(..)
+                        | rustdoc_types::ItemEnum::Variant(..)
+                        | rustdoc_types::ItemEnum::Function(..)
+                        | rustdoc_types::ItemEnum::Impl(..)
+                        | rustdoc_types::ItemEnum::Trait(..)
+                )
+            })
+            .map(move |value| origin.make_item_vertex(value)),
+    )
+}

--- a/src/adapter/optimizations/method_lookup.rs
+++ b/src/adapter/optimizations/method_lookup.rs
@@ -1,0 +1,217 @@
+use std::collections::{BTreeSet, HashMap};
+
+use rustdoc_types::{Id, Impl, Item, ItemEnum, Type};
+use trustfall::{
+    provider::{
+        resolve_neighbors_with, CandidateValue, ContextIterator, ContextOutcomeIterator,
+        ResolveEdgeInfo, VertexInfo, VertexIterator,
+    },
+    FieldValue,
+};
+
+use crate::{
+    adapter::{Origin, Vertex},
+    indexed_crate::ImplEntry,
+    IndexedCrate, RustdocAdapter,
+};
+
+pub(crate) fn resolve_impl_methods<'a>(
+    adapter: &RustdocAdapter<'a>,
+    contexts: ContextIterator<'a, Vertex<'a>>,
+    resolve_info: &ResolveEdgeInfo,
+) -> ContextOutcomeIterator<'a, Vertex<'a>, VertexIterator<'a, Vertex<'a>>> {
+    let current_crate = adapter.current_crate;
+    let previous_crate = adapter.previous_crate;
+
+    let neighbor_info = resolve_info.destination();
+
+    // Is the `name` value within that edge known, either statically or dynamically?
+    // If so, we can use an index to look up a specific method directly.
+    //
+    // There's no advantage in our implementation between knowing values
+    // statically vs dynamically, so we check the dynamic case first since
+    // it might be more specific.
+    if let Some(resolver) = neighbor_info.dynamically_required_property("name") {
+        resolver.resolve_with(adapter, contexts, move |vertex, candidate| {
+            resolve_method_from_candidate_value(current_crate, previous_crate, vertex, candidate)
+        })
+    } else if let Some(candidate) = neighbor_info.statically_required_property("name") {
+        let candidate = candidate.cloned();
+        return resolve_neighbors_with(contexts, move |vertex| {
+            resolve_method_from_candidate_value(
+                current_crate,
+                previous_crate,
+                vertex,
+                candidate.clone(),
+            )
+        });
+    } else {
+        resolve_neighbors_with(contexts, move |vertex| {
+            let origin = vertex.origin;
+            let item_index = match origin {
+                Origin::CurrentCrate => &current_crate.inner.index,
+                Origin::PreviousCrate => {
+                    &previous_crate
+                        .expect("no previous crate provided")
+                        .inner
+                        .index
+                }
+            };
+
+            let impl_vertex = vertex.as_impl().expect("not an Impl vertex");
+            resolve_methods_slow_path(impl_vertex, origin, item_index)
+        })
+    }
+}
+
+fn find_impl_owner_id(impl_vertex: &Impl) -> Option<&Id> {
+    let mut ty = &impl_vertex.for_;
+    loop {
+        match ty {
+            Type::ResolvedPath(path) => break Some(&path.id),
+            Type::BorrowedRef {
+                lifetime: _,
+                mutable: _,
+                type_,
+            } => {
+                ty = type_;
+            }
+            Type::RawPointer { mutable: _, type_ } => {
+                ty = type_;
+            }
+            _ => {
+                // We encountered an `impl <X>` or `impl Trait for <X>` with an unexpected `<X>`.
+                // Ideally, this case would never happen.
+                // But since it did, let's fall back to the slow path.
+                break None;
+            }
+        }
+    }
+}
+
+fn resolve_method_from_candidate_value<'a>(
+    current_crate: &'a IndexedCrate<'a>,
+    previous_crate: Option<&'a IndexedCrate<'a>>,
+    vertex: &Vertex<'a>,
+    method_name: CandidateValue<FieldValue>,
+) -> VertexIterator<'a, Vertex<'a>> {
+    let origin = vertex.origin;
+    let (item_index, impl_index) = match origin {
+        Origin::CurrentCrate => (
+            &current_crate.inner.index,
+            current_crate
+                .impl_index
+                .as_ref()
+                .expect("no impl index present"),
+        ),
+        Origin::PreviousCrate => {
+            let previous_crate = previous_crate.expect("no previous crate provided");
+            (
+                &previous_crate.inner.index,
+                previous_crate
+                    .impl_index
+                    .as_ref()
+                    .expect("no impl index provided"),
+            )
+        }
+    };
+
+    let impl_id = &vertex.as_item().expect("not an Item vertex").id;
+    let impl_vertex = vertex.as_impl().expect("not an Impl vertex");
+
+    if let Some(impl_owner_id) = find_impl_owner_id(impl_vertex) {
+        match method_name {
+            CandidateValue::Impossible => Box::new(std::iter::empty()),
+            CandidateValue::Single(name) => {
+                let method_name = name.as_str().expect("method name was not a string");
+                resolve_impl_method_by_name(origin, impl_index, impl_owner_id, impl_id, method_name)
+            }
+            CandidateValue::Multiple(names) => Box::new(names.into_iter().flat_map(move |name| {
+                let method_name = name.as_str().expect("method name was not a string");
+                resolve_impl_method_by_name(origin, impl_index, impl_owner_id, impl_id, method_name)
+            })),
+            _ => {
+                // Fall back to the default slow path.
+                resolve_methods_slow_path(impl_vertex, origin, item_index)
+            }
+        }
+    } else {
+        // We couldn't determine the Id of the item that owns this method.
+        // Fall back to the default slow path.
+        resolve_methods_slow_path(impl_vertex, origin, item_index)
+    }
+}
+
+fn resolve_impl_method_by_name<'a>(
+    origin: Origin,
+    impl_index: &'a HashMap<ImplEntry<'a>, Vec<(&'a Item, &'a Item)>>,
+    impl_owner_id: &'a Id,
+    impl_id: &'a Id,
+    method_name: &str,
+) -> VertexIterator<'a, Vertex<'a>> {
+    if let Some(method_ids) = impl_index.get(&(impl_owner_id, method_name)) {
+        Box::new(method_ids.iter().filter_map(move |(impl_item, item)| {
+            (&impl_item.id == impl_id).then_some(origin.make_item_vertex(item))
+        }))
+    } else {
+        Box::new(std::iter::empty())
+    }
+}
+
+fn resolve_methods_slow_path<'a>(
+    impl_vertex: &'a Impl,
+    origin: Origin,
+    item_index: &'a HashMap<Id, Item>,
+) -> VertexIterator<'a, Vertex<'a>> {
+    let provided_methods: Box<dyn Iterator<Item = &Id>> =
+        if impl_vertex.provided_trait_methods.is_empty() {
+            Box::new(std::iter::empty())
+        } else {
+            let method_names: BTreeSet<&str> = impl_vertex
+                .provided_trait_methods
+                .iter()
+                .map(|x| x.as_str())
+                .collect();
+
+            let trait_path = impl_vertex
+                .trait_
+                .as_ref()
+                .expect("no trait but provided_trait_methods was non-empty");
+            let trait_item = item_index.get(&trait_path.id);
+
+            if let Some(trait_item) = trait_item {
+                if let ItemEnum::Trait(trait_item) = &trait_item.inner {
+                    Box::new(trait_item.items.iter().filter(move |item_id| {
+                        let next_item = &item_index.get(item_id);
+                        if let Some(name) = next_item.and_then(|x| x.name.as_deref()) {
+                            method_names.contains(name)
+                        } else {
+                            false
+                        }
+                    }))
+                } else {
+                    unreachable!("found a non-trait type {trait_item:?}");
+                }
+            } else {
+                Box::new(std::iter::empty())
+            }
+        };
+
+    Box::new(
+        provided_methods
+            .chain(impl_vertex.items.iter())
+            .filter_map(move |item_id| {
+                let next_item = &item_index.get(item_id);
+                if let Some(next_item) = next_item {
+                    match &next_item.inner {
+                        rustdoc_types::ItemEnum::Function(..) => {
+                            Some(origin.make_item_vertex(next_item))
+                        }
+                        _ => None,
+                    }
+                } else {
+                    None
+                }
+            }),
+    )
+}

--- a/src/adapter/optimizations/mod.rs
+++ b/src/adapter/optimizations/mod.rs
@@ -1,0 +1,3 @@
+pub(super) mod impl_lookup;
+pub(super) mod item_lookup;
+pub(super) mod method_lookup;


### PR DESCRIPTION
The new Trustfall optimization hints API allows adapters to offer "fast paths" when resolving data. This PR adds such fast paths for the three hottest lookups performed by `cargo-semver-checks`: items by name, methods by name, and impls containing a method with a specific name. While these specific fast paths were chosen based on the workload in `cargo-semver-checks`, they are by no means specific to it: any query that looks up items by name, methods by name, or impl blocks based on the names of its methods will automatically take advantage of them as well.

The fast paths work by enabling the Trustfall engine and the adapter in this library to collaborate better. Neither can perform these optimizations without the other!
- The Trustfall engine doesn't know how the underlying data is represented or stored, so it can't know whether a faster path is possible. But it does know what the *query that is executing* is trying to do.
- The adapter knows all about the underlying data representation and about different (possibly faster!) ways to look up data within. But it doesn't know anything about the *query that is executing*.

Clearly, the two components together have all the required information and just need to exchange this information. Done naively, this would *massively complicate* the `Adapter` trait which is the interface between Trustfall and adapter implementations. We don't want that! Adapters should be as easy as possible to build -- simple use cases shouldn't pay the complexity cost of power user features they will never use!

Instead, the new Trustfall optimization hints API flips the traditional roles: instead of Trustfall *telling* the adapter all about the query, it gives the adapter a way to *ask Trustfall* about the parts of the query that might be relevant. These are questions like:
- "For the edge I'm currently resolving, is the query then going to filter the results by their `name` property? If so, what values does it expect?"
- "Is a future step of the query going to resolve the `method` edge?"
- "The edge I'm resolving can point to a few different types of vertices, did the query apply a type coercion to select only a specific one? Which one?"

This way we get to have our cake and eat it too:
- Adapter implementations that don't care about optimizations get to *completely ignore* this argument. No cost if you aren't using it!
- Adapters that care about optimizations get to have their questions answered *without* needing to understand the internal representation (IR) of Trustfall queries. You shouldn't need to be a database or compiler engineer to write adapter optimizations!
- There is an infinite set of possible pieces of data the adapter may be interested in. Trustfall doesn't have to check and compute *everything under the Sun* ahead of time -- it can be lazy and only compute what it gets asked about. Again, pay for only what you use!

I expect that both our optimizations and the Trustfall optimization hints API will continue to evolve, and become both simpler to use and more powerful in what they can support. The current code in this PR is already a bit repetitive, and has helped me spot a few opportunities for new helper methods that simplify common usage patterns of the new APIs.

But the code in its current state is too good to *not* release. The new Trustfall APIs are covered by ~25,000 lines of new tests. The perf impact is GIGANTIC: ~2354x speedup in `cargo-semver-checks` over a large crate. Perfect is the enemy of good enough, and this is *comfortably* more than good enough.
