### PR TITLE
Add supertrait to schema

### DIFF
--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -1,4 +1,4 @@
-use rustdoc_types::{Id, VariantKind};
+use rustdoc_types::{GenericBound::TraitBound, Id, VariantKind};
 use trustfall::provider::{
     resolve_neighbors_with, ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo,
     VertexIterator,
@@ -342,6 +342,30 @@ pub(super) fn resolve_trait_edge<'a>(
     previous_crate: Option<&'a IndexedCrate<'a>>,
 ) -> ContextOutcomeIterator<'a, Vertex<'a>, VertexIterator<'a, Vertex<'a>>> {
     match edge_name {
+        "supertrait" => resolve_neighbors_with(contexts, move |vertex| {
+            let origin = vertex.origin;
+            let item_index = match origin {
+                Origin::CurrentCrate => &current_crate.inner.index,
+                Origin::PreviousCrate => {
+                    &previous_crate
+                        .expect("no previous crate provided")
+                        .inner
+                        .index
+                }
+            };
+
+            let trait_vertex = vertex.as_trait().expect("not a Trait vertex");
+            Box::new(trait_vertex.bounds.iter().filter_map(move |bound| {
+                if let TraitBound { trait_, .. } = bound {
+                    item_index
+                        .get(&trait_.id)
+                        .as_ref()
+                        .map(|next_item| origin.make_implemented_trait_vertex(trait_, next_item))
+                } else {
+                    None
+                }
+            }))
+        }),
         "method" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
             let item_index = match origin {

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -108,10 +108,10 @@ fn rustdoc_finds_supertrait() {
     assert_eq!(
         vec![
             btreemap! {
-                Arc::from("name") => FieldValue::String("supertrait2".to_string()),
+                Arc::from("name") => FieldValue::String("Supertrait2".to_string()),
             },
             btreemap! {
-                Arc::from("name") => FieldValue::String("supertrait".to_string()),
+                Arc::from("name") => FieldValue::String("Supertrait".to_string()),
             }
         ],
         results

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -413,6 +413,8 @@ type Trait implements Item & Importable {
   Methods defined in this trait.
   """
   method: [Method!]
+
+  supertrait: [ImplementedTrait!]
 }
 
 """

--- a/test_crates/supertrait/Cargo.toml
+++ b/test_crates/supertrait/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+publish = false
+name = "supertrait"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/test_crates/supertrait/src/lib.rs
+++ b/test_crates/supertrait/src/lib.rs
@@ -1,0 +1,5 @@
+pub trait supertrait {}
+
+pub trait supertrait2 {}
+
+pub trait base_trait : supertrait2 + supertrait {}

--- a/test_crates/supertrait/src/lib.rs
+++ b/test_crates/supertrait/src/lib.rs
@@ -1,5 +1,5 @@
-pub trait supertrait {}
+pub trait Supertrait {}
 
-pub trait supertrait2 {}
+pub trait Supertrait2 {}
 
-pub trait base_trait : supertrait2 + supertrait {}
+pub trait BaseTrait : Supertrait2 + Supertrait {}


### PR DESCRIPTION
Following discussion at https://github.com/obi1kenobi/cargo-semver-checks/issues/232, this PR adds a `supertrait` field to `trait` in order to enable the new lint on `cargo-semver-checks`.