### PR TITLE
add AssociatedType to schema (#211)

### DIFF
--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -93,7 +93,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                 "Item" => properties::resolve_item_property(contexts, property_name),
                 "ImplOwner" | "Struct" | "StructField" | "Enum" | "Variant" | "PlainVariant"
                 | "TupleVariant" | "StructVariant" | "Trait" | "Function" | "Method" | "Impl"
-                | "GlobalValue" | "Constant" | "Static"
+                | "GlobalValue" | "Constant" | "Static" | "AssociatedType"
                     if matches!(
                         property_name.as_ref(),
                         "id" | "crate_id" | "name" | "docs" | "attrs" | "visibility_limit"
@@ -132,6 +132,9 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                 {
                     // fields from "RawType"
                     properties::resolve_raw_type_property(contexts, property_name)
+                }
+                "AssociatedType" => {
+                    properties::resolve_associated_type_property(contexts, property_name)
                 }
                 _ => unreachable!("resolve_property {type_name} {property_name}"),
             }
@@ -260,5 +263,6 @@ pub(crate) fn supported_item_kind(item: &Item) -> bool {
             | rustdoc_types::ItemEnum::Trait(..)
             | rustdoc_types::ItemEnum::Constant(..)
             | rustdoc_types::ItemEnum::Static(..)
+            | rustdoc_types::ItemEnum::AssocType { .. }
     )
 }

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -1,3 +1,4 @@
+use rustdoc_types::ItemEnum;
 use trustfall::{
     provider::{
         accessor_property, field_property, resolve_property_with, ContextIterator,
@@ -286,5 +287,23 @@ pub(crate) fn resolve_static_property<'a>(
     match property_name {
         "mutable" => resolve_property_with(contexts, field_property!(as_static, mutable)),
         _ => unreachable!("Static property {property_name}"),
+    }
+}
+
+pub(crate) fn resolve_associated_type_property<'a>(
+    contexts: ContextIterator<'a, Vertex<'a>>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, Vertex<'a>, FieldValue> {
+    match property_name {
+        "has_default" => resolve_property_with(
+            contexts,
+            field_property!(as_item, inner, {
+                let ItemEnum::AssocType { default, .. } = &inner else {
+                    unreachable!("expected to have a AssocType")
+                };
+                default.is_some().into()
+            }),
+        ),
+        _ => unreachable!("AssociatedType property {property_name}"),
     }
 }

--- a/src/adapter/vertex.rs
+++ b/src/adapter/vertex.rs
@@ -56,6 +56,7 @@ impl<'a> Typename for Vertex<'a> {
                 rustdoc_types::ItemEnum::Trait(..) => "Trait",
                 rustdoc_types::ItemEnum::Constant(..) => "Constant",
                 rustdoc_types::ItemEnum::Static(..) => "Static",
+                rustdoc_types::ItemEnum::AssocType { .. } => "AssociatedType",
                 _ => unreachable!("unexpected item.inner for item: {item:?}"),
             },
             VertexKind::Span(..) => "Span",

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -415,6 +415,8 @@ type Trait implements Item & Importable {
   method: [Method!]
 
   supertrait: [ImplementedTrait!]
+
+  associated_type: [AssociatedType!]
 }
 
 """
@@ -722,6 +724,50 @@ type PrimitiveType implements RawType {
   For example: "usize"
   """
   name: String!
+}
+
+"""
+https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Item.html
+https://docs.rs/rustdoc-types/latest/rustdoc_types/enum.ItemEnum.html#variant.AssocType
+"""
+type AssociatedType implements Item {
+  # properties from Item
+  id: String!
+  crate_id: Int!
+
+  """
+  The name of the associated type.
+
+  For example:
+  ```rust
+  trait Iterator {
+      type Item;  // `"Item"` is the name of the associated type
+  }
+  ```
+  """
+  name: String
+  docs: String
+  attrs: [String!]!
+  visibility_limit: String!
+
+  # properties for AssociatedType
+  """
+  Whether the type is defined to have a default value.
+
+  For example:
+  ```rust
+  trait IntIterator {
+      type Item = i64;  // by default, the associated type is `i64` so this property is `true`.
+  }
+  ```
+
+  Associated type defaults are currently unstable: https://github.com/rust-lang/rust/issues/29661
+  """
+  has_default: Boolean!
+
+  # edges from Item
+  span: Span
+  attribute: [Attribute!]
 }
 
 """

--- a/test_crates/traits_with_associated_types/Cargo.toml
+++ b/test_crates/traits_with_associated_types/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+publish = false
+name = "traits_with_associated_types"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/test_crates/traits_with_associated_types/src/lib.rs
+++ b/test_crates/traits_with_associated_types/src/lib.rs
@@ -1,0 +1,6 @@
+#![feature(associated_type_defaults)]
+
+pub trait Serializer {
+    type SerializedType = [u8; 20];
+    type DeserializedType;
+}


### PR DESCRIPTION
* add AssociatedType to schema

* remove from resolveCoercion

* fix copypasta

* implement Item instead of RawType

* rename trait_with_types to traits_with_associated_types

* remove generic test that doesn't test added functionality

* remove last bang on associated_type edge

* Add link to Item rustdoc in graphql type def comment

* Reorder urls from lowest to most important

* put properties together

* Add docs to some of associatedtype

* Fixup docs.

---------

Co-authored-by: Predrag Gruevski <obi1kenobi82@gmail.com>
