### PR TITLE
Add `FunctionAbi` type to queryable schema. (#231)

### DIFF
--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -148,6 +148,16 @@ pub(super) fn resolve_function_like_edge<'a>(
                     .map(move |(name, _type_)| origin.make_function_parameter_vertex(name)),
             )
         }),
+        "abi" => resolve_neighbors_with(contexts, move |vertex| {
+            let origin = vertex.origin;
+            let abi = &vertex
+                .as_function()
+                .expect("vertex was not a Function")
+                .header
+                .abi;
+
+            Box::new(std::iter::once(origin.make_function_abi_vertex(abi)))
+        }),
         _ => unreachable!("resolve_function_like_edge {edge_name}"),
     }
 }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -118,6 +118,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                 "FunctionParameter" => {
                     properties::resolve_function_parameter_property(contexts, property_name)
                 }
+                "FunctionAbi" => properties::resolve_function_abi_property(contexts, property_name),
                 "Impl" => properties::resolve_impl_property(contexts, property_name),
                 "Attribute" => properties::resolve_attribute_property(contexts, property_name),
                 "AttributeMetaItem" => {
@@ -180,7 +181,9 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
             {
                 edges::resolve_impl_owner_edge(self, contexts, edge_name, resolve_info)
             }
-            "Function" | "Method" | "FunctionLike" if matches!(edge_name.as_ref(), "parameter") => {
+            "Function" | "Method" | "FunctionLike"
+                if matches!(edge_name.as_ref(), "parameter" | "abi") =>
+            {
                 edges::resolve_function_like_edge(contexts, edge_name)
             }
             "Struct" => edges::resolve_struct_edge(

--- a/src/adapter/origin.rs
+++ b/src/adapter/origin.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use rustdoc_types::{Item, Span};
+use rustdoc_types::{Abi, Item, Span};
 
 use crate::attributes::{Attribute, AttributeMetaItem};
 
@@ -84,6 +84,13 @@ impl Origin {
         Vertex {
             origin: *self,
             kind: VertexKind::FunctionParameter(name),
+        }
+    }
+
+    pub(super) fn make_function_abi_vertex<'a>(&self, abi: &'a Abi) -> Vertex<'a> {
+        Vertex {
+            origin: *self,
+            kind: abi.into(),
         }
     }
 }

--- a/src/adapter/vertex.rs
+++ b/src/adapter/vertex.rs
@@ -1,8 +1,8 @@
 use std::rc::Rc;
 
 use rustdoc_types::{
-    Constant, Crate, Enum, Function, Impl, Item, Path, Span, Static, Struct, Trait, Type, Variant,
-    VariantKind,
+    Abi, Constant, Crate, Enum, Function, Impl, Item, Path, Span, Static, Struct, Trait, Type,
+    Variant, VariantKind,
 };
 use trustfall::provider::Typename;
 
@@ -34,6 +34,7 @@ pub enum VertexKind<'a> {
     AttributeMetaItem(Rc<AttributeMetaItem<'a>>),
     ImplementedTrait(&'a Path, &'a Item),
     FunctionParameter(&'a str),
+    FunctionAbi(&'a Abi),
 }
 
 impl<'a> Typename for Vertex<'a> {
@@ -73,6 +74,7 @@ impl<'a> Typename for Vertex<'a> {
                 _ => "OtherType",
             },
             VertexKind::FunctionParameter(..) => "FunctionParameter",
+            VertexKind::FunctionAbi(..) => "FunctionAbi",
         }
     }
 }
@@ -181,6 +183,13 @@ impl<'a> Vertex<'a> {
         }
     }
 
+    pub(super) fn as_function_abi(&self) -> Option<&'a Abi> {
+        match self.kind {
+            VertexKind::FunctionAbi(abi) => Some(abi),
+            _ => None,
+        }
+    }
+
     pub(super) fn as_impl(&self) -> Option<&'a Impl> {
         self.as_item().and_then(|item| match &item.inner {
             rustdoc_types::ItemEnum::Impl(x) => Some(x),
@@ -246,5 +255,11 @@ impl<'a> From<&'a IndexedCrate<'a>> for VertexKind<'a> {
 impl<'a> From<&'a Span> for VertexKind<'a> {
     fn from(s: &'a Span) -> Self {
         Self::Span(s)
+    }
+}
+
+impl<'a> From<&'a Abi> for VertexKind<'a> {
+    fn from(a: &'a Abi) -> Self {
+        Self::FunctionAbi(a)
     }
 }

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -478,6 +478,7 @@ interface FunctionLike {
 
   # own edges
   parameter: [FunctionParameter!]
+  abi: FunctionAbi!
 }
 
 """
@@ -486,6 +487,54 @@ https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.FnDecl.html
 """
 type FunctionParameter {
   name: String!
+}
+
+"""
+The ABI of a function, method, or function pointer.
+
+It defines the calling convention for those functions, including whether unwinding across
+the call boundary is supported. More info: https://rust-lang.github.io/rfcs/2945-c-unwind-abi.html
+
+The list of supported ABIs is here:
+https://github.com/rust-lang/rust/blob/557359f92512ca88b62a602ebda291f17a953002/compiler/rustc_target/src/spec/abi.rs#L74-L110
+
+Backed by:
+https://docs.rs/rustdoc-types/latest/rustdoc_types/enum.Abi.html
+"""
+type FunctionAbi {
+    """
+    The name of the ABI, with any `"-unwind"` modifier stripped.
+
+    To get the ABI name directly as it would appear in a Rust source file,
+    use the `raw_name` property instead.
+
+    For example, a function defined as `extern "C-unwind" fn example()` would
+    have `name = "C"` and `raw_name = "C-unwind"`.
+
+    Functions with no specified ABI by default have an ABI named `"Rust"`.
+    """
+    name: String!
+
+    """
+    The raw name of the ABI, as it would appear in a Rust source file.
+
+    For example: "C-unwind" or "thiscall-unwind"
+
+    Functions with no specified ABI by default have an ABI named `"Rust"`.
+    """
+    raw_name: String!
+
+    """
+    Whether unwinding across this call is supported.
+
+    If encountering an unknown ABI, this value will be `null` due to unknown unwind semantics.
+
+    Unwind ability is specified in rustc here:
+    https://github.com/rust-lang/rust/blob/557359f92512ca88b62a602ebda291f17a953002/compiler/rustc_middle/src/ty/layout.rs#L1422-L1488
+
+    More info: https://rust-lang.github.io/rfcs/2945-c-unwind-abi.html
+    """
+    unwind: Boolean
 }
 
 """
@@ -513,6 +562,7 @@ type Function implements Item & FunctionLike & Importable {
 
   # edges from FunctionLike
   parameter: [FunctionParameter!]
+  abi: FunctionAbi!
 
   # edges from Importable
   importable_path: [ImportablePath!]
@@ -544,6 +594,7 @@ type Method implements Item & FunctionLike {
 
   # edges from FunctionLike
   parameter: [FunctionParameter!]
+  abi: FunctionAbi!
 }
 
 """

--- a/test_crates/function_abi/Cargo.toml
+++ b/test_crates/function_abi/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+publish = false
+name = "function_abi"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/test_crates/function_abi/src/lib.rs
+++ b/test_crates/function_abi/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(c_unwind)]
+
 pub extern "C-unwind" fn example_unwind() {}
 
 pub extern "C" fn example_not_unwind() {}

--- a/test_crates/function_abi/src/lib.rs
+++ b/test_crates/function_abi/src/lib.rs
@@ -1,0 +1,5 @@
+pub extern "C-unwind" fn example_unwind() {}
+
+pub extern "C" fn example_not_unwind() {}
+
+pub fn rust_abi() {}


### PR DESCRIPTION
* Add `FunctionAbi` type to queryable schema.

* Don't produce items that aren't from the rustdoc's own crate.
