### PR TITLE
Release 26.1.5.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "26.1.4"
+version = "26.1.5"
 dependencies = [
  "anyhow",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustfall-rustdoc-adapter"
-version = "26.1.4"
+version = "26.1.5"
 edition = "2021"
 authors = ["Predrag Gruevski <obi1kenobi82@gmail.com>"]
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
```
$ git shortlog v26.1.4..
Predrag Gruevski (6):
      Clarify docs for associated constant defaults. (#222)
      Remove stale unimplemented portions of schema. (#225)
      Use `similar_asserts` for pretty test case error messages. (#228)
      Add `FunctionAbi` type to queryable schema. (#231)
      Return used portions of schema and prune more carefully. (#234)
      Add `export_name` property on `Function`. (#237)
```