### PR TITLE
Implement properties around participation in public APIs on importable paths and items.

### DIFF
--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -4,10 +4,7 @@ use trustfall::provider::{
     VertexIterator,
 };
 
-use crate::{
-    adapter::supported_item_kind, attributes::Attribute, indexed_crate::ImportablePath,
-    IndexedCrate,
-};
+use crate::{adapter::supported_item_kind, attributes::Attribute, IndexedCrate};
 
 use super::{optimizations, origin::Origin, vertex::Vertex, RustdocAdapter};
 
@@ -105,15 +102,7 @@ pub(super) fn resolve_importable_edge<'a>(
                 parent_crate
                     .publicly_importable_names(item_id)
                     .into_iter()
-                    .map(move |x| {
-                        // TODO: fold doc_hidden and deprecated along the whole path
-                        origin.make_importable_path_vertex(ImportablePath::new(
-                            x,
-                            // TODO: parse the attribute properly to allow for other args to doc
-                            item.attrs.iter().any(|attr| attr == "#[doc(hidden)]"),
-                            item.deprecation.is_some(),
-                        ))
-                    }),
+                    .map(move |x| origin.make_importable_path_vertex(x)),
             )
         }),
         _ => unreachable!("resolve_importable_edge {edge_name}"),

--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -4,7 +4,10 @@ use trustfall::provider::{
     VertexIterator,
 };
 
-use crate::{adapter::supported_item_kind, attributes::Attribute, IndexedCrate};
+use crate::{
+    adapter::supported_item_kind, attributes::Attribute, indexed_crate::ImportablePath,
+    IndexedCrate,
+};
 
 use super::{optimizations, origin::Origin, vertex::Vertex, RustdocAdapter};
 
@@ -102,7 +105,15 @@ pub(super) fn resolve_importable_edge<'a>(
                 parent_crate
                     .publicly_importable_names(item_id)
                     .into_iter()
-                    .map(move |x| origin.make_importable_path_vertex(x)),
+                    .map(move |x| {
+                        // TODO: fold doc_hidden and deprecated along the whole path
+                        origin.make_importable_path_vertex(ImportablePath::new(
+                            x,
+                            // TODO: parse the attribute properly to allow for other args to doc
+                            item.attrs.iter().any(|attr| attr == "#[doc(hidden)]"),
+                            item.deprecation.is_some(),
+                        ))
+                    }),
             )
         }),
         _ => unreachable!("resolve_importable_edge {edge_name}"),

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -97,7 +97,14 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                 | "AssociatedConstant" | "Module"
                     if matches!(
                         property_name.as_ref(),
-                        "id" | "crate_id" | "name" | "docs" | "attrs" | "visibility_limit"
+                        "id" | "crate_id"
+                            | "name"
+                            | "docs"
+                            | "attrs"
+                            | "doc_hidden"
+                            | "deprecated"
+                            | "public_api_eligible"
+                            | "visibility_limit"
                     ) =>
                 {
                     // properties inherited from Item, accesssed on Item subtypes

--- a/src/adapter/optimizations/item_lookup.rs
+++ b/src/adapter/optimizations/item_lookup.rs
@@ -89,7 +89,7 @@ fn resolve_items_by_importable_path_field_value<'a>(
         .expect("crate's imports_index was never constructed")
         .get(path_components.as_slice())
     {
-        resolve_item_vertices(origin, items.iter().copied())
+        resolve_item_vertices(origin, items.iter().map(|(item, _)| item).copied())
     } else {
         // No such items found.
         Box::new(std::iter::empty())

--- a/src/adapter/origin.rs
+++ b/src/adapter/origin.rs
@@ -2,7 +2,10 @@ use std::rc::Rc;
 
 use rustdoc_types::{Abi, Item, Span};
 
-use crate::attributes::{Attribute, AttributeMetaItem};
+use crate::{
+    attributes::{Attribute, AttributeMetaItem},
+    indexed_crate::ImportablePath,
+};
 
 use super::vertex::{Vertex, VertexKind};
 
@@ -37,7 +40,7 @@ impl Origin {
 
     pub(super) fn make_importable_path_vertex<'a>(
         &self,
-        importable_path: Vec<&'a str>,
+        importable_path: ImportablePath<'a>,
     ) -> Vertex<'a> {
         Vertex {
             origin: *self,

--- a/src/adapter/origin.rs
+++ b/src/adapter/origin.rs
@@ -44,7 +44,7 @@ impl Origin {
     ) -> Vertex<'a> {
         Vertex {
             origin: *self,
-            kind: VertexKind::ImportablePath(importable_path),
+            kind: VertexKind::ImportablePath(Rc::from(importable_path)),
         }
     }
 

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -162,6 +162,7 @@ pub(super) fn resolve_importable_path_property<'a>(
             vertex
                 .as_importable_path()
                 .expect("not an importable path")
+                .path
                 .components
                 .iter()
                 .map(ToString::to_string)
@@ -169,12 +170,18 @@ pub(super) fn resolve_importable_path_property<'a>(
                 .into()
         }),
         "visibility_limit" => resolve_property_with(contexts, |_| "public".into()),
-        "doc_hidden" => {
-            resolve_property_with(contexts, field_property!(as_importable_path, doc_hidden))
-        }
-        "deprecated" => {
-            resolve_property_with(contexts, field_property!(as_importable_path, deprecated))
-        }
+        "doc_hidden" => resolve_property_with(
+            contexts,
+            field_property!(as_importable_path, modifiers, {
+                modifiers.doc_hidden.into()
+            }),
+        ),
+        "deprecated" => resolve_property_with(
+            contexts,
+            field_property!(as_importable_path, modifiers, {
+                modifiers.deprecated.into()
+            }),
+        ),
         "public_api" => {
             resolve_property_with(contexts, accessor_property!(as_importable_path, public_api))
         }

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -1,4 +1,4 @@
-use rustdoc_types::ItemEnum;
+use rustdoc_types::{ItemEnum, Visibility};
 use trustfall::{
     provider::{
         accessor_property, field_property, resolve_property_with, ContextIterator,
@@ -46,6 +46,35 @@ pub(super) fn resolve_item_property<'a>(
         "name" => resolve_property_with(contexts, field_property!(as_item, name)),
         "docs" => resolve_property_with(contexts, field_property!(as_item, docs)),
         "attrs" => resolve_property_with(contexts, field_property!(as_item, attrs)),
+        "deprecated" => resolve_property_with(
+            contexts,
+            field_property!(as_item, deprecation, { deprecation.is_some().into() }),
+        ),
+        "doc_hidden" => resolve_property_with(
+            contexts,
+            field_property!(as_item, attrs, {
+                attrs
+                    .iter()
+                    .any(|attr| Attribute::is_doc_hidden(attr))
+                    .into()
+            }),
+        ),
+        "public_api_eligible" => resolve_property_with(contexts, move |vertex| {
+            // Items are eligible for public API if both:
+            // - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+            // - The item is deprecated, or not `#[doc(hidden)]`.
+            //
+            // This does not mean that the item is necessarily part of the public API!
+            // An item that is not eligible by itself cannot be part of the public API,
+            // but eligible items might not be public API -- for example, pub-in-priv items
+            // (public items in a private module) are eligible but not public API.
+            let item = vertex.as_item().expect("vertex was not an Item");
+            let is_public = matches!(item.visibility, Visibility::Public | Visibility::Default);
+            (is_public
+                && (item.deprecation.is_some()
+                    || !item.attrs.iter().any(|attr| Attribute::is_doc_hidden(attr))))
+            .into()
+        }),
         "visibility_limit" => resolve_property_with(contexts, |vertex| {
             let item = vertex.as_item().expect("not an item");
             match &item.visibility {

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -162,12 +162,22 @@ pub(super) fn resolve_importable_path_property<'a>(
             vertex
                 .as_importable_path()
                 .expect("not an importable path")
+                .components
                 .iter()
                 .map(ToString::to_string)
                 .collect::<Vec<_>>()
                 .into()
         }),
         "visibility_limit" => resolve_property_with(contexts, |_| "public".into()),
+        "doc_hidden" => {
+            resolve_property_with(contexts, field_property!(as_importable_path, doc_hidden))
+        }
+        "deprecated" => {
+            resolve_property_with(contexts, field_property!(as_importable_path, deprecated))
+        }
+        "public_api" => {
+            resolve_property_with(contexts, accessor_property!(as_importable_path, public_api))
+        }
         _ => unreachable!("ImportablePath property {property_name}"),
     }
 }

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -1170,3 +1170,225 @@ fn item_own_public_api_properties() {
 
     similar_asserts::assert_eq!(expected_results, results);
 }
+
+/// Enum variants have as-if-public visibility by default -- they are public if the enum is public.
+#[test]
+fn enum_variant_public_api_eligible() {
+    let path = "./localdata/test_data/importable_paths/rustdoc.json";
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
+        .expect("failed to load rustdoc");
+
+    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
+    let indexed_crate = IndexedCrate::new(&crate_);
+    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Variant {
+                name @output
+                doc_hidden @output
+                deprecated @output
+                public_api_eligible @output
+            }
+        }
+    }
+}
+"#;
+
+    let variables: BTreeMap<&str, &str> = BTreeMap::default();
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        doc_hidden: bool,
+        deprecated: bool,
+        public_api_eligible: bool,
+    }
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    // We are checking whether the *items themselves* are deprecated / hidden.
+    // We are *not* checking whether their paths are deprecated or hidden.
+    // This is why it doesn't matter that the enum itself is private.
+    //
+    // We write the results in the order the items appear in the test file,
+    // and sort them afterward in order to compare with the (sorted) query results.
+    // This makes it easier to verify that the expected data here is correct
+    // by reading it side-by-side with the file.
+    let mut expected_results = vec![
+        Output {
+            name: "NotHidden".into(),
+            doc_hidden: false,
+            deprecated: false,
+            public_api_eligible: true,
+        },
+        Output {
+            name: "Deprecated".into(),
+            doc_hidden: false,
+            deprecated: true,
+            public_api_eligible: true,
+        },
+        Output {
+            name: "DeprecatedHidden".into(),
+            doc_hidden: true,
+            deprecated: true,
+            public_api_eligible: true,
+        },
+        Output {
+            name: "Hidden".into(),
+            doc_hidden: true,
+            deprecated: false,
+            public_api_eligible: false,
+        },
+    ];
+    expected_results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
+/// Trait associated items have as-if-public visibility by default.
+#[test]
+fn trait_associated_items_public_api_eligible() {
+    let path = "./localdata/test_data/importable_paths/rustdoc.json";
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
+        .expect("failed to load rustdoc");
+
+    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
+    let indexed_crate = IndexedCrate::new(&crate_);
+    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Trait {
+                name @filter(op: "=", value: ["$trait"])
+
+                associated_type {
+                    name @output
+                    doc_hidden @output
+                    deprecated @output
+                    public_api_eligible @output
+                }
+            }
+        }
+    }
+}
+"#;
+
+    let variables: BTreeMap<&str, &str> = btreemap! {
+        "trait" => "SomeTrait"
+    };
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        doc_hidden: bool,
+        deprecated: bool,
+        public_api_eligible: bool,
+    }
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    similar_asserts::assert_eq!(
+        vec![Output {
+            name: "T".into(),
+            doc_hidden: true,
+            deprecated: true,
+            public_api_eligible: true
+        },],
+        results
+    );
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Trait {
+                name @filter(op: "=", value: ["$trait"])
+
+                associated_constant {
+                    name @output
+                    doc_hidden @output
+                    deprecated @output
+                    public_api_eligible @output
+                }
+            }
+        }
+    }
+}
+"#;
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    similar_asserts::assert_eq!(
+        vec![Output {
+            name: "N".into(),
+            doc_hidden: true,
+            deprecated: true,
+            public_api_eligible: true
+        },],
+        results
+    );
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Trait {
+                name @filter(op: "=", value: ["$trait"])
+
+                method {
+                    name @output
+                    doc_hidden @output
+                    deprecated @output
+                    public_api_eligible @output
+                }
+            }
+        }
+    }
+}
+"#;
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    similar_asserts::assert_eq!(
+        vec![Output {
+            name: "associated".into(),
+            doc_hidden: true,
+            deprecated: true,
+            public_api_eligible: true
+        },],
+        results
+    );
+}

--- a/src/adapter/vertex.rs
+++ b/src/adapter/vertex.rs
@@ -29,7 +29,7 @@ pub enum VertexKind<'a> {
     Item(&'a Item),
     Span(&'a Span),
     Path(&'a [String]),
-    ImportablePath(ImportablePath<'a>),
+    ImportablePath(Rc<ImportablePath<'a>>),
     RawType(&'a Type),
     Attribute(Attribute<'a>),
     AttributeMetaItem(Rc<AttributeMetaItem<'a>>),

--- a/src/adapter/vertex.rs
+++ b/src/adapter/vertex.rs
@@ -8,6 +8,7 @@ use trustfall::provider::Typename;
 
 use crate::{
     attributes::{Attribute, AttributeMetaItem},
+    indexed_crate::ImportablePath,
     IndexedCrate,
 };
 
@@ -28,7 +29,7 @@ pub enum VertexKind<'a> {
     Item(&'a Item),
     Span(&'a Span),
     Path(&'a [String]),
-    ImportablePath(Vec<&'a str>),
+    ImportablePath(ImportablePath<'a>),
     RawType(&'a Type),
     Attribute(Attribute<'a>),
     AttributeMetaItem(Rc<AttributeMetaItem<'a>>),
@@ -169,7 +170,7 @@ impl<'a> Vertex<'a> {
         }
     }
 
-    pub(super) fn as_importable_path(&self) -> Option<&'_ Vec<&'a str>> {
+    pub(super) fn as_importable_path(&self) -> Option<&'_ ImportablePath<'a>> {
         match &self.kind {
             VertexKind::ImportablePath(path) => Some(path),
             _ => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,4 +10,7 @@ mod visibility_tracker;
 // Re-export the Crate type so we can deserialize it.
 pub use rustdoc_types::Crate;
 
-pub use {adapter::RustdocAdapter, indexed_crate::IndexedCrate};
+pub use {
+    adapter::RustdocAdapter,
+    indexed_crate::{ImportablePath, IndexedCrate},
+};

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -53,6 +53,37 @@ interface Item {
   """
   attrs: [String!]!
 
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   # stringified version of the visibility struct field
   visibility_limit: String!
 
@@ -71,6 +102,38 @@ type Module implements Item & Importable {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # own properties
@@ -101,6 +164,38 @@ type Struct implements Item & Importable & ImplOwner {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # own properties
@@ -155,6 +250,38 @@ type StructField implements Item {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # edges from Item
@@ -177,6 +304,38 @@ type Enum implements Item & Importable & ImplOwner {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # own properties
@@ -230,6 +389,38 @@ interface Variant implements Item {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # edges from Item
@@ -252,6 +443,38 @@ type PlainVariant implements Item & Variant {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # edges from Item
@@ -274,6 +497,38 @@ type TupleVariant implements Item & Variant {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # edges from Item
@@ -296,6 +551,38 @@ type StructVariant implements Item & Variant {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # edges from Item
@@ -335,6 +622,38 @@ interface ImplOwner implements Item & Importable {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # edges from Item
@@ -382,6 +701,37 @@ type Impl implements Item {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
 
   # stringified version of the visibility struct field
   visibility_limit: String!
@@ -434,6 +784,38 @@ type Trait implements Item & Importable {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # own properties
@@ -493,10 +875,10 @@ type ImportablePath {
   deprecated: Boolean!
 
   """
-  This path should be treated as public API. This is true if:
-  - the path is visible in documentation, or
-  - the path is not visible and is also deprecated.
-    (Which assumes that in the past it was a public API.)
+  This path should be treated as public API. This is true if either:
+  - The path is visible in documentation.
+  - The path is not visible and is deprecated,
+    since deprecated paths are assumed to have been part of the public API in the past.
   """
   public_api: Boolean!
 
@@ -604,6 +986,38 @@ type Function implements Item & FunctionLike & Importable {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # properties from FunctionLike
@@ -660,6 +1074,38 @@ type Method implements Item & FunctionLike {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # properties from FunctionLike
@@ -688,6 +1134,38 @@ interface GlobalValue implements Item & Importable {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # edges from Item
@@ -711,6 +1189,38 @@ type Constant implements Item & Importable & GlobalValue {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # properties for Constant
@@ -791,6 +1301,38 @@ type Static implements Item & Importable & GlobalValue {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # own properties
@@ -905,6 +1447,38 @@ type AssociatedType implements Item {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # properties for AssociatedType
@@ -949,6 +1523,38 @@ type AssociatedConstant implements Item {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # properties for AssociatedConstant

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -483,6 +483,24 @@ type ImportablePath {
   visibility_limit: String!
 
   """
+  This path is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This path is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  This path should be treated as public API. This is true if:
+  - the path is visible in documentation, or
+  - the path is not visible and is also deprecated.
+    (Which assumes that in the past it was a public API.)
+  """
+  public_api: Boolean!
+
+  """
   The path from which the item can be imported.
 
   For example: ["foo", "bar", "Baz"] for a type importable as foo::bar::Baz

--- a/src/visibility_tracker.rs
+++ b/src/visibility_tracker.rs
@@ -119,23 +119,8 @@ impl<'a> VisibilityTracker<'a> {
             stack.push(pushed_name);
         }
 
-        let next_doc_hidden = currently_doc_hidden
-            || item
-                .attrs
-                .iter()
-                // Attribute formatting is normalized by rustdoc, so let's pre-filter attributes
-                // before parsing them, since parsing is expensive and allocates quite a bit.
-                .filter(|attr| attr.starts_with("#[doc("))
-                .any(|attr| {
-                    let attribute = Attribute::new(attr);
-                    attribute.content.base == "doc"
-                        && attribute
-                            .content
-                            .arguments
-                            .iter()
-                            .flatten()
-                            .any(|arg| arg.base == "hidden")
-                });
+        let next_doc_hidden =
+            currently_doc_hidden || item.attrs.iter().any(|attr| Attribute::is_doc_hidden(attr));
         let next_deprecated = currently_deprecated || item.deprecation.is_some();
 
         self.collect_publicly_importable_names_recurse(

--- a/src/visibility_tracker.rs
+++ b/src/visibility_tracker.rs
@@ -2,6 +2,8 @@ use std::collections::{HashMap, HashSet};
 
 use rustdoc_types::{Crate, GenericArgs, Id, Item, ItemEnum, TypeAlias, Visibility};
 
+use crate::{attributes::Attribute, ImportablePath};
+
 #[derive(Debug, Clone)]
 pub(crate) struct VisibilityTracker<'a> {
     // The crate this represents.
@@ -29,12 +31,30 @@ impl<'a> VisibilityTracker<'a> {
         }
     }
 
-    pub(crate) fn collect_publicly_importable_names(
+    pub(crate) fn collect_publicly_importable_names(&self, id: &'a Id) -> Vec<ImportablePath<'a>> {
+        let mut already_visited_ids = Default::default();
+        let mut result = Default::default();
+
+        self.collect_publicly_importable_names_inner(
+            id,
+            &mut already_visited_ids,
+            &mut vec![],
+            false,
+            false,
+            &mut result,
+        );
+
+        result
+    }
+
+    pub(crate) fn collect_publicly_importable_names_inner(
         &self,
         next_id: &'a Id,
         already_visited_ids: &mut HashSet<&'a Id>,
         stack: &mut Vec<&'a str>,
-        output: &mut Vec<Vec<&'a str>>,
+        currently_doc_hidden: bool,
+        currently_deprecated: bool,
+        output: &mut Vec<ImportablePath<'a>>,
     ) {
         if !already_visited_ids.insert(next_id) {
             // We found a cycle, and we've already processed this item.
@@ -99,7 +119,33 @@ impl<'a> VisibilityTracker<'a> {
             stack.push(pushed_name);
         }
 
-        self.collect_publicly_importable_names_inner(next_id, already_visited_ids, stack, output);
+        let next_doc_hidden = currently_doc_hidden
+            || item
+                .attrs
+                .iter()
+                // Attribute formatting is normalized by rustdoc, so let's pre-filter attributes
+                // before parsing them, since parsing is expensive and allocates quite a bit.
+                .filter(|attr| attr.starts_with("#[doc("))
+                .any(|attr| {
+                    let attribute = Attribute::new(attr);
+                    attribute.content.base == "doc"
+                        && attribute
+                            .content
+                            .arguments
+                            .iter()
+                            .flatten()
+                            .any(|arg| arg.base == "hidden")
+                });
+        let next_deprecated = currently_deprecated || item.deprecation.is_some();
+
+        self.collect_publicly_importable_names_recurse(
+            next_id,
+            already_visited_ids,
+            stack,
+            next_doc_hidden,
+            next_deprecated,
+            output,
+        );
 
         // Undo any changes made to the stack, returning it to its pre-recursion state.
         if let Some(pushed_name) = push_name {
@@ -115,22 +161,30 @@ impl<'a> VisibilityTracker<'a> {
         assert!(removed);
     }
 
-    fn collect_publicly_importable_names_inner(
+    fn collect_publicly_importable_names_recurse(
         &self,
         next_id: &'a Id,
         already_visited_ids: &mut HashSet<&'a Id>,
         stack: &mut Vec<&'a str>,
-        output: &mut Vec<Vec<&'a str>>,
+        currently_doc_hidden: bool,
+        currently_deprecated: bool,
+        output: &mut Vec<ImportablePath<'a>>,
     ) {
         if next_id == &self.inner.root {
             let final_name = stack.iter().rev().copied().collect();
-            output.push(final_name);
+            output.push(ImportablePath::new(
+                final_name,
+                currently_doc_hidden,
+                currently_deprecated,
+            ));
         } else if let Some(visible_parents) = self.visible_parent_ids.get(next_id) {
             for parent_id in visible_parents.iter().copied() {
-                self.collect_publicly_importable_names(
+                self.collect_publicly_importable_names_inner(
                     parent_id,
                     already_visited_ids,
                     stack,
+                    currently_doc_hidden,
+                    currently_deprecated,
                     output,
                 );
             }

--- a/test_crates/importable_paths/Cargo.toml
+++ b/test_crates/importable_paths/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "importable_paths"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/test_crates/importable_paths/src/lib.rs
+++ b/test_crates/importable_paths/src/lib.rs
@@ -1,7 +1,9 @@
 pub struct PublicImportable {}
 
 mod private {
-    pub struct Private {}
+    pub struct PubInPriv {}
+
+    struct Private {}
 }
 
 #[doc(hidden)]

--- a/test_crates/importable_paths/src/lib.rs
+++ b/test_crates/importable_paths/src/lib.rs
@@ -43,5 +43,24 @@ pub use submodule::Hidden as UsedHidden;
 // This is expected to be public_api and deprecated
 pub use deprecated::ModuleDeprecated as UsedModuleDeprecated;
 
-// not public_api; it's not relevant that the module was deprecated
+// Still public_api, the item is deprecated (via its module) so the item is visible.
 pub use deprecated::ModuleDeprecatedHidden as UsedModuleDeprecatedHidden;
+
+pub mod reexports {
+    // Re-exports can be deprecated too.
+    #[deprecated]
+    pub use super::PublicImportable as DeprecatedReexport;
+
+    // Re-exports can be doc-hidden as well.
+    #[doc(hidden)]
+    pub use super::PublicImportable as HiddenReexport;
+
+    // Doc-hidden re-exports of deprecated items are still public API.
+    #[doc(hidden)]
+    pub use super::deprecated::ModuleDeprecated as HiddenDeprecatedReexport;
+}
+
+// Our doc-hidden analysis works even when `#[doc(hidden)]` does not appear verbatim
+// in the attributes, and is instead combined with other `doc` commands.
+#[doc(hidden, alias = "TheAlias")]
+pub struct Aliased;

--- a/test_crates/importable_paths/src/lib.rs
+++ b/test_crates/importable_paths/src/lib.rs
@@ -1,0 +1,47 @@
+pub struct PublicImportable {}
+
+mod private {
+    pub struct Private {}
+}
+
+#[doc(hidden)]
+pub mod hidden {
+    pub struct ModuleHidden {}
+
+    #[deprecated]
+    pub struct DeprecatedModuleHidden {} // public_api
+
+    #[deprecated]
+    pub mod deprecated {
+        pub struct ModuleDeprecatedModuleHidden {} // public_api
+    }
+}
+
+pub mod submodule {
+    #[doc(hidden)]
+    pub struct Hidden {}
+
+    #[deprecated]
+    #[doc(hidden)]
+    pub struct DeprecatedHidden {} // public_api
+}
+
+#[deprecated]
+pub mod deprecated {
+    pub struct ModuleDeprecated {} // public_api
+
+    #[doc(hidden)]
+    pub struct ModuleDeprecatedHidden {} // public_api
+}
+
+// This is expected to be visible in rustdoc.
+pub use hidden::ModuleHidden as UsedVisible; // public_api
+
+// This is expected to be hidden in rustdoc.
+pub use submodule::Hidden as UsedHidden;
+
+// This is expected to be public_api and deprecated
+pub use deprecated::ModuleDeprecated as UsedModuleDeprecated;
+
+// not public_api; it's not relevant that the module was deprecated
+pub use deprecated::ModuleDeprecatedHidden as UsedModuleDeprecatedHidden;

--- a/test_crates/importable_paths/src/lib.rs
+++ b/test_crates/importable_paths/src/lib.rs
@@ -4,6 +4,34 @@ mod private {
     pub struct PubInPriv {}
 
     struct Private {}
+
+    enum PrivateEnum {
+        NotHidden,
+
+        #[deprecated]
+        Deprecated,
+
+        #[deprecated]
+        #[doc(hidden)]
+        DeprecatedHidden,
+
+        #[doc(hidden)]
+        Hidden,
+    }
+
+    trait SomeTrait {
+        #[doc(hidden)]
+        #[deprecated]
+        type T;
+
+        #[doc(hidden)]
+        #[deprecated]
+        const N: i64;
+
+        #[doc(hidden)]
+        #[deprecated]
+        fn associated();
+    }
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
Related to https://github.com/obi1kenobi/cargo-semver-checks/issues/120

Adds new properties to `ImportablePath` to probe whether an API is "public", which is currently implemented as:
- Has an importable path
- Which may be deprecated
- If not deprecated, it must not be hidden

This was done together in collaboration with @obi1kenobi (thanks, was fun pairing!); one or both of us may pick this up again in the future time permitting. Mostly complete barring the TODOs in `edges.rs` and `indexed_crate.rs`, plus test output will change once those are corrected.