### PR TITLE
Add adapter support for a Module item type.

### DIFF
--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -4,7 +4,7 @@ use trustfall::provider::{
     VertexIterator,
 };
 
-use crate::{attributes::Attribute, IndexedCrate};
+use crate::{adapter::supported_item_kind, attributes::Attribute, IndexedCrate};
 
 use super::{optimizations, origin::Origin, vertex::Vertex, RustdocAdapter};
 
@@ -186,6 +186,7 @@ pub(super) fn resolve_module_edge<'a>(
             Box::new(module_item.items.iter().filter_map(move |item_id| {
                 item_index
                     .get(item_id)
+                    .filter(|item| supported_item_kind(item))
                     .map(|item| origin.make_item_vertex(item))
             }))
         }),

--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -183,8 +183,10 @@ pub(super) fn resolve_module_edge<'a>(
                 }
             };
 
-            Box::new(module_item.items.iter().map(move |item_id| {
-                origin.make_item_vertex(item_index.get(item_id).expect("missing item"))
+            Box::new(module_item.items.iter().filter_map(move |item_id| {
+                item_index
+                    .get(item_id)
+                    .map(|item| origin.make_item_vertex(item))
             }))
         }),
         _ => unreachable!("resolve_module_edge {edge_name}"),

--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -35,6 +35,29 @@ pub(super) fn resolve_crate_edge<'a>(
 ) -> ContextOutcomeIterator<'a, Vertex<'a>, VertexIterator<'a, Vertex<'a>>> {
     match edge_name {
         "item" => optimizations::item_lookup::resolve_crate_items(adapter, contexts, resolve_info),
+        "root_module" => {
+            let current_crate = adapter.current_crate;
+            let previous_crate = adapter.previous_crate;
+
+            resolve_neighbors_with(contexts, move |vertex| {
+                let origin = vertex.origin;
+                let crate_ = vertex.as_crate().expect("vertex was not a crate!");
+                let item_index = match origin {
+                    Origin::CurrentCrate => &current_crate.inner.index,
+                    Origin::PreviousCrate => {
+                        &previous_crate
+                            .expect("no previous crate provided")
+                            .inner
+                            .index
+                    }
+                };
+
+                let module = item_index
+                    .get(&crate_.root)
+                    .expect("crate had no root module");
+                Box::new(std::iter::once(origin.make_item_vertex(module)))
+            })
+        }
         _ => unreachable!("resolve_crate_edge {edge_name}"),
     }
 }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -94,7 +94,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                 "ImplOwner" | "Struct" | "StructField" | "Enum" | "Variant" | "PlainVariant"
                 | "TupleVariant" | "StructVariant" | "Trait" | "Function" | "Method" | "Impl"
                 | "GlobalValue" | "Constant" | "Static" | "AssociatedType"
-                | "AssociatedConstant"
+                | "AssociatedConstant" | "Module"
                     if matches!(
                         property_name.as_ref(),
                         "id" | "crate_id" | "name" | "docs" | "attrs" | "visibility_limit"
@@ -103,6 +103,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                     // properties inherited from Item, accesssed on Item subtypes
                     properties::resolve_item_property(contexts, property_name)
                 }
+                "Module" => properties::resolve_module_property(contexts, property_name),
                 "Struct" => properties::resolve_struct_property(contexts, property_name),
                 "Enum" => properties::resolve_enum_property(contexts, property_name),
                 "Span" => properties::resolve_span_property(contexts, property_name),
@@ -157,7 +158,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
             "CrateDiff" => edges::resolve_crate_diff_edge(contexts, edge_name),
             "Crate" => edges::resolve_crate_edge(self, contexts, edge_name, resolve_info),
             "Importable" | "ImplOwner" | "Struct" | "Enum" | "Trait" | "Function"
-            | "GlobalValue" | "Constant" | "Static"
+            | "GlobalValue" | "Constant" | "Static" | "Module"
                 if matches!(edge_name.as_ref(), "importable_path" | "canonical_path") =>
             {
                 edges::resolve_importable_edge(
@@ -170,7 +171,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
             "Item" | "ImplOwner" | "Struct" | "StructField" | "Enum" | "Variant"
             | "PlainVariant" | "TupleVariant" | "StructVariant" | "Trait" | "Function"
             | "Method" | "Impl" | "GlobalValue" | "Constant" | "Static" | "AssociatedType"
-            | "AssociatedConstant"
+            | "AssociatedConstant" | "Module"
                 if matches!(edge_name.as_ref(), "span" | "attribute") =>
             {
                 edges::resolve_item_edge(contexts, edge_name)
@@ -185,6 +186,12 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
             {
                 edges::resolve_function_like_edge(contexts, edge_name)
             }
+            "Module" => edges::resolve_module_edge(
+                contexts,
+                edge_name,
+                self.current_crate,
+                self.previous_crate,
+            ),
             "Struct" => edges::resolve_struct_edge(
                 contexts,
                 edge_name,
@@ -268,5 +275,6 @@ pub(crate) fn supported_item_kind(item: &Item) -> bool {
             | rustdoc_types::ItemEnum::Constant(..)
             | rustdoc_types::ItemEnum::Static(..)
             | rustdoc_types::ItemEnum::AssocType { .. }
+            | rustdoc_types::ItemEnum::Module { .. }
     )
 }

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -66,7 +66,6 @@ pub(super) fn resolve_module_property<'a>(
     property_name: &str,
 ) -> ContextOutcomeIterator<'a, Vertex<'a>, FieldValue> {
     match property_name {
-        "is_crate" => resolve_property_with(contexts, field_property!(as_module, is_crate)),
         "is_stripped" => resolve_property_with(contexts, field_property!(as_module, is_stripped)),
         _ => unreachable!("Module property {property_name}"),
     }

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -61,6 +61,17 @@ pub(super) fn resolve_item_property<'a>(
     }
 }
 
+pub(super) fn resolve_module_property<'a>(
+    contexts: ContextIterator<'a, Vertex<'a>>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, Vertex<'a>, FieldValue> {
+    match property_name {
+        "is_crate" => resolve_property_with(contexts, field_property!(as_module, is_crate)),
+        "is_stripped" => resolve_property_with(contexts, field_property!(as_module, is_stripped)),
+        _ => unreachable!("Module property {property_name}"),
+    }
+}
+
 pub(super) fn resolve_struct_property<'a>(
     contexts: ContextIterator<'a, Vertex<'a>>,
     property_name: &str,

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -491,6 +491,39 @@ fn rustdoc_modules() {
         ],
         results
     );
+
+    let root_query = r#"
+{
+   Crate {
+       root_module {
+           module: name @output
+           is_crate @output
+           is_stripped @output
+           item @fold {
+               members: name @output
+               types: __typename @output
+           }
+       }
+   }
+}
+"#;
+
+    let results: Vec<Output> =
+        trustfall::execute_query(&schema, adapter.clone(), root_query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+
+    similar_asserts::assert_eq!(
+        vec![Output {
+            module: "modules".into(),
+            is_crate: true,
+            is_stripped: false,
+            members: vec![Some("hello".into()), Some("outer".into())],
+            types: vec!["Module".into(), "Module".into()],
+        }],
+        results
+    );
 }
 
 #[test]

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -1,8 +1,8 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use anyhow::Context;
-use maplit::{btreemap, btreeset};
+use maplit::btreemap;
 use trustfall::{Schema, TryIntoStruct};
 
 use crate::{IndexedCrate, RustdocAdapter};
@@ -422,6 +422,7 @@ fn rustdoc_modules() {
                is_stripped @output
                item @fold {
                    members: name @output
+                   types: __typename @output
                }
            }
        }
@@ -439,7 +440,8 @@ fn rustdoc_modules() {
         module: String,
         is_crate: bool,
         is_stripped: bool,
-        members: BTreeSet<Option<String>>,
+        members: Vec<Option<String>>,
+        types: Vec<String>,
     }
 
     let mut results: Vec<Output> =
@@ -455,31 +457,36 @@ fn rustdoc_modules() {
                 module: "hello".into(),
                 is_crate: false,
                 is_stripped: false,
-                members: btreeset![Some("T2".into(),), Some("world".into(),),]
+                members: vec![Some("world".into()), Some("T2".into())],
+                types: vec!["Module".into(), "Struct".into()],
             },
             Output {
                 module: "inner".into(),
                 is_crate: false,
                 is_stripped: false,
-                members: btreeset![Some("T4".into(),),],
+                members: vec![Some("T4".into(),),],
+                types: vec!["Struct".into()],
             },
             Output {
                 module: "modules".into(),
                 is_crate: true,
                 is_stripped: false,
-                members: btreeset![Some("hello".into(),), Some("outer".into(),),],
+                members: vec![Some("hello".into()), Some("outer".into())],
+                types: vec!["Module".into(), "Module".into()],
             },
             Output {
                 module: "outer".into(),
                 is_crate: false,
                 is_stripped: false,
-                members: btreeset![None, Some("T3".into(),), Some("inner".into(),),],
+                members: vec![Some("inner".into()), Some("T3".into())],
+                types: vec!["Module".into(), "Struct".into()],
             },
             Output {
                 module: "world".into(),
                 is_crate: false,
                 is_stripped: false,
-                members: btreeset![Some("T1".into(),),],
+                members: vec![Some("T1".into())],
+                types: vec!["Struct".into()],
             },
         ],
         results

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -401,6 +401,116 @@ fn rustdoc_finds_statics() {
 }
 
 #[test]
+fn rustdoc_modules() {
+    let path = "./localdata/test_data/modules/rustdoc.json";
+
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
+        .expect("failed to load rustdoc");
+
+    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
+    let indexed_crate = IndexedCrate::new(&crate_);
+    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+
+    let mod_query = r#"
+{
+   Crate {
+       item {
+           ... on Module {
+               module: name @output
+               is_crate @output
+               is_stripped @output
+               item {
+                   member: name @output
+               }
+           }
+       }
+   }
+}
+"#;
+
+    let variables: BTreeMap<&str, &str> = BTreeMap::default();
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        member: Option<String>,
+        module: String,
+        is_crate: bool,
+        is_stripped: bool,
+    }
+
+    let mut results: Vec<Output> =
+        trustfall::execute_query(&schema, adapter.clone(), mod_query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    similar_asserts::assert_eq!(
+        vec![
+            Output {
+                member: None,
+                module: "outer".into(),
+                is_crate: false,
+                is_stripped: false,
+            },
+            Output {
+                member: Some("T1".into(),),
+                module: "world".into(),
+                is_crate: false,
+                is_stripped: false,
+            },
+            Output {
+                member: Some("T2".into(),),
+                module: "hello".into(),
+                is_crate: false,
+                is_stripped: false,
+            },
+            Output {
+                member: Some("T3".into(),),
+                module: "outer".into(),
+                is_crate: false,
+                is_stripped: false,
+            },
+            Output {
+                member: Some("T4".into(),),
+                module: "inner".into(),
+                is_crate: false,
+                is_stripped: false,
+            },
+            Output {
+                member: Some("hello".into(),),
+                module: "modules".into(),
+                is_crate: true,
+                is_stripped: false,
+            },
+            Output {
+                member: Some("inner".into(),),
+                module: "outer".into(),
+                is_crate: false,
+                is_stripped: false,
+            },
+            Output {
+                member: Some("outer".into(),),
+                module: "modules".into(),
+                is_crate: true,
+                is_stripped: false,
+            },
+            Output {
+                member: Some("world".into(),),
+                module: "hello".into(),
+                is_crate: false,
+                is_stripped: false,
+            },
+        ],
+        results
+    );
+}
+
+#[test]
 fn rustdoc_associated_consts() {
     let path = "./localdata/test_data/associated_consts/rustdoc.json";
     let content = std::fs::read_to_string(path)

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -418,7 +418,6 @@ fn rustdoc_modules() {
        item {
            ... on Module {
                module: name @output
-               is_crate @output
                is_stripped @output
                item @fold {
                    members: name @output
@@ -438,7 +437,6 @@ fn rustdoc_modules() {
     #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
     struct Output {
         module: String,
-        is_crate: bool,
         is_stripped: bool,
         members: Vec<Option<String>>,
         types: Vec<String>,
@@ -455,35 +453,30 @@ fn rustdoc_modules() {
         vec![
             Output {
                 module: "hello".into(),
-                is_crate: false,
                 is_stripped: false,
                 members: vec![Some("world".into()), Some("T2".into())],
                 types: vec!["Module".into(), "Struct".into()],
             },
             Output {
                 module: "inner".into(),
-                is_crate: false,
                 is_stripped: false,
                 members: vec![Some("T4".into(),),],
                 types: vec!["Struct".into()],
             },
             Output {
                 module: "modules".into(),
-                is_crate: true,
                 is_stripped: false,
                 members: vec![Some("hello".into()), Some("outer".into())],
                 types: vec!["Module".into(), "Module".into()],
             },
             Output {
                 module: "outer".into(),
-                is_crate: false,
                 is_stripped: false,
                 members: vec![Some("inner".into()), Some("T3".into())],
                 types: vec!["Module".into(), "Struct".into()],
             },
             Output {
                 module: "world".into(),
-                is_crate: false,
                 is_stripped: false,
                 members: vec![Some("T1".into())],
                 types: vec!["Struct".into()],
@@ -497,7 +490,6 @@ fn rustdoc_modules() {
    Crate {
        root_module {
            module: name @output
-           is_crate @output
            is_stripped @output
            item @fold {
                members: name @output
@@ -517,7 +509,6 @@ fn rustdoc_modules() {
     similar_asserts::assert_eq!(
         vec![Output {
             module: "modules".into(),
-            is_crate: true,
             is_stripped: false,
             members: vec![Some("hello".into()), Some("outer".into())],
             types: vec!["Module".into(), "Module".into()],

--- a/src/adapter/vertex.rs
+++ b/src/adapter/vertex.rs
@@ -1,8 +1,8 @@
 use std::rc::Rc;
 
 use rustdoc_types::{
-    Abi, Constant, Crate, Enum, Function, Impl, Item, Path, Span, Static, Struct, Trait, Type,
-    Variant, VariantKind,
+    Abi, Constant, Crate, Enum, Function, Impl, Item, Module, Path, Span, Static, Struct, Trait,
+    Type, Variant, VariantKind,
 };
 use trustfall::provider::Typename;
 
@@ -44,6 +44,7 @@ impl<'a> Typename for Vertex<'a> {
     fn typename(&self) -> &'static str {
         match self.kind {
             VertexKind::Item(item) => match &item.inner {
+                rustdoc_types::ItemEnum::Module { .. } => "Module",
                 rustdoc_types::ItemEnum::Struct(..) => "Struct",
                 rustdoc_types::ItemEnum::Enum(..) => "Enum",
                 rustdoc_types::ItemEnum::Function(..) => "Function",
@@ -110,6 +111,13 @@ impl<'a> Vertex<'a> {
             VertexKind::Item(item) => Some(item),
             _ => None,
         }
+    }
+
+    pub(super) fn as_module(&self) -> Option<&'a Module> {
+        self.as_item().and_then(|item| match &item.inner {
+            rustdoc_types::ItemEnum::Module(m) => Some(m),
+            _ => None,
+        })
     }
 
     pub(super) fn as_struct(&self) -> Option<&'a Struct> {

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -27,6 +27,9 @@ type Crate {
   includes_private: Boolean!
   format_version: Int!
 
+  """
+  The top-level module of the crate, in which everything else in the crate is contained.
+  """
   root_module: Module!
 
   item: [Item!]

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -74,7 +74,6 @@ type Module implements Item & Importable {
   visibility_limit: String!
 
   # own properties
-  is_crate: Boolean!
   is_stripped: Boolean!
 
   # edges from Item

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -57,6 +57,36 @@ interface Item {
 
 """
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Item.html
+https://docs.rs/rustdoc-types/0.16.0/rustdoc_types/struct.Module.html
+"""
+type Module implements Item & Importable {
+  # properties from Item
+  id: String!
+  crate_id: Int!
+  name: String
+  docs: String
+  attrs: [String!]!
+  visibility_limit: String!
+
+  # own properties
+  is_crate: Boolean!
+  is_stripped: Boolean!
+
+  # edges from Item
+  span: Span
+  attribute: [Attribute!]
+
+  # edges from Importable
+  importable_path: [ImportablePath!]
+  canonical_path: Path
+
+  # own edges
+  item: [Item!]!
+}
+
+
+"""
+https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Item.html
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/enum.ItemEnum.html
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Struct.html
 """

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -27,6 +27,8 @@ type Crate {
   includes_private: Boolean!
   format_version: Int!
 
+  root_module: Module!
+
   item: [Item!]
 }
 

--- a/test_crates/modules/Cargo.toml
+++ b/test_crates/modules/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+publish = false
+name = "modules"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/test_crates/modules/src/lib.rs
+++ b/test_crates/modules/src/lib.rs
@@ -1,4 +1,3 @@
-
 pub mod hello {
     pub mod world {
 	pub struct T1 {}
@@ -7,4 +6,3 @@ pub mod hello {
 }
 
 pub mod outer;
-

--- a/test_crates/modules/src/lib.rs
+++ b/test_crates/modules/src/lib.rs
@@ -1,0 +1,10 @@
+
+pub mod hello {
+    pub mod world {
+	pub struct T1 {}
+    }
+    pub struct T2 {}
+}
+
+pub mod outer;
+

--- a/test_crates/modules/src/outer.rs
+++ b/test_crates/modules/src/outer.rs
@@ -1,0 +1,8 @@
+
+pub struct T3 {}
+
+pub use inner::T4;
+
+mod inner {
+    pub struct T4 {}
+}

--- a/test_crates/modules/src/outer.rs
+++ b/test_crates/modules/src/outer.rs
@@ -1,4 +1,3 @@
-
 pub struct T3 {}
 
 pub use inner::T4;


### PR DESCRIPTION
Hello!

This is prerequisite for solving
https://github.com/obi1kenobi/cargo-semver-checks/issues/482

This is my first attempt at using trustfall, graphql, or the rustdoc_types crate, so I certainly may have missed some things.  Please do not assume I know what I am doing in the slightest. :wink: 

The patch is against rustdoc-v27.  I _think_ it should work similarly with the other branches since the Module struct is the same across all the supported versions of rustdoc, but I don't know how you prefer to handle porting patches like this.