### PR TITLE
Add adapter support for a Module item type. (#261)

### DIFF
--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -94,7 +94,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                 "ImplOwner" | "Struct" | "StructField" | "Enum" | "Variant" | "PlainVariant"
                 | "TupleVariant" | "StructVariant" | "Trait" | "Function" | "Method" | "Impl"
                 | "GlobalValue" | "Constant" | "Static" | "AssociatedType"
-                | "AssociatedConstant"
+                | "AssociatedConstant" | "Module"
                     if matches!(
                         property_name.as_ref(),
                         "id" | "crate_id" | "name" | "docs" | "attrs" | "visibility_limit"
@@ -103,6 +103,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                     // properties inherited from Item, accesssed on Item subtypes
                     properties::resolve_item_property(contexts, property_name)
                 }
+                "Module" => properties::resolve_module_property(contexts, property_name),
                 "Struct" => properties::resolve_struct_property(contexts, property_name),
                 "Enum" => properties::resolve_enum_property(contexts, property_name),
                 "Span" => properties::resolve_span_property(contexts, property_name),
@@ -156,7 +157,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
             "CrateDiff" => edges::resolve_crate_diff_edge(contexts, edge_name),
             "Crate" => edges::resolve_crate_edge(self, contexts, edge_name, resolve_info),
             "Importable" | "ImplOwner" | "Struct" | "Enum" | "Trait" | "Function"
-            | "GlobalValue" | "Constant" | "Static"
+            | "GlobalValue" | "Constant" | "Static" | "Module"
                 if matches!(edge_name.as_ref(), "importable_path" | "canonical_path") =>
             {
                 edges::resolve_importable_edge(
@@ -169,7 +170,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
             "Item" | "ImplOwner" | "Struct" | "StructField" | "Enum" | "Variant"
             | "PlainVariant" | "TupleVariant" | "StructVariant" | "Trait" | "Function"
             | "Method" | "Impl" | "GlobalValue" | "Constant" | "Static" | "AssociatedType"
-            | "AssociatedConstant"
+            | "AssociatedConstant" | "Module"
                 if matches!(edge_name.as_ref(), "span" | "attribute") =>
             {
                 edges::resolve_item_edge(contexts, edge_name)
@@ -184,6 +185,12 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
             {
                 edges::resolve_function_like_edge(contexts, edge_name)
             }
+            "Module" => edges::resolve_module_edge(
+                contexts,
+                edge_name,
+                self.current_crate,
+                self.previous_crate,
+            ),
             "Struct" => edges::resolve_struct_edge(
                 contexts,
                 edge_name,
@@ -267,5 +274,6 @@ pub(crate) fn supported_item_kind(item: &Item) -> bool {
             | rustdoc_types::ItemEnum::Constant(..)
             | rustdoc_types::ItemEnum::Static(..)
             | rustdoc_types::ItemEnum::AssocType { .. }
+            | rustdoc_types::ItemEnum::Module { .. }
     )
 }

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -59,6 +59,16 @@ pub(super) fn resolve_item_property<'a>(
     }
 }
 
+pub(super) fn resolve_module_property<'a>(
+    contexts: ContextIterator<'a, Vertex<'a>>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, Vertex<'a>, FieldValue> {
+    match property_name {
+        "is_stripped" => resolve_property_with(contexts, field_property!(as_module, is_stripped)),
+        _ => unreachable!("Module property {property_name}"),
+    }
+}
+
 pub(super) fn resolve_struct_property<'a>(
     contexts: ContextIterator<'a, Vertex<'a>>,
     property_name: &str,

--- a/src/adapter/vertex.rs
+++ b/src/adapter/vertex.rs
@@ -1,8 +1,8 @@
 use std::rc::Rc;
 
 use rustdoc_types::{
-    Abi, Constant, Crate, Enum, Function, Impl, Item, Path, Span, Static, Struct, Trait, Type,
-    Variant,
+    Abi, Constant, Crate, Enum, Function, Impl, Item, Module, Path, Span, Static, Struct, Trait,
+    Type, Variant,
 };
 use trustfall::provider::Typename;
 
@@ -44,6 +44,7 @@ impl<'a> Typename for Vertex<'a> {
     fn typename(&self) -> &'static str {
         match self.kind {
             VertexKind::Item(item) => match &item.inner {
+                rustdoc_types::ItemEnum::Module { .. } => "Module",
                 rustdoc_types::ItemEnum::Struct(..) => "Struct",
                 rustdoc_types::ItemEnum::Enum(..) => "Enum",
                 rustdoc_types::ItemEnum::Function(..) => "Function",
@@ -110,6 +111,13 @@ impl<'a> Vertex<'a> {
             VertexKind::Item(item) => Some(item),
             _ => None,
         }
+    }
+
+    pub(super) fn as_module(&self) -> Option<&'a Module> {
+        self.as_item().and_then(|item| match &item.inner {
+            rustdoc_types::ItemEnum::Module(m) => Some(m),
+            _ => None,
+        })
     }
 
     pub(super) fn as_struct(&self) -> Option<&'a Struct> {

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -27,6 +27,11 @@ type Crate {
   includes_private: Boolean!
   format_version: Int!
 
+  """
+  The top-level module of the crate, in which everything else in the crate is contained.
+  """
+  root_module: Module!
+
   item: [Item!]
 }
 
@@ -54,6 +59,35 @@ interface Item {
   attribute: [Attribute!]
   span: Span
 }
+
+"""
+https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Item.html
+https://docs.rs/rustdoc-types/0.16.0/rustdoc_types/struct.Module.html
+"""
+type Module implements Item & Importable {
+  # properties from Item
+  id: String!
+  crate_id: Int!
+  name: String
+  docs: String
+  attrs: [String!]!
+  visibility_limit: String!
+
+  # own properties
+  is_stripped: Boolean!
+
+  # edges from Item
+  span: Span
+  attribute: [Attribute!]
+
+  # edges from Importable
+  importable_path: [ImportablePath!]
+  canonical_path: Path
+
+  # own edges
+  item: [Item!]!
+}
+
 
 """
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Item.html

--- a/test_crates/modules/Cargo.toml
+++ b/test_crates/modules/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+publish = false
+name = "modules"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/test_crates/modules/src/lib.rs
+++ b/test_crates/modules/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod hello {
+    pub mod world {
+	pub struct T1 {}
+    }
+    pub struct T2 {}
+}
+
+pub mod outer;

--- a/test_crates/modules/src/outer.rs
+++ b/test_crates/modules/src/outer.rs
@@ -1,0 +1,7 @@
+pub struct T3 {}
+
+pub use inner::T4;
+
+mod inner {
+    pub struct T4 {}
+}


### PR DESCRIPTION
* Add adapter support for a Module item type.

This is prerequisite for solving
https://github.com/obi1kenobi/cargo-semver-checks/issues/482

* fixup! Add adapter support for a Module item type.

Remove extraneous empty lines from test_crates/modules.

* fixup! Add adapter support for a Module item type.

In resolve_module_edge, tolerate item re-exports.

* fixup! Add adapter support for a Module item type.

In test, use @fold to combine all module members.

* fixup! Add adapter support for a Module item type.

Modules:items: only return supported items.

* fixup! Add adapter support for a Module item type.

In modules test, check item types.

* Implement a root_module edge from Crate.

* Update src/rustdoc_schema.graphql

Co-authored-by: Predrag Gruevski <2348618+obi1kenobi@users.noreply.github.com>

* fixup! Add adapter support for a Module item type.

Remove "is_crate" property.

---------

Co-authored-by: Predrag Gruevski <2348618+obi1kenobi@users.noreply.github.com>
