### PR TITLE
Handle `pub use Trait as _` cases correctly: the item is unnameable.

### DIFF
--- a/test_crates/nested_reexport_as_underscore/Cargo.toml
+++ b/test_crates/nested_reexport_as_underscore/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+publish = false
+name = "nested_reexport_as_underscore"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/test_crates/nested_reexport_as_underscore/src/lib.rs
+++ b/test_crates/nested_reexport_as_underscore/src/lib.rs
@@ -1,0 +1,26 @@
+//! This crate does not re-export any *nameable* items.
+//!
+//! However, glob imports of this file (in the style of a prelude)
+//! make `Trait::method()` visible, making `().method()` valid Rust.
+//!
+//! Docs: <https://doc.rust-lang.org/reference/items/use-declarations.html#underscore-imports>
+
+mod inner {
+    pub trait Trait {
+        fn method(&self) {}
+    }
+
+    impl Trait for () {}
+}
+
+mod second {
+    pub use super::inner::Trait as _;
+}
+
+pub use second::*;
+
+/// Verify that the trait is indeed visible.
+#[allow(dead_code)]
+fn proof() {
+    ().method();
+}

--- a/test_crates/overlapping_reexport_as_underscore/Cargo.toml
+++ b/test_crates/overlapping_reexport_as_underscore/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+publish = false
+name = "overlapping_reexport_as_underscore"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/test_crates/overlapping_reexport_as_underscore/src/lib.rs
+++ b/test_crates/overlapping_reexport_as_underscore/src/lib.rs
@@ -1,0 +1,23 @@
+//! This crate re-exports only the struct `Example`.
+//!
+//! Even though `second` imports two items named `Example`, one of them is renamed to `_`
+//! making it unnameable.
+//!
+//! Docs: <https://doc.rust-lang.org/reference/items/use-declarations.html#underscore-imports>
+
+mod inner {
+    pub trait Example {
+        fn method(&self) {}
+    }
+}
+
+mod inner2 {
+    pub struct Example {}
+}
+
+mod second {
+    pub use super::inner::Example as _;
+    pub use super::inner2::Example;
+}
+
+pub use second::*;

--- a/test_crates/reexport_as_underscore/Cargo.toml
+++ b/test_crates/reexport_as_underscore/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+publish = false
+name = "reexport_as_underscore"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/test_crates/reexport_as_underscore/src/lib.rs
+++ b/test_crates/reexport_as_underscore/src/lib.rs
@@ -1,0 +1,32 @@
+//! This crate re-exports only the name `Struct`.
+//!
+//! However, glob imports of this file (in the style of a prelude)
+//! also make `Trait::method()` visible as well, making `().method()` valid Rust.
+//!
+//! The `_` re-export of the module `hidden` is not nameable at all, and here has no effect.
+//! `hidden::UnderscoreImported` is not nameable outside this crate.
+//!
+//! Docs: <https://doc.rust-lang.org/reference/items/use-declarations.html#underscore-imports>
+
+mod inner {
+    pub trait Trait {
+        fn method(&self) {}
+    }
+
+    impl Trait for () {}
+
+    pub struct Struct {}
+}
+
+mod nested {
+    pub mod hidden {
+        pub struct UnderscoreImported;
+    }
+}
+
+pub use inner::{
+    Struct,
+    Trait as _,
+};
+
+pub use nested::hidden as _;


### PR DESCRIPTION
Part of resolving https://github.com/obi1kenobi/cargo-semver-checks/issues/536.
