### PR TITLE
Add Constant type/value properties

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "./README.md"
 [dependencies]
 trustfall = "0.6.0"
 rustdoc-types = "0.22.0"
+serde_json = "1.0.85"
 
 [dev-dependencies]
 anyhow = "1.0.58"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ readme = "./README.md"
 [dependencies]
 trustfall = "0.6.0"
 rustdoc-types = "0.22.0"
-serde_json = "1.0.85"
 
 [dev-dependencies]
 anyhow = "1.0.58"

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -141,6 +141,9 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                 "AssociatedConstant" => {
                     properties::resolve_associated_constant_property(contexts, property_name)
                 }
+                "Constant" => {
+                    properties::resolve_constant_property(contexts, property_name)
+                }
                 _ => unreachable!("resolve_property {type_name} {property_name}"),
             }
         }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -141,9 +141,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                 "AssociatedConstant" => {
                     properties::resolve_associated_constant_property(contexts, property_name)
                 }
-                "Constant" => {
-                    properties::resolve_constant_property(contexts, property_name)
-                }
+                "Constant" => properties::resolve_constant_property(contexts, property_name),
                 _ => unreachable!("resolve_property {type_name} {property_name}"),
             }
         }

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -465,6 +465,26 @@ pub(crate) fn resolve_associated_constant_property<'a>(
         _ => unreachable!("AssociatedConstant property {property_name}"),
     }
 }
+
+
+// const example from rustdocs
+// {"id"           	:"0:9:xx","crate_id":0,
+// "name"          	:"PUB_CONST_NAME",
+// "span"          	:{"filename":"","begin":[5,0],"end":[5,68]},
+// "visibility"    	:"public",
+// "docs"          	:null,
+// "links"         	:{},
+// "attrs"         	:[],
+// "deprecation"   	: null,
+// "inner"         	: { ← &inner will be set to ItemEnum::Constant(c), where c=struct rustdoc_types::Constant
+//   "constant"    	: { rustdoc_types::Constant has type_/expr/value/is_literal fields (docs.rs/rustdoc-types/latest/rustdoc_types/struct.Constant.html)
+//     "type"      	:{"primitive":"i32"}, or ↓ or any of docs.rs/rustdoc-types/latest/rustdoc_types/enum.Type.html
+//     "type"      	:{"borrowed_ref":{"lifetime": "'static","mutable": false,"type":{"primitive": "str"}}},
+//     "type"      	:{"resolved_path":{"name":"Years","id": "0:3:1633","args":{"angle_bracketed":{"args":[],"bindings":[]}}}},
+//     "expr"      	: "_",
+//     "value"     	: null,
+//     "is_literal"	: false}}
+// },
 pub(crate) fn resolve_constant_property<'a>(
     contexts: ContextIterator<'a, Vertex<'a>>,
     property_name: &str,

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -465,3 +465,24 @@ pub(crate) fn resolve_associated_constant_property<'a>(
         _ => unreachable!("AssociatedConstant property {property_name}"),
     }
 }
+pub(crate) fn resolve_constant_property<'a>(
+    contexts: ContextIterator<'a, Vertex<'a>>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, Vertex<'a>, FieldValue> {
+    match property_name {
+        "type_"      => resolve_property_with(contexts, field_property!(as_item, inner, {
+            let ItemEnum::Constant(c) = &inner else {unreachable!("expected to have a Constant")};
+            // c.type_     .clone().into()}),), // Type→FieldValue not implemented, use ↓ json
+            serde_json::to_string(&c.type_.clone()).unwrap().into()}),),
+        "expr"       => resolve_property_with(contexts, field_property!(as_item, inner, {
+            let ItemEnum::Constant(c) = &inner else {unreachable!("expected to have a Constant")};
+            c.expr      .clone().into()}),),
+        "value"      => resolve_property_with(contexts, field_property!(as_item, inner, {
+            let ItemEnum::Constant(c) = &inner else {unreachable!("expected to have a Constant")};
+            c.value     .clone().into()}),),
+        "is_literal" => resolve_property_with(contexts, field_property!(as_item, inner, {
+            let ItemEnum::Constant(c) = &inner else {unreachable!("expected to have a Constant")};
+            c.is_literal.clone().into()}),),
+        _ => unreachable!("Constant property {property_name}"),
+    }
+}

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -502,7 +502,7 @@ pub(crate) fn resolve_constant_property<'a>(
             c.value     .clone().into()}),),
         "is_literal" => resolve_property_with(contexts, field_property!(as_item, inner, {
             let ItemEnum::Constant(c) = &inner else {unreachable!("expected to have a Constant")};
-            c.is_literal.clone().into()}),),
+            c.is_literal        .into()}),),
         _ => unreachable!("Constant property {property_name}"),
     }
 }

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -462,16 +462,6 @@ pub(crate) fn resolve_associated_constant_property<'a>(
                 default.clone().into()
             }),
         ),
-        "type_" => resolve_property_with(
-            contexts,
-            field_property!(as_item, inner, {
-                let ItemEnum::AssocConst { type_, .. } = &inner else {
-                    unreachable!("expected to have a AssocConst")
-                };
-                // type_.clone().into() // Type→FieldValue not implemented, use ↓ json
-                serde_json::to_string(&type_.clone()).unwrap().into()
-            }),
-        ),
         _ => unreachable!("AssociatedConstant property {property_name}"),
     }
 }
@@ -487,6 +477,7 @@ pub(crate) fn resolve_associated_constant_property<'a>(
 // "deprecation"   	: null,
 // "inner"         	: { ← &inner will be set to ItemEnum::Constant(c), where c=struct rustdoc_types::Constant
 //   "constant"    	: { rustdoc_types::Constant has type_/expr/value/is_literal fields (docs.rs/rustdoc-types/latest/rustdoc_types/struct.Constant.html)
+//     "type"      	: currently not supported as a property pending custom scalar type support in Trustfall (https://github.com/obi1kenobi/trustfall-rustdoc-adapter/pull/280#discussion_r1348950734)
 //     "type"      	:{"primitive":"i32"}, or ↓ or any of docs.rs/rustdoc-types/latest/rustdoc_types/enum.Type.html
 //     "type"      	:{"borrowed_ref":{"lifetime": "'static","mutable": false,"type":{"primitive": "str"}}},
 //     "type"      	:{"resolved_path":{"name":"Years","id": "0:3:1633","args":{"angle_bracketed":{"args":[],"bindings":[]}}}},
@@ -499,16 +490,6 @@ pub(crate) fn resolve_constant_property<'a>(
     property_name: &str,
 ) -> ContextOutcomeIterator<'a, Vertex<'a>, FieldValue> {
     match property_name {
-        "type_" => resolve_property_with(
-            contexts,
-            field_property!(as_item, inner, {
-                let ItemEnum::Constant(c) = &inner else {
-                    unreachable!("expected to have a Constant")
-                };
-                // c.type_     .clone().into()}),), // Type→FieldValue not implemented, use ↓ json
-                serde_json::to_string(&c.type_.clone()).unwrap().into()
-            }),
-        ),
         "expr" => resolve_property_with(
             contexts,
             field_property!(as_item, inner, {

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -462,6 +462,16 @@ pub(crate) fn resolve_associated_constant_property<'a>(
                 default.clone().into()
             }),
         ),
+        "type_" => resolve_property_with(
+            contexts,
+            field_property!(as_item, inner, {
+                let ItemEnum::AssocConst { type_, .. } = &inner else {
+                    unreachable!("expected to have a AssocConst")
+                };
+                // type_.clone().into() // Type→FieldValue not implemented, use ↓ json
+                serde_json::to_string(&type_.clone()).unwrap().into()
+            }),
+        ),
         _ => unreachable!("AssociatedConstant property {property_name}"),
     }
 }

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -466,25 +466,6 @@ pub(crate) fn resolve_associated_constant_property<'a>(
     }
 }
 
-// const example from rustdocs
-// {"id"           	:"0:9:xx","crate_id":0,
-// "name"          	:"PUB_CONST_NAME",
-// "span"          	:{"filename":"","begin":[5,0],"end":[5,68]},
-// "visibility"    	:"public",
-// "docs"          	:null,
-// "links"         	:{},
-// "attrs"         	:[],
-// "deprecation"   	: null,
-// "inner"         	: { ← &inner will be set to ItemEnum::Constant(c), where c=struct rustdoc_types::Constant
-//   "constant"    	: { rustdoc_types::Constant has type_/expr/value/is_literal fields (docs.rs/rustdoc-types/latest/rustdoc_types/struct.Constant.html)
-//     "type"      	: currently not supported as a property pending custom scalar type support in Trustfall (https://github.com/obi1kenobi/trustfall-rustdoc-adapter/pull/280#discussion_r1348950734)
-//     "type"      	:{"primitive":"i32"}, or ↓ or any of docs.rs/rustdoc-types/latest/rustdoc_types/enum.Type.html
-//     "type"      	:{"borrowed_ref":{"lifetime": "'static","mutable": false,"type":{"primitive": "str"}}},
-//     "type"      	:{"resolved_path":{"name":"Years","id": "0:3:1633","args":{"angle_bracketed":{"args":[],"bindings":[]}}}},
-//     "expr"      	: "_",
-//     "value"     	: null,
-//     "is_literal"	: false}}
-// },
 pub(crate) fn resolve_constant_property<'a>(
     contexts: ContextIterator<'a, Vertex<'a>>,
     property_name: &str,

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -466,7 +466,6 @@ pub(crate) fn resolve_associated_constant_property<'a>(
     }
 }
 
-
 // const example from rustdocs
 // {"id"           	:"0:9:xx","crate_id":0,
 // "name"          	:"PUB_CONST_NAME",
@@ -490,19 +489,43 @@ pub(crate) fn resolve_constant_property<'a>(
     property_name: &str,
 ) -> ContextOutcomeIterator<'a, Vertex<'a>, FieldValue> {
     match property_name {
-        "type_"      => resolve_property_with(contexts, field_property!(as_item, inner, {
-            let ItemEnum::Constant(c) = &inner else {unreachable!("expected to have a Constant")};
-            // c.type_     .clone().into()}),), // Type→FieldValue not implemented, use ↓ json
-            serde_json::to_string(&c.type_.clone()).unwrap().into()}),),
-        "expr"       => resolve_property_with(contexts, field_property!(as_item, inner, {
-            let ItemEnum::Constant(c) = &inner else {unreachable!("expected to have a Constant")};
-            c.expr      .clone().into()}),),
-        "value"      => resolve_property_with(contexts, field_property!(as_item, inner, {
-            let ItemEnum::Constant(c) = &inner else {unreachable!("expected to have a Constant")};
-            c.value     .clone().into()}),),
-        "is_literal" => resolve_property_with(contexts, field_property!(as_item, inner, {
-            let ItemEnum::Constant(c) = &inner else {unreachable!("expected to have a Constant")};
-            c.is_literal        .into()}),),
+        "type_" => resolve_property_with(
+            contexts,
+            field_property!(as_item, inner, {
+                let ItemEnum::Constant(c) = &inner else {
+                    unreachable!("expected to have a Constant")
+                };
+                // c.type_     .clone().into()}),), // Type→FieldValue not implemented, use ↓ json
+                serde_json::to_string(&c.type_.clone()).unwrap().into()
+            }),
+        ),
+        "expr" => resolve_property_with(
+            contexts,
+            field_property!(as_item, inner, {
+                let ItemEnum::Constant(c) = &inner else {
+                    unreachable!("expected to have a Constant")
+                };
+                c.expr.clone().into()
+            }),
+        ),
+        "value" => resolve_property_with(
+            contexts,
+            field_property!(as_item, inner, {
+                let ItemEnum::Constant(c) = &inner else {
+                    unreachable!("expected to have a Constant")
+                };
+                c.value.clone().into()
+            }),
+        ),
+        "is_literal" => resolve_property_with(
+            contexts,
+            field_property!(as_item, inner, {
+                let ItemEnum::Constant(c) = &inner else {
+                    unreachable!("expected to have a Constant")
+                };
+                c.is_literal.into()
+            }),
+        ),
         _ => unreachable!("Constant property {property_name}"),
     }
 }

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -951,7 +951,7 @@ type AssociatedConstant implements Item {
 
   If the associated constant is on a type's inherent impl, `default` is always required to be set.
 
-  If the associated constant is set
+  If the associated constant is set:
 
     - to be equal to another constant, `default` holds the name of that other constant.
     - by evaluating a `const` expression, such as `2 + 2` or a `const fn` call, `default` is `"_"` instead of evaluating the constant value or including the full expression.

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -694,6 +694,7 @@ type Constant implements Item & Importable & GlobalValue {
   docs: String
   attrs: [String!]!
   visibility_limit: String!
+
   # properties for Constant
   """
   A type represented in the "raw" rustdoc JSON representation, see interface RawType.

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -708,28 +708,56 @@ type Constant implements Item & Importable & GlobalValue {
   """
   type_: String
   """
-  The expression/value of the constant, if any, as a Rust literal, expression, or `"_"`, as well as its literal flag. For example:
+  The expression of the constant, if any, as a Rust literal or `"_"`. For example:
   ```rust
-  //                                 // is_literal value       expr
-  const MIN     : usize = 16       ; // true       `"16usize"` `16`
-  const MIN_SIZE: usize = MIN      ; // false      `"16usize"` "MIN", referring to the other constant's name
-  const LOG_AS  : &str  = "batch"  ; // true       None        `"\"batch\""` including escaped quotes
-  const YEAR    : Years = Years(42); // false      None        "_"
-  const EXPR_2_2: i32   = 2 + 2    ; // false      `"4i32"     "_"
-  const FN_FIVE : i32   = five()   ; // false      `"5i32"     "_"
+  //                                 // expr
+  const MIN     : usize = 16       ; // 16
+  const MIN_SIZE: usize = MIN      ; // "MIN", referring to the other constant's name
+  const LOG_AS  : &str  = "batch"  ; // "\"batch\"", including escaped quotes
+  const YEAR    : Years = Years(42); // "_"
+  const EXPR_2_2: i32   = 2 + 2    ; // "_"
+  const FN_FIVE : i32   = five()   ; // "_"
   const fn five() -> i32 { 5 };
   struct Years(i32);
   ```
-  If the constant is set to be equal to another constant, `expr` holds the name of that other constant, while `value` holds the value of that other constant.
-  If the constant is set by evaluating a `const` expression, such as `2 + 2` or a `const fn` call, rustdoc's current behavior is to show an `expr` of `"_"` (`value` is evaluated)
+  If the constant is set:
+
+    - to be equal to another constant, `expr` holds the name of that other constant.
+    - by evaluating a `const` expression, such as `2 + 2` or a `const fn` call, `expr` is `"_"` instead of including the full expression.
   """
   expr: String
   """
-  See `expr` docs for a comprehensive example also covering `value`
+  The value of the constant, if any, as a Rust literal. For example:
+  ```rust
+  //                                 // value
+  const MIN     : usize = 16       ; // "16usize"
+  const MIN_SIZE: usize = MIN      ; // "16usize"
+  const LOG_AS  : &str  = "batch"  ; // None
+  const YEAR    : Years = Years(42); // None
+  const EXPR_2_2: i32   = 2 + 2    ; // "4i32"
+  const FN_FIVE : i32   = five()   ; // "5i32"
+  const fn five() -> i32 { 5 };
+  struct Years(i32);
+  ```
+  If the  If the constant is set:
+
+    - to be equal to another constant, `value` holds the value of that other constant.
+    - by evaluating a `const` expression, such as `2 + 2` or a `const fn` call, `value` is evaluated
   """
   value: String
   """
-  See `expr` docs for a comprehensive example also covering `is_literal`
+  The literal flag of the constant. For example:
+  ```rust
+  //                                 // is_literal
+  const MIN     : usize = 16       ; // true
+  const MIN_SIZE: usize = MIN      ; // false
+  const LOG_AS  : &str  = "batch"  ; // true
+  const YEAR    : Years = Years(42); // false
+  const EXPR_2_2: i32   = 2 + 2    ; // false
+  const FN_FIVE : i32   = five()   ; // false
+  const fn five() -> i32 { 5 };
+  struct Years(i32);
+  ```
   """
   is_literal: Boolean
 

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -697,7 +697,7 @@ type Constant implements Item & Importable & GlobalValue {
 
   # properties for Constant
   """
-  A type represented in the "raw" rustdoc JSON representation (see `interface RawType`)
+  A type represented in the "raw" rustdoc JSON representation (see `interface RawType`)<br>
   Currently serialized as a serde_json String instead of a proper RawType
   ```rust
   //                               // rustdocs type field
@@ -944,7 +944,7 @@ type AssociatedConstant implements Item {
 
   # properties for AssociatedConstant
   """
-  A type represented in the "raw" rustdoc JSON representation (see `interface RawType`)
+  A type represented in the "raw" rustdoc JSON representation (see `interface RawType`)<br>
   Currently serialized as a serde_json String instead of a proper RawType
   ```rust
   const fn five() -> i32 { 5 };
@@ -977,14 +977,12 @@ type AssociatedConstant implements Item {
   }
   ```
 
-  If the associated constant is on a type's inherent impl, the default is always required to be set.
+  If the associated constant is on a type's inherent impl, `default` is always required to be set.
 
-  If the associated constant is set to be equal to another constant, the default holds the name
-  of that other constant.
+  If the associated constant is set
 
-  If the associated constant is set by evaluating a `const` expression, such as `2 + 2` or
-  a `const fn` call, rustdoc's current behavior is to show a default value of `"_"`
-  instead of evaluating the constant value or including the full expression.
+    - to be equal to another constant, `default` holds the name of that other constant.
+    - by evaluating a `const` expression, such as `2 + 2` or a `const fn` call, `default` is `"_"` instead of evaluating the constant value or including the full expression.
   """
   default: String
 

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -916,14 +916,36 @@ type AssociatedConstant implements Item {
 
   # properties for AssociatedConstant
   """
+  A type represented in the "raw" rustdoc JSON representation (see `interface RawType`)
+  Currently serialized as a serde_json String instead of a proper RawType
+  ```rust
+  const fn five() -> i32 { 5 };
+  struct Years(i32);
+  trait BatchIterator<const MIN: usize> {	    // rustdocs type field
+    const MIN     : usize        = 16       ; // {"primitive":"usize"}
+    const MIN_SIZE: usize        = MIN      ; // {"primitive":"usize"}
+    const LOG_AS  : &'static str = "batch"  ; // {"borrowed_ref":{"lifetime":null,"mutable":false,"type":{"primitive":"str"}}}
+    const YEAR    : Years        = Years(42); // {"resolved_path":{"name":"Years","id":"0:3:1633","args":{"angle_bracketed":{"args":[],"bindings":[]}}}}
+    const EXPR2_2 : i32          = 2+2      ; // {"primitive":"i32"}
+    const FN_FIVE : i32          = five()   ; // {"primitive":"i32"}
+  }
+  ```
+  """
+  type_: String
+  """
   The default value of the constant, if any, as a Rust literal, expression, or `"_"`.
 
   For example:
   ```rust
-  trait BatchIterator<const MIN: usize> {
-    const SIZE: usize = 16;  // `"16"` is the default
-    const LOG_AS: &'static str = "batch";  // `"\"batch\""` is the default, including escaped quotes
-    const MIN_SIZE: usize = MIN;  // "MIN" is the default, referring to the other constant's name
+  const fn five() -> i32 { 5 };
+  struct Years(i32);
+  trait BatchIterator<const MIN: usize> {	    // rustdocs default field
+    const MIN     : usize        = 16       ; // `"16"`
+    const MIN_SIZE: usize        = MIN      ; // `"MIN"`, referring to the other constant's name
+    const LOG_AS  : &'static str = "batch"  ; // `"\"batch\""`, including escaped quotes
+    const EXPR2_2 : i32          = 2+2      ; // `"_"`
+    const FN_FIVE : i32          = five()   ; // `"_"`
+    const YEAR    : Years        = Years(42); // `"_"`
   }
   ```
 

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -949,7 +949,7 @@ type AssociatedConstant implements Item {
   ```rust
   const fn five() -> i32 { 5 };
   struct Years(i32);
-  trait BatchIterator<const MIN: usize> {	    // rustdocs type field
+  trait MyTrait<const MINT: usize> {          // rustdocs type field
     const MIN     : usize        = 16       ; // {"primitive":"usize"}
     const MIN_SIZE: usize        = MIN      ; // {"primitive":"usize"}
     const LOG_AS  : &'static str = "batch"  ; // {"borrowed_ref":{"lifetime":null,"mutable":false,"type":{"primitive":"str"}}}
@@ -967,7 +967,7 @@ type AssociatedConstant implements Item {
   ```rust
   const fn five() -> i32 { 5 };
   struct Years(i32);
-  trait BatchIterator<const MIN: usize> {	    // rustdocs default field
+  trait MyTrait<const MINT: usize> {          // rustdocs default field
     const MIN     : usize        = 16       ; // `"16"`
     const MIN_SIZE: usize        = MIN      ; // `"MIN"`, referring to the other constant's name
     const LOG_AS  : &'static str = "batch"  ; // `"\"batch\""`, including escaped quotes

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -739,7 +739,7 @@ type Constant implements Item & Importable & GlobalValue {
   const fn five() -> i32 { 5 };
   struct Years(i32);
   ```
-  If the  If the constant is set:
+  If the constant is set:
 
     - to be equal to another constant, `value` holds the value of that other constant.
     - by evaluating a `const` expression, such as `2 + 2` or a `const fn` call, `value` is evaluated

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -939,13 +939,13 @@ type AssociatedConstant implements Item {
   ```rust
   const fn five() -> i32 { 5 };
   struct Years(i32);
-  trait MyTrait<const MINT: usize> {          // rustdocs default field
-    const MIN     : usize        = 16       ; // `"16"`
-    const MIN_SIZE: usize        = MIN      ; // `"MIN"`, referring to the other constant's name
-    const LOG_AS  : &'static str = "batch"  ; // `"\"batch\""`, including escaped quotes
-    const EXPR2_2 : i32          = 2+2      ; // `"_"`
-    const FN_FIVE : i32          = five()   ; // `"_"`
-    const YEAR    : Years        = Years(42); // `"_"`
+  trait MyTrait<const MIN: usize> {           // rustdocs default field
+    const NUM     : i32          = 16       ; // 16
+    const MIN_SIZE: usize        = MIN      ; // "MIN", referring to the other constant's name
+    const LOG_AS  : &'static str = "batch"  ; // "\"batch\"", including escaped quotes
+    const EXPR2_2 : i32          = 2+2      ; // "_"
+    const FN_FIVE : i32          = five()   ; // "_"
+    const YEAR    : Years        = Years(42); // "_"
   }
   ```
 

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -697,31 +697,31 @@ type Constant implements Item & Importable & GlobalValue {
 
   # properties for Constant
   """
-  A type represented in the "raw" rustdoc JSON representation, see interface RawType.
+  A type represented in the "raw" rustdoc JSON representation (see `interface RawType`)
   Currently serialized as a serde_json String instead of a proper RawType
   ```rust
-  //          	                	            	// rustdocs type field
-  const MIN   	:          usize	= 16       ;	// {"primitive":"usize"}
-  const LOG_AS	: &'static str  	= "batch"  ;	// {"borrowed_ref":{"lifetime":"'static","mutable":false,"type":{"primitive":"str"}}}
-  const YEAR  	:          Years	= Years(42);	// {"resolved_path":{"name":"Years","id":"0:3:1633","args":{"angle_bracketed":{"args":[],"bindings":[]}}}}
+  //                               // rustdocs type field
+  const MIN   : usize = 16       ; // {"primitive":"usize"}
+  const LOG_AS: &str  = "batch"  ; // {"borrowed_ref":{"lifetime":null,"mutable":false,"type":{"primitive":"str"}}}
+  const YEAR  : Years = Years(42); // {"resolved_path":{"name":"Years","id":"0:3:1633","args":{"angle_bracketed":{"args":[],"bindings":[]}}}}
   ```
   """
   type_: String
   """
   The expression/value of the constant, if any, as a Rust literal, expression, or `"_"`, as well as its literal flag. For example:
   ```rust
-  //            	                	            	// is_literal	value      	expr
-  const MIN     	:          usize	= 16       ;	// true      	`"16usize"`	`16`
-  const MIN_SIZE	:          usize	= MIN      ;	// false     	`"16usize"`	"MIN", referring to the other constant's name
-  const LOG_AS  	: &'static str  	= "batch"  ;	// true      	None       	`"\"batch\""` including escaped quotes
-  const YEAR    	:          Years	= Years(42);	// false     	None       	"_"
-  const EXPR_2_2	:          i32  	= 2 + 2    ;	// false     	`"4i32"    	"_"
-  const FN_FIVE 	:          i32  	= five()   ;	// false     	`"5i32"    	"_"
-  const fn five() -> i32 { 5 } ;
+  //                                 // is_literal value       expr
+  const MIN     : usize = 16       ; // true       `"16usize"` `16`
+  const MIN_SIZE: usize = MIN      ; // false      `"16usize"` "MIN", referring to the other constant's name
+  const LOG_AS  : &str  = "batch"  ; // true       None        `"\"batch\""` including escaped quotes
+  const YEAR    : Years = Years(42); // false      None        "_"
+  const EXPR_2_2: i32   = 2 + 2    ; // false      `"4i32"     "_"
+  const FN_FIVE : i32   = five()   ; // false      `"5i32"     "_"
+  const fn five() -> i32 { 5 };
   struct Years(i32);
   ```
-  If the constant is set to be equal to another constant, the expr holds the name of that other constant, while the value holds the value of that other constant.
-  If the constant is set by evaluating a `const` expression, such as `2 + 2` or a `const fn` call, rustdoc's current behavior is to show an expr of `"_"` (the value is evaluated)
+  If the constant is set to be equal to another constant, `expr` holds the name of that other constant, while `value` holds the value of that other constant.
+  If the constant is set by evaluating a `const` expression, such as `2 + 2` or a `const fn` call, rustdoc's current behavior is to show an `expr` of `"_"` (`value` is evaluated)
   """
   expr: String
   value: String

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -954,7 +954,8 @@ type AssociatedConstant implements Item {
   If the associated constant is set:
 
     - to be equal to another constant, `default` holds the name of that other constant.
-    - by evaluating a `const` expression, such as `2 + 2` or a `const fn` call, `default` is `"_"` instead of evaluating the constant value or including the full expression.
+    - by evaluating a `const` expression, such as `2 + 2` or a `const fn` call, 
+      `default` is `"_"` instead of evaluating the constant value or including the full expression.
   """
   default: String
 

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -697,17 +697,6 @@ type Constant implements Item & Importable & GlobalValue {
 
   # properties for Constant
   """
-  A type represented in the "raw" rustdoc JSON representation (see `interface RawType`)<br>
-  Currently serialized as a serde_json String instead of a proper RawType
-  ```rust
-  //                               // rustdocs type field
-  const MIN   : usize = 16       ; // {"primitive":"usize"}
-  const LOG_AS: &str  = "batch"  ; // {"borrowed_ref":{"lifetime":null,"mutable":false,"type":{"primitive":"str"}}}
-  const YEAR  : Years = Years(42); // {"resolved_path":{"name":"Years","id":"0:3:1633","args":{"angle_bracketed":{"args":[],"bindings":[]}}}}
-  ```
-  """
-  type_: String
-  """
   The expression of the constant, if any, as a Rust literal or `"_"`. For example:
   ```rust
   //                                 // expr
@@ -943,23 +932,6 @@ type AssociatedConstant implements Item {
   visibility_limit: String!
 
   # properties for AssociatedConstant
-  """
-  A type represented in the "raw" rustdoc JSON representation (see `interface RawType`)<br>
-  Currently serialized as a serde_json String instead of a proper RawType
-  ```rust
-  const fn five() -> i32 { 5 };
-  struct Years(i32);
-  trait MyTrait<const MINT: usize> {          // rustdocs type field
-    const MIN     : usize        = 16       ; // {"primitive":"usize"}
-    const MIN_SIZE: usize        = MIN      ; // {"primitive":"usize"}
-    const LOG_AS  : &'static str = "batch"  ; // {"borrowed_ref":{"lifetime":null,"mutable":false,"type":{"primitive":"str"}}}
-    const YEAR    : Years        = Years(42); // {"resolved_path":{"name":"Years","id":"0:3:1633","args":{"angle_bracketed":{"args":[],"bindings":[]}}}}
-    const EXPR2_2 : i32          = 2+2      ; // {"primitive":"i32"}
-    const FN_FIVE : i32          = five()   ; // {"primitive":"i32"}
-  }
-  ```
-  """
-  type_: String
   """
   The default value of the constant, if any, as a Rust literal, expression, or `"_"`.
 

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -724,7 +724,13 @@ type Constant implements Item & Importable & GlobalValue {
   If the constant is set by evaluating a `const` expression, such as `2 + 2` or a `const fn` call, rustdoc's current behavior is to show an `expr` of `"_"` (`value` is evaluated)
   """
   expr: String
+  """
+  See `expr` docs for a comprehensive example also covering `value`
+  """
   value: String
+  """
+  See `expr` docs for a comprehensive example also covering `is_literal`
+  """
   is_literal: Boolean
 
   # edges from Item

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -694,6 +694,37 @@ type Constant implements Item & Importable & GlobalValue {
   docs: String
   attrs: [String!]!
   visibility_limit: String!
+  # properties for Constant
+  """
+  A type represented in the "raw" rustdoc JSON representation, see interface RawType.
+  Currently serialized as a serde_json String instead of a proper RawType
+  ```rust
+  //          	                	            	// rustdocs type field
+  const MIN   	:          usize	= 16       ;	// {"primitive":"usize"}
+  const LOG_AS	: &'static str  	= "batch"  ;	// {"borrowed_ref":{"lifetime":"'static","mutable":false,"type":{"primitive":"str"}}}
+  const YEAR  	:          Years	= Years(42);	// {"resolved_path":{"name":"Years","id":"0:3:1633","args":{"angle_bracketed":{"args":[],"bindings":[]}}}}
+  ```
+  """
+  type_: String
+  """
+  The expression/value of the constant, if any, as a Rust literal, expression, or `"_"`, as well as its literal flag. For example:
+  ```rust
+  //            	                	            	// is_literal	value      	expr
+  const MIN     	:          usize	= 16       ;	// true      	`"16usize"`	`16`
+  const MIN_SIZE	:          usize	= MIN      ;	// false     	`"16usize"`	"MIN", referring to the other constant's name
+  const LOG_AS  	: &'static str  	= "batch"  ;	// true      	None       	`"\"batch\""` including escaped quotes
+  const YEAR    	:          Years	= Years(42);	// false     	None       	"_"
+  const EXPR_2_2	:          i32  	= 2 + 2    ;	// false     	`"4i32"    	"_"
+  const FN_FIVE 	:          i32  	= five()   ;	// false     	`"5i32"    	"_"
+  const fn five() -> i32 { 5 } ;
+  struct Years(i32);
+  ```
+  If the constant is set to be equal to another constant, the expr holds the name of that other constant, while the value holds the value of that other constant.
+  If the constant is set by evaluating a `const` expression, such as `2 + 2` or a `const fn` call, rustdoc's current behavior is to show an expr of `"_"` (the value is evaluated)
+  """
+  expr: String
+  value: String
+  is_literal: Boolean
 
   # edges from Item
   span: Span


### PR DESCRIPTION
This is some draft of the edits I've made (currently only to v26 as that's the version of the locally generated docs) to be able to extract a list of constants from a crate as mentioned in https://github.com/obi1kenobi/trustfall-rustdoc-adapter/issues/279

Unresolved question: 
  - currently I'm using serde json to de/ser the [`Type` ](https://docs.rs/rustdoc-types/latest/rustdoc_types/enum.Type.html) since there is no conversion to [trustfall](https://docs.rs/trustfall/latest/trustfall/index.html)::[FieldValue](https://docs.rs/trustfall/latest/trustfall/enum.FieldValue.html#) implemented for this type, but that seems clunky, so what's the easiest way to have a proper support of this conversion (is it only possible in the trustfall main crate?)
    - it's clunky since on the receiving side I can only `try_into_struct`
```rs
  struct Output {
    // type_  	: rustdoc_types::Type, // Type→FieldValue not implemented, use ↓ json→string
    type_     	: String,
  }
let results:Vec<_> = trustfall::execute_query(&schema, adapter.clone(), query, variables.clone()).expect("failed to run query")
    .map(|row| row.try_into_struct::<Output>().expect("shape mismatch")).collect();
```
 into a string field, can't make it deserialise from json automatically).

(haven't done any formatting/tests yet)
