### PR TITLE
Repro bug in 1.72

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
   rust-tests:
     name: Run tests
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       matrix:
         toolchain: ["1.71", "1.72", "1.73"]

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -97,7 +97,14 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                 | "AssociatedConstant" | "Module"
                     if matches!(
                         property_name.as_ref(),
-                        "id" | "crate_id" | "name" | "docs" | "attrs" | "visibility_limit"
+                        "id" | "crate_id"
+                            | "name"
+                            | "docs"
+                            | "attrs"
+                            | "doc_hidden"
+                            | "deprecated"
+                            | "public_api_eligible"
+                            | "visibility_limit"
                     ) =>
                 {
                     // properties inherited from Item, accesssed on Item subtypes

--- a/src/adapter/optimizations/item_lookup.rs
+++ b/src/adapter/optimizations/item_lookup.rs
@@ -89,7 +89,7 @@ fn resolve_items_by_importable_path_field_value<'a>(
         .expect("crate's imports_index was never constructed")
         .get(path_components.as_slice())
     {
-        resolve_item_vertices(origin, items.iter().copied())
+        resolve_item_vertices(origin, items.iter().map(|(item, _)| item).copied())
     } else {
         // No such items found.
         Box::new(std::iter::empty())

--- a/src/adapter/origin.rs
+++ b/src/adapter/origin.rs
@@ -2,7 +2,10 @@ use std::rc::Rc;
 
 use rustdoc_types::{Abi, Item, Span};
 
-use crate::attributes::{Attribute, AttributeMetaItem};
+use crate::{
+    attributes::{Attribute, AttributeMetaItem},
+    indexed_crate::ImportablePath,
+};
 
 use super::vertex::{Vertex, VertexKind};
 
@@ -37,11 +40,11 @@ impl Origin {
 
     pub(super) fn make_importable_path_vertex<'a>(
         &self,
-        importable_path: Vec<&'a str>,
+        importable_path: ImportablePath<'a>,
     ) -> Vertex<'a> {
         Vertex {
             origin: *self,
-            kind: VertexKind::ImportablePath(importable_path),
+            kind: VertexKind::ImportablePath(Rc::from(importable_path)),
         }
     }
 

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -825,3 +825,570 @@ fn function_export_name() {
         results
     );
 }
+
+#[test]
+fn importable_paths() {
+    let path = "./localdata/test_data/importable_paths/rustdoc.json";
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
+        .expect("failed to load rustdoc");
+
+    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
+    let indexed_crate = IndexedCrate::new(&crate_);
+    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Struct {
+                name @output
+                importable_path {
+                    path @output
+                    doc_hidden @output
+                    deprecated @output
+                    public_api @output
+                }
+            }
+        }
+    }
+}
+"#;
+
+    let variables: BTreeMap<&str, &str> = BTreeMap::default();
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        path: Vec<String>,
+        doc_hidden: bool,
+        deprecated: bool,
+        public_api: bool,
+    }
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    // We write the results in the order the items appear in the test file,
+    // and sort them afterward in order to compare with the (sorted) query results.
+    // This makes it easier to verify that the expected data here is correct
+    // by reading it side-by-side with the file.
+    let mut expected_results = vec![
+        Output {
+            name: "PublicImportable".into(),
+            path: vec!["importable_paths".into(), "PublicImportable".into()],
+            doc_hidden: false,
+            deprecated: false,
+            public_api: true,
+        },
+        Output {
+            name: "ModuleHidden".into(),
+            path: vec![
+                "importable_paths".into(),
+                "hidden".into(),
+                "ModuleHidden".into(),
+            ],
+            doc_hidden: true,
+            deprecated: false,
+            public_api: false,
+        },
+        Output {
+            name: "DeprecatedModuleHidden".into(),
+            path: vec![
+                "importable_paths".into(),
+                "hidden".into(),
+                "DeprecatedModuleHidden".into(),
+            ],
+            doc_hidden: true,
+            deprecated: true,
+            public_api: true,
+        },
+        Output {
+            name: "ModuleDeprecatedModuleHidden".into(),
+            path: vec![
+                "importable_paths".into(),
+                "hidden".into(),
+                "deprecated".into(),
+                "ModuleDeprecatedModuleHidden".into(),
+            ],
+            doc_hidden: true,
+            deprecated: true,
+            public_api: true,
+        },
+        Output {
+            name: "Hidden".into(),
+            path: vec![
+                "importable_paths".into(),
+                "submodule".into(),
+                "Hidden".into(),
+            ],
+            doc_hidden: true,
+            deprecated: false,
+            public_api: false,
+        },
+        Output {
+            name: "DeprecatedHidden".into(),
+            path: vec![
+                "importable_paths".into(),
+                "submodule".into(),
+                "DeprecatedHidden".into(),
+            ],
+            doc_hidden: true,
+            deprecated: true,
+            public_api: true,
+        },
+        Output {
+            name: "ModuleDeprecated".into(),
+            path: vec![
+                "importable_paths".into(),
+                "deprecated".into(),
+                "ModuleDeprecated".into(),
+            ],
+            doc_hidden: false,
+            deprecated: true,
+            public_api: true,
+        },
+        Output {
+            name: "ModuleDeprecatedHidden".into(),
+            path: vec![
+                "importable_paths".into(),
+                "deprecated".into(),
+                "ModuleDeprecatedHidden".into(),
+            ],
+            doc_hidden: true,
+            deprecated: true,
+            public_api: true,
+        },
+        Output {
+            name: "ModuleHidden".into(),
+            path: vec!["importable_paths".into(), "UsedVisible".into()],
+            doc_hidden: false,
+            deprecated: false,
+            public_api: true,
+        },
+        Output {
+            name: "Hidden".into(),
+            path: vec!["importable_paths".into(), "UsedHidden".into()],
+            doc_hidden: true,
+            deprecated: false,
+            public_api: false,
+        },
+        Output {
+            name: "ModuleDeprecated".into(),
+            path: vec!["importable_paths".into(), "UsedModuleDeprecated".into()],
+            doc_hidden: false,
+            deprecated: true,
+            public_api: true,
+        },
+        Output {
+            name: "ModuleDeprecatedHidden".into(),
+            path: vec![
+                "importable_paths".into(),
+                "UsedModuleDeprecatedHidden".into(),
+            ],
+            doc_hidden: true,
+            deprecated: true,
+            public_api: true,
+        },
+        Output {
+            name: "PublicImportable".into(),
+            path: vec![
+                "importable_paths".into(),
+                "reexports".into(),
+                "DeprecatedReexport".into(),
+            ],
+            doc_hidden: false,
+            deprecated: true,
+            public_api: true,
+        },
+        Output {
+            name: "PublicImportable".into(),
+            path: vec![
+                "importable_paths".into(),
+                "reexports".into(),
+                "HiddenReexport".into(),
+            ],
+            doc_hidden: true,
+            deprecated: false,
+            public_api: false,
+        },
+        Output {
+            name: "ModuleDeprecated".into(),
+            path: vec![
+                "importable_paths".into(),
+                "reexports".into(),
+                "HiddenDeprecatedReexport".into(),
+            ],
+            doc_hidden: true,
+            deprecated: true,
+            public_api: true,
+        },
+        Output {
+            name: "Aliased".into(),
+            path: vec!["importable_paths".into(), "Aliased".into()],
+            doc_hidden: true,
+            deprecated: false,
+            public_api: false,
+        },
+    ];
+    expected_results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
+#[test]
+fn item_own_public_api_properties() {
+    let path = "./localdata/test_data/importable_paths/rustdoc.json";
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
+        .expect("failed to load rustdoc");
+
+    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
+    let indexed_crate = IndexedCrate::new(&crate_);
+    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Struct {
+                name @output
+                doc_hidden @output
+                deprecated @output
+                public_api_eligible @output
+            }
+        }
+    }
+}
+"#;
+
+    let variables: BTreeMap<&str, &str> = BTreeMap::default();
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        doc_hidden: bool,
+        deprecated: bool,
+        public_api_eligible: bool,
+    }
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    // We are checking whether the *items themselves* are deprecated / hidden.
+    // We are *not* checking whether their paths are deprecated or hidden.
+    // Recall that Rust propagates deprecations into child item definitions,
+    // but does not propagate "hidden"-ness.
+    //
+    // We write the results in the order the items appear in the test file,
+    // and sort them afterward in order to compare with the (sorted) query results.
+    // This makes it easier to verify that the expected data here is correct
+    // by reading it side-by-side with the file.
+    let mut expected_results = vec![
+        Output {
+            name: "PublicImportable".into(),
+            doc_hidden: false,
+            deprecated: false,
+            public_api_eligible: true,
+        },
+        Output {
+            name: "PubInPriv".into(),
+            doc_hidden: false,
+            deprecated: false,
+            public_api_eligible: true,
+        },
+        Output {
+            name: "Private".into(),
+            doc_hidden: false,
+            deprecated: false,
+            public_api_eligible: false,
+        },
+        Output {
+            name: "ModuleHidden".into(),
+            doc_hidden: false,
+            deprecated: false,
+            public_api_eligible: true,
+        },
+        Output {
+            name: "DeprecatedModuleHidden".into(),
+            doc_hidden: false,
+            deprecated: true,
+            public_api_eligible: true,
+        },
+        Output {
+            name: "ModuleDeprecatedModuleHidden".into(),
+            doc_hidden: false,
+            deprecated: true,
+            public_api_eligible: true,
+        },
+        Output {
+            name: "Hidden".into(),
+            doc_hidden: true,
+            deprecated: false,
+            public_api_eligible: false,
+        },
+        Output {
+            name: "DeprecatedHidden".into(),
+            doc_hidden: true,
+            deprecated: true,
+            public_api_eligible: true,
+        },
+        Output {
+            name: "ModuleDeprecated".into(),
+            doc_hidden: false,
+            deprecated: true,
+            public_api_eligible: true,
+        },
+        Output {
+            name: "ModuleDeprecatedHidden".into(),
+            doc_hidden: true,
+            deprecated: true,
+            public_api_eligible: true,
+        },
+        Output {
+            name: "Aliased".into(),
+            doc_hidden: true,
+            deprecated: false,
+            public_api_eligible: false,
+        },
+    ];
+    expected_results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
+/// Enum variants have as-if-public visibility by default -- they are public if the enum is public.
+#[test]
+fn enum_variant_public_api_eligible() {
+    let path = "./localdata/test_data/importable_paths/rustdoc.json";
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
+        .expect("failed to load rustdoc");
+
+    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
+    let indexed_crate = IndexedCrate::new(&crate_);
+    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Variant {
+                name @output
+                doc_hidden @output
+                deprecated @output
+                public_api_eligible @output
+            }
+        }
+    }
+}
+"#;
+
+    let variables: BTreeMap<&str, &str> = BTreeMap::default();
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        doc_hidden: bool,
+        deprecated: bool,
+        public_api_eligible: bool,
+    }
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    // We are checking whether the *items themselves* are deprecated / hidden.
+    // We are *not* checking whether their paths are deprecated or hidden.
+    // This is why it doesn't matter that the enum itself is private.
+    //
+    // We write the results in the order the items appear in the test file,
+    // and sort them afterward in order to compare with the (sorted) query results.
+    // This makes it easier to verify that the expected data here is correct
+    // by reading it side-by-side with the file.
+    let mut expected_results = vec![
+        Output {
+            name: "NotHidden".into(),
+            doc_hidden: false,
+            deprecated: false,
+            public_api_eligible: true,
+        },
+        Output {
+            name: "Deprecated".into(),
+            doc_hidden: false,
+            deprecated: true,
+            public_api_eligible: true,
+        },
+        Output {
+            name: "DeprecatedHidden".into(),
+            doc_hidden: true,
+            deprecated: true,
+            public_api_eligible: true,
+        },
+        Output {
+            name: "Hidden".into(),
+            doc_hidden: true,
+            deprecated: false,
+            public_api_eligible: false,
+        },
+    ];
+    expected_results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
+/// Trait associated items have as-if-public visibility by default.
+#[test]
+fn trait_associated_items_public_api_eligible() {
+    let path = "./localdata/test_data/importable_paths/rustdoc.json";
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
+        .expect("failed to load rustdoc");
+
+    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
+    let indexed_crate = IndexedCrate::new(&crate_);
+    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Trait {
+                name @filter(op: "=", value: ["$trait"])
+
+                associated_type {
+                    name @output
+                    doc_hidden @output
+                    deprecated @output
+                    public_api_eligible @output
+                }
+            }
+        }
+    }
+}
+"#;
+
+    let variables: BTreeMap<&str, &str> = btreemap! {
+        "trait" => "SomeTrait"
+    };
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        doc_hidden: bool,
+        deprecated: bool,
+        public_api_eligible: bool,
+    }
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    similar_asserts::assert_eq!(
+        vec![Output {
+            name: "T".into(),
+            doc_hidden: true,
+            deprecated: true,
+            public_api_eligible: true
+        },],
+        results
+    );
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Trait {
+                name @filter(op: "=", value: ["$trait"])
+
+                associated_constant {
+                    name @output
+                    doc_hidden @output
+                    deprecated @output
+                    public_api_eligible @output
+                }
+            }
+        }
+    }
+}
+"#;
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    similar_asserts::assert_eq!(
+        vec![Output {
+            name: "N".into(),
+            doc_hidden: true,
+            deprecated: true,
+            public_api_eligible: true
+        },],
+        results
+    );
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Trait {
+                name @filter(op: "=", value: ["$trait"])
+
+                method {
+                    name @output
+                    doc_hidden @output
+                    deprecated @output
+                    public_api_eligible @output
+                }
+            }
+        }
+    }
+}
+"#;
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    similar_asserts::assert_eq!(
+        vec![Output {
+            name: "associated".into(),
+            doc_hidden: true,
+            deprecated: true,
+            public_api_eligible: true
+        },],
+        results
+    );
+}

--- a/src/adapter/vertex.rs
+++ b/src/adapter/vertex.rs
@@ -8,6 +8,7 @@ use trustfall::provider::Typename;
 
 use crate::{
     attributes::{Attribute, AttributeMetaItem},
+    indexed_crate::ImportablePath,
     IndexedCrate,
 };
 
@@ -28,7 +29,7 @@ pub enum VertexKind<'a> {
     Item(&'a Item),
     Span(&'a Span),
     Path(&'a [String]),
-    ImportablePath(Vec<&'a str>),
+    ImportablePath(Rc<ImportablePath<'a>>),
     RawType(&'a Type),
     Attribute(Attribute<'a>),
     AttributeMetaItem(Rc<AttributeMetaItem<'a>>),
@@ -169,7 +170,7 @@ impl<'a> Vertex<'a> {
         }
     }
 
-    pub(super) fn as_importable_path(&self) -> Option<&'_ Vec<&'a str>> {
+    pub(super) fn as_importable_path(&self) -> Option<&'_ ImportablePath<'a>> {
         match &self.kind {
             VertexKind::ImportablePath(path) => Some(path),
             _ => None,

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -20,7 +20,7 @@ pub struct IndexedCrate<'a> {
     pub(crate) visibility_tracker: VisibilityTracker<'a>,
 
     /// index: importable name (in any namespace) -> list of items under that name
-    pub(crate) imports_index: Option<HashMap<ImportablePath<'a>, Vec<&'a Item>>>,
+    pub(crate) imports_index: Option<HashMap<Path<'a>, Vec<(&'a Item, Modifiers)>>>,
 
     /// index: impl owner + impl'd item name -> list of (impl itself, the named item))
     pub(crate) impl_index: Option<HashMap<ImplEntry<'a>, Vec<(&'a Item, &'a Item)>>>,
@@ -51,7 +51,7 @@ impl<'a> IndexedCrate<'a> {
             impl_index: None,
         };
 
-        let mut imports_index: HashMap<ImportablePath, Vec<&Item>> =
+        let mut imports_index: HashMap<Path, Vec<(&Item, Modifiers)>> =
             HashMap::with_capacity(crate_.index.len());
         for item in crate_
             .index
@@ -59,10 +59,12 @@ impl<'a> IndexedCrate<'a> {
             .filter(|item| supported_item_kind(item))
         {
             for importable_path in value.publicly_importable_names(&item.id) {
+                let modifiers = importable_path.modifiers;
+
                 imports_index
-                    .entry(ImportablePath::new(importable_path))
+                    .entry(importable_path.path)
                     .or_default()
-                    .push(item);
+                    .push((item, modifiers));
             }
         }
         let index_size = imports_index.len();
@@ -142,37 +144,60 @@ impl<'a> IndexedCrate<'a> {
         value
     }
 
-    /// Return all the paths (as Vec<&'a str> of component names, joinable with "::")
-    /// with which the given item can be imported from this crate.
-    pub fn publicly_importable_names(&self, id: &'a Id) -> Vec<Vec<&'a str>> {
-        let mut result = vec![];
-
+    /// Return all the paths with which the given item can be imported from this crate.
+    pub fn publicly_importable_names(&self, id: &'a Id) -> Vec<ImportablePath<'a>> {
         if self.inner.index.contains_key(id) {
-            let mut already_visited_ids = Default::default();
-            self.visibility_tracker.collect_publicly_importable_names(
-                id,
-                &mut already_visited_ids,
-                &mut vec![],
-                &mut result,
-            );
+            self.visibility_tracker
+                .collect_publicly_importable_names(id)
+        } else {
+            Default::default()
         }
-
-        result
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct ImportablePath<'a> {
+#[non_exhaustive]
+pub struct Path<'a> {
     pub(crate) components: Vec<&'a str>,
 }
 
-impl<'a> ImportablePath<'a> {
+impl<'a> Path<'a> {
     fn new(components: Vec<&'a str>) -> Self {
         Self { components }
     }
 }
 
-impl<'a: 'b, 'b> Borrow<[&'b str]> for ImportablePath<'a> {
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub struct Modifiers {
+    pub(crate) doc_hidden: bool,
+    pub(crate) deprecated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub struct ImportablePath<'a> {
+    pub(crate) path: Path<'a>,
+    pub(crate) modifiers: Modifiers,
+}
+
+impl<'a> ImportablePath<'a> {
+    pub(crate) fn new(components: Vec<&'a str>, doc_hidden: bool, deprecated: bool) -> Self {
+        Self {
+            path: Path::new(components),
+            modifiers: Modifiers {
+                doc_hidden,
+                deprecated,
+            },
+        }
+    }
+
+    pub(crate) fn public_api(&self) -> bool {
+        self.modifiers.deprecated || !self.modifiers.doc_hidden
+    }
+}
+
+impl<'a: 'b, 'b> Borrow<[&'b str]> for Path<'a> {
     fn borrow(&self) -> &[&'b str] {
         &self.components
     }
@@ -360,7 +385,7 @@ mod tests {
     use itertools::Itertools;
     use rustdoc_types::{Crate, Id};
 
-    use crate::{test_util::load_pregenerated_rustdoc, IndexedCrate};
+    use crate::{test_util::load_pregenerated_rustdoc, ImportablePath, IndexedCrate};
 
     fn find_item_id<'a>(crate_: &'a Crate, name: &str) -> &'a Id {
         crate_
@@ -407,23 +432,27 @@ mod tests {
 
         // But only `top_level_function` is importable.
         assert_eq!(
-            vec![vec!["structs_are_not_modules", "top_level_function"]],
+            vec![ImportablePath::new(
+                vec!["structs_are_not_modules", "top_level_function"],
+                false,
+                false,
+            )],
             indexed_crate.publicly_importable_names(top_level_function)
         );
         assert_eq!(
-            Vec::<Vec<&str>>::new(),
+            Vec::<ImportablePath<'_>>::new(),
             indexed_crate.publicly_importable_names(method)
         );
         assert_eq!(
-            Vec::<Vec<&str>>::new(),
+            Vec::<ImportablePath<'_>>::new(),
             indexed_crate.publicly_importable_names(associated_fn)
         );
         assert_eq!(
-            Vec::<Vec<&str>>::new(),
+            Vec::<ImportablePath<'_>>::new(),
             indexed_crate.publicly_importable_names(field)
         );
         assert_eq!(
-            Vec::<Vec<&str>>::new(),
+            Vec::<ImportablePath<'_>>::new(),
             indexed_crate.publicly_importable_names(const_item)
         );
     }
@@ -465,23 +494,31 @@ mod tests {
 
         // But only `top_level_function` and `Foo::variant` is importable.
         assert_eq!(
-            vec![vec!["enums_are_not_modules", "top_level_function"]],
+            vec![ImportablePath::new(
+                vec!["enums_are_not_modules", "top_level_function"],
+                false,
+                false,
+            )],
             indexed_crate.publicly_importable_names(top_level_function)
         );
         assert_eq!(
-            vec![vec!["enums_are_not_modules", "Foo", "Variant"]],
+            vec![ImportablePath::new(
+                vec!["enums_are_not_modules", "Foo", "Variant"],
+                false,
+                false,
+            )],
             indexed_crate.publicly_importable_names(variant)
         );
         assert_eq!(
-            Vec::<Vec<&str>>::new(),
+            Vec::<ImportablePath<'_>>::new(),
             indexed_crate.publicly_importable_names(method)
         );
         assert_eq!(
-            Vec::<Vec<&str>>::new(),
+            Vec::<ImportablePath<'_>>::new(),
             indexed_crate.publicly_importable_names(associated_fn)
         );
         assert_eq!(
-            Vec::<Vec<&str>>::new(),
+            Vec::<ImportablePath<'_>>::new(),
             indexed_crate.publicly_importable_names(const_item)
         );
     }
@@ -527,27 +564,31 @@ mod tests {
 
         // But only `top_level_function` is importable.
         assert_eq!(
-            vec![vec!["unions_are_not_modules", "top_level_function"]],
+            vec![ImportablePath::new(
+                vec!["unions_are_not_modules", "top_level_function"],
+                false,
+                false,
+            )],
             indexed_crate.publicly_importable_names(top_level_function)
         );
         assert_eq!(
-            Vec::<Vec<&str>>::new(),
+            Vec::<ImportablePath<'_>>::new(),
             indexed_crate.publicly_importable_names(method)
         );
         assert_eq!(
-            Vec::<Vec<&str>>::new(),
+            Vec::<ImportablePath<'_>>::new(),
             indexed_crate.publicly_importable_names(associated_fn)
         );
         assert_eq!(
-            Vec::<Vec<&str>>::new(),
+            Vec::<ImportablePath<'_>>::new(),
             indexed_crate.publicly_importable_names(left_field)
         );
         assert_eq!(
-            Vec::<Vec<&str>>::new(),
+            Vec::<ImportablePath<'_>>::new(),
             indexed_crate.publicly_importable_names(right_field)
         );
         assert_eq!(
-            Vec::<Vec<&str>>::new(),
+            Vec::<ImportablePath<'_>>::new(),
             indexed_crate.publicly_importable_names(const_item)
         );
     }
@@ -559,7 +600,7 @@ mod tests {
         use maplit::{btreemap, btreeset};
         use rustdoc_types::{ItemEnum, Visibility};
 
-        use crate::{test_util::load_pregenerated_rustdoc, IndexedCrate};
+        use crate::{test_util::load_pregenerated_rustdoc, ImportablePath, IndexedCrate};
 
         fn assert_exported_items_match(
             test_crate: &str,
@@ -591,7 +632,7 @@ mod tests {
                 let actual_items: Vec<_> = indexed_crate
                     .publicly_importable_names(item_id)
                     .into_iter()
-                    .map(|components| components.into_iter().join("::"))
+                    .map(|importable| importable.path.components.into_iter().join("::"))
                     .collect();
                 let deduplicated_actual_items: BTreeSet<_> =
                     actual_items.iter().map(|x| x.as_str()).collect();
@@ -642,7 +683,7 @@ mod tests {
                     let actual_items: Vec<_> = indexed_crate
                         .publicly_importable_names(item_id)
                         .into_iter()
-                        .map(|components| components.into_iter().join("::"))
+                        .map(|importable| importable.path.components.into_iter().join("::"))
                         .collect();
                     let deduplicated_actual_items: BTreeSet<_> =
                         actual_items.iter().map(|x| x.as_str()).collect();
@@ -1301,7 +1342,7 @@ mod tests {
                 let actual_items: Vec<_> = indexed_crate
                     .publicly_importable_names(item_id)
                     .into_iter()
-                    .map(|components| components.into_iter().join("::"))
+                    .map(|importable| importable.path.components.into_iter().join("::"))
                     .collect();
                 let deduplicated_actual_items: BTreeSet<_> =
                     actual_items.iter().map(|x| x.as_str()).collect();
@@ -1371,7 +1412,7 @@ expected exactly one importable path for `Foo` items in this crate but got: {act
                 let actual_items: Vec<_> = indexed_crate
                     .publicly_importable_names(item_id)
                     .into_iter()
-                    .map(|components| components.into_iter().join("::"))
+                    .map(|importable| importable.path.components.into_iter().join("::"))
                     .collect();
                 let deduplicated_actual_items: BTreeSet<_> =
                     actual_items.iter().map(|x| x.as_str()).collect();
@@ -1435,7 +1476,7 @@ expected exactly one importable path for `Foo` items in this crate but got: {act
                 let actual_items: Vec<_> = indexed_crate
                     .publicly_importable_names(item_id)
                     .into_iter()
-                    .map(|components| components.into_iter().join("::"))
+                    .map(|importable| importable.path.components.into_iter().join("::"))
                     .collect();
                 let deduplicated_actual_items: BTreeSet<_> =
                     actual_items.iter().map(|x| x.as_str()).collect();
@@ -1519,20 +1560,20 @@ expected exactly one importable path for `Foo` items in this crate but got: {act
                 .expect("no struct item found");
 
             assert_eq!(
-                vec![vec![
-                    "overlapping_glob_of_enum_with_local_item",
-                    "Foo",
-                    "First"
-                ],],
+                vec![ImportablePath::new(
+                    vec!["overlapping_glob_of_enum_with_local_item", "Foo", "First"],
+                    false,
+                    false,
+                )],
                 indexed_crate.publicly_importable_names(&variant_item.id),
             );
             assert_eq!(
                 // The struct definition overrides the glob-imported variant here.
-                vec![vec![
-                    "overlapping_glob_of_enum_with_local_item",
-                    "inner",
-                    "First"
-                ]],
+                vec![ImportablePath::new(
+                    vec!["overlapping_glob_of_enum_with_local_item", "inner", "First"],
+                    false,
+                    false,
+                )],
                 indexed_crate.publicly_importable_names(&struct_item.id),
             );
         }
@@ -1560,7 +1601,7 @@ expected exactly one importable path for `Foo` items in this crate but got: {act
                 let actual_items: Vec<_> = indexed_crate
                     .publicly_importable_names(item_id)
                     .into_iter()
-                    .map(|components| components.into_iter().join("::"))
+                    .map(|importable| importable.path.components.into_iter().join("::"))
                     .collect();
                 let deduplicated_actual_items: BTreeSet<_> =
                     actual_items.iter().map(|x| x.as_str()).collect();
@@ -1613,7 +1654,7 @@ expected exactly one importable path for `Foo` items in this crate but got: {act
                 let actual_items: Vec<_> = indexed_crate
                     .publicly_importable_names(item_id)
                     .into_iter()
-                    .map(|components| components.into_iter().join("::"))
+                    .map(|importable| importable.path.components.into_iter().join("::"))
                     .collect();
 
                 assert!(
@@ -1656,7 +1697,7 @@ expected exactly one importable path for `Foo` items in this crate but got: {act
                 let actual_items: Vec<_> = indexed_crate
                     .publicly_importable_names(item_id)
                     .into_iter()
-                    .map(|components| components.into_iter().join("::"))
+                    .map(|importable| importable.path.components.into_iter().join("::"))
                     .collect();
 
                 assert!(
@@ -1689,7 +1730,7 @@ expected exactly one importable path for `Foo` items in this crate but got: {act
                 let actual_items: Vec<_> = indexed_crate
                     .publicly_importable_names(item_id)
                     .into_iter()
-                    .map(|components| components.into_iter().join("::"))
+                    .map(|importable| importable.path.components.into_iter().join("::"))
                     .collect();
 
                 if rustdoc.index[item_id].visibility == Visibility::Public {
@@ -1841,7 +1882,7 @@ expected exactly one importable path for `Foo` items in this crate but got: {act
                 let importable_paths: Vec<_> = indexed_crate
                     .publicly_importable_names(item_id)
                     .into_iter()
-                    .map(|components| components.into_iter().join("::"))
+                    .map(|importable| importable.path.components.into_iter().join("::"))
                     .collect();
 
                 match &rustdoc.index[item_id].inner {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,4 +10,7 @@ mod visibility_tracker;
 // Re-export the Crate type so we can deserialize it.
 pub use rustdoc_types::Crate;
 
-pub use {adapter::RustdocAdapter, indexed_crate::IndexedCrate};
+pub use {
+    adapter::RustdocAdapter,
+    indexed_crate::{ImportablePath, IndexedCrate},
+};

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -53,6 +53,37 @@ interface Item {
   """
   attrs: [String!]!
 
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   # stringified version of the visibility struct field
   visibility_limit: String!
 
@@ -71,6 +102,38 @@ type Module implements Item & Importable {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # own properties
@@ -101,6 +164,38 @@ type Struct implements Item & Importable & ImplOwner {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # own properties
@@ -155,6 +250,38 @@ type StructField implements Item {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # edges from Item
@@ -177,6 +304,38 @@ type Enum implements Item & Importable & ImplOwner {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # own properties
@@ -230,6 +389,38 @@ interface Variant implements Item {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # edges from Item
@@ -252,6 +443,38 @@ type PlainVariant implements Item & Variant {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # edges from Item
@@ -274,6 +497,38 @@ type TupleVariant implements Item & Variant {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # edges from Item
@@ -296,6 +551,38 @@ type StructVariant implements Item & Variant {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # edges from Item
@@ -335,6 +622,38 @@ interface ImplOwner implements Item & Importable {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # edges from Item
@@ -382,6 +701,37 @@ type Impl implements Item {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
 
   # stringified version of the visibility struct field
   visibility_limit: String!
@@ -434,6 +784,38 @@ type Trait implements Item & Importable {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # own properties
@@ -481,6 +863,24 @@ type ImportablePath {
   For example: "public"
   """
   visibility_limit: String!
+
+  """
+  This path is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This path is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  This path should be treated as public API. This is true if either:
+  - The path is visible in documentation.
+  - The path is not visible and is deprecated,
+    since deprecated paths are assumed to have been part of the public API in the past.
+  """
+  public_api: Boolean!
 
   """
   The path from which the item can be imported.
@@ -586,6 +986,38 @@ type Function implements Item & FunctionLike & Importable {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # properties from FunctionLike
@@ -642,6 +1074,38 @@ type Method implements Item & FunctionLike {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # properties from FunctionLike
@@ -670,6 +1134,38 @@ interface GlobalValue implements Item & Importable {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # edges from Item
@@ -693,6 +1189,38 @@ type Constant implements Item & Importable & GlobalValue {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # properties for Constant
@@ -773,6 +1301,38 @@ type Static implements Item & Importable & GlobalValue {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # own properties
@@ -887,6 +1447,38 @@ type AssociatedType implements Item {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # properties for AssociatedType
@@ -931,6 +1523,38 @@ type AssociatedConstant implements Item {
   name: String
   docs: String
   attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible and but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
   visibility_limit: String!
 
   # properties for AssociatedConstant

--- a/test_crates/importable_paths/Cargo.toml
+++ b/test_crates/importable_paths/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "importable_paths"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/test_crates/importable_paths/src/lib.rs
+++ b/test_crates/importable_paths/src/lib.rs
@@ -1,0 +1,96 @@
+pub struct PublicImportable {}
+
+mod private {
+    pub struct PubInPriv {}
+
+    struct Private {}
+
+    enum PrivateEnum {
+        NotHidden,
+
+        #[deprecated]
+        Deprecated,
+
+        #[deprecated]
+        #[doc(hidden)]
+        DeprecatedHidden,
+
+        #[doc(hidden)]
+        Hidden,
+    }
+
+    trait SomeTrait {
+        #[doc(hidden)]
+        #[deprecated]
+        type T;
+
+        #[doc(hidden)]
+        #[deprecated]
+        const N: i64;
+
+        #[doc(hidden)]
+        #[deprecated]
+        fn associated();
+    }
+}
+
+#[doc(hidden)]
+pub mod hidden {
+    pub struct ModuleHidden {}
+
+    #[deprecated]
+    pub struct DeprecatedModuleHidden {} // public_api
+
+    #[deprecated]
+    pub mod deprecated {
+        pub struct ModuleDeprecatedModuleHidden {} // public_api
+    }
+}
+
+pub mod submodule {
+    #[doc(hidden)]
+    pub struct Hidden {}
+
+    #[deprecated]
+    #[doc(hidden)]
+    pub struct DeprecatedHidden {} // public_api
+}
+
+#[deprecated]
+pub mod deprecated {
+    pub struct ModuleDeprecated {} // public_api
+
+    #[doc(hidden)]
+    pub struct ModuleDeprecatedHidden {} // public_api
+}
+
+// This is expected to be visible in rustdoc.
+pub use hidden::ModuleHidden as UsedVisible; // public_api
+
+// This is expected to be hidden in rustdoc.
+pub use submodule::Hidden as UsedHidden;
+
+// This is expected to be public_api and deprecated
+pub use deprecated::ModuleDeprecated as UsedModuleDeprecated;
+
+// Still public_api, the item is deprecated (via its module) so the item is visible.
+pub use deprecated::ModuleDeprecatedHidden as UsedModuleDeprecatedHidden;
+
+pub mod reexports {
+    // Re-exports can be deprecated too.
+    #[deprecated]
+    pub use super::PublicImportable as DeprecatedReexport;
+
+    // Re-exports can be doc-hidden as well.
+    #[doc(hidden)]
+    pub use super::PublicImportable as HiddenReexport;
+
+    // Doc-hidden re-exports of deprecated items are still public API.
+    #[doc(hidden)]
+    pub use super::deprecated::ModuleDeprecated as HiddenDeprecatedReexport;
+}
+
+// Our doc-hidden analysis works even when `#[doc(hidden)]` does not appear verbatim
+// in the attributes, and is instead combined with other `doc` commands.
+#[doc(hidden, alias = "TheAlias")]
+pub struct Aliased;


### PR DESCRIPTION
Demonstrate that Rust 1.72 fails to include re-exports of `#[doc(hidden)]` items in rustdoc JSON despite the use of the flag requesting that hidden items be included in the output. 