### PR TITLE
`implemented_trait` was implemented

### DIFF
--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -749,8 +749,6 @@ type Impl implements Item {
 
   """
   The trait being implemented. Inherent impls don't have a trait.
-
-  TODO: implement me
   """
   implemented_trait: ImplementedTrait
 


### PR DESCRIPTION
Noticed that a TODO wasn't removed from the docs while writing a query in the playground.