### PR TITLE
Add `rust-toolchain.toml` file to ensure generated rustdoc has correct version.

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+# Pinning our toolchain ensures ./scripts/regenerate_test_rustdocs.sh always
+# emits the desired format.
+
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
I was getting errors like the following:

```
---- adapter::tests::rustdoc_associated_consts stdout ---- 
thread 'adapter::tests::rustdoc_associated_consts' panicked at src/adapter/tests.rs:580:49:
failed to parse rustdoc: Error("missing field `is_object_safe`", line: 1, column: 99832)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- adapter::tests::importable_paths stdout ----
thread 'adapter::tests::importable_paths' panicked at src/adapter/tests.rs:836:49:
failed to parse rustdoc: Error("missing field `is_object_safe`", line: 1, column: 165267)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

because I was not using a nightly compiler.

I don't know if this change should actually be merged - do we always use the nightly rustdoc output?