### PR TITLE
pin toolchain for rustdoc-v27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,10 +83,10 @@ jobs:
         run: ./scripts/regenerate_test_rustdocs.sh +${{ matrix.toolchain }}
 
       - name: compile
-        run: cargo test --no-run
+        run: cargo +${{ matrix.toolchain }} test --no-run
 
       - name: test
-        run: cargo test
+        run: cargo +${{ matrix.toolchain }} test
 
   publish:
     name: Publish to crates.io

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+# Pinning our toolchain ensures ./scripts/regenerate_test_rustdocs.sh always
+# emits the desired format.
+
+[toolchain]
+channel = "1.75"


### PR DESCRIPTION
pin toolchain to latest rustdoc-v27 stable (1.75)