### PR TITLE
Update rustdoc v27 Rust CI target versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: ["beta", "nightly"]
+        toolchain: ["1.74", "1.75", "beta"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Nightly is now v28, v27 is from 1.74 through 1.76-beta.

Will unblock #312.