### PR TITLE
Drop testing on Rust 1.71 and 1.72 due to rustdoc bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: ["1.71", "1.72", "1.73"]
+        toolchain: ["1.73"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The bug reproduced in #300 affects Rust versions older than 1.73, and will never be fixed. Our tests will always be broken on Rust older than 1.73, so we shouldn't bother testing on it anymore.