### PR TITLE
object safe traits v27

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ localdata/
 
 # lockfiles of test crates
 test_crates/**/Cargo.lock
+
+# ide
+.idea

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -459,7 +459,7 @@ pub(super) fn resolve_trait_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
 ) -> ContextOutcomeIterator<'a, V, FieldValue> {
     match property_name {
         "unsafe" => resolve_property_with(contexts, field_property!(as_trait, is_unsafe)),
-        "object_safe" => resolve_property_with(contexts, field_property!(as_trait, is_object_safe)),
+        "object_safe" => resolve_property_with(contexts, |_| FieldValue::Null),
         _ => unreachable!("Trait property {property_name}"),
     }
 }

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -459,6 +459,7 @@ pub(super) fn resolve_trait_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
 ) -> ContextOutcomeIterator<'a, V, FieldValue> {
     match property_name {
         "unsafe" => resolve_property_with(contexts, field_property!(as_trait, is_unsafe)),
+        "object_safe" => resolve_property_with(contexts, field_property!(as_trait, is_object_safe)),
         _ => unreachable!("Trait property {property_name}"),
     }
 }

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -905,7 +905,13 @@ type Trait implements Item & Importable {
 
   # own properties
   unsafe: Boolean!
-  object_safe: Boolean!
+
+  """
+  This property is added for forward-compatibility with queries over rustdoc v28.
+  It was added to rustdoc JSON output in v28, and did not exist prior to that.
+  In versions prior to v28, it will always have a value of `null`.
+  """
+  object_safe: Boolean
 
   # edges from Item
   span: Span

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -905,6 +905,7 @@ type Trait implements Item & Importable {
 
   # own properties
   unsafe: Boolean!
+  object_safe: Boolean!
 
   # edges from Item
   span: Span


### PR DESCRIPTION
- feat: Object safe traits (#323)
- Return `null` for object-safety of traits prior to rustdoc v28.
