### PR TITLE
object safe traits v27 (#324)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ localdata/
 
 # lockfiles of test crates
 test_crates/**/Cargo.lock
+
+# ide
+.idea

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -459,6 +459,7 @@ pub(super) fn resolve_trait_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
 ) -> ContextOutcomeIterator<'a, V, FieldValue> {
     match property_name {
         "unsafe" => resolve_property_with(contexts, field_property!(as_trait, is_unsafe)),
+        "object_safe" => resolve_property_with(contexts, |_| FieldValue::Null),
         _ => unreachable!("Trait property {property_name}"),
     }
 }

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -906,6 +906,13 @@ type Trait implements Item & Importable {
   # own properties
   unsafe: Boolean!
 
+  """
+  This property is added for forward-compatibility with queries over rustdoc v28.
+  It was added to rustdoc JSON output in v28, and did not exist prior to that.
+  In versions prior to v28, it will always have a value of `null`.
+  """
+  object_safe: Boolean
+
   # edges from Item
   span: Span
   attribute: [Attribute!]


### PR DESCRIPTION
* feat: Object safe traits (#323)

* feat: Expose object_safe property on type Trait

* feat: Expose object_safe property on type Trait

* feat: Expose object_safe property on type Trait

* feat: Expose object_safe property on type Trait

* feat: Expose object_safe property on type Trait

* Add newline to the end of the .gitignore.

---------

Co-authored-by: Predrag Gruevski <2348618+obi1kenobi@users.noreply.github.com>

* Return `null` for object-safety of traits prior to rustdoc v28.

---------

Co-authored-by: WeblWabl <devandbenz@gmail.com>