### PR TITLE
reproducer: fails to query trait imported from a dependecy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,9 +222,9 @@ checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "rustdoc-types"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0904b9147011800e63763fb9e49bbeaf76c1b6ab8982824c659dce5433712559"
+checksum = "60966414633fced9e2341cd3d51a329d72306367325ba3d34e7e517c3bb84f3c"
 dependencies = [
  "serde",
 ]
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "28.0.2"
+version = "29.0.0"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -100,6 +100,69 @@ fn impl_for_ref() {
 }
 
 #[test]
+fn impl_name_for_impl_owners() {
+    let path = "./localdata/test_data/impl_for_ref/rustdoc.json";
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
+        .expect("failed to load rustdoc");
+
+    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
+    let indexed_crate = IndexedCrate::new(&crate_);
+    let adapter = RustdocAdapter::new(&indexed_crate, None);
+
+    let query = r#"
+        {
+            Crate {
+            item {
+                    ... on ImplOwner {
+                    name @output
+                    impl {
+                        implemented_trait {
+                            name @output(name: "impls")
+                        }
+                      }
+                    }
+                }
+            }
+        }
+        "#;
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        impls: Option<String>,
+    }
+
+    let vars: BTreeMap<&str, &str> = Default::default();
+    let mut results: Vec<_> = trustfall::execute_query(&schema, adapter.into(), query, vars)
+        .expect("failed to run query")
+        .map(|row| row.try_into_struct().expect("shape mismatch"))
+        .collect();
+
+    results.sort_unstable();
+
+    // OK
+    assert!(results.contains(&Output {
+        name: "StringHolder".to_string(),
+        impls: Some("PartialEq".to_string())
+    }));
+
+    // Ok
+    assert!(results.contains(&Output {
+        name: "StringHolder".to_string(),
+        impls: Some("Trait".to_string())
+    }));
+
+    // Fails !
+    assert!(results.contains(&Output {
+        name: "StringHolder".to_string(),
+        impls: Some("DummyExternalTrait".to_string())
+    }));
+}
+#[test]
 fn rustdoc_finds_supertrait() {
     let path = "./localdata/test_data/supertrait/rustdoc.json";
     let content = std::fs::read_to_string(path)

--- a/test_crates/dummy_ext/Cargo.toml
+++ b/test_crates/dummy_ext/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "dummy_ext"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/dummy_ext/src/lib.rs
+++ b/test_crates/dummy_ext/src/lib.rs
@@ -1,0 +1,3 @@
+pub trait DummyExternalTrait {
+    fn do_something(&self);
+}

--- a/test_crates/impl_for_ref/Cargo.toml
+++ b/test_crates/impl_for_ref/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+dummy_ext = { path = "../dummy_ext" }

--- a/test_crates/impl_for_ref/src/lib.rs
+++ b/test_crates/impl_for_ref/src/lib.rs
@@ -1,5 +1,13 @@
+use dummy_ext::DummyExternalTrait;
+pub trait Trait {}
+
 pub struct StringHolder {
     content: String,
+}
+
+impl Trait for StringHolder {}
+impl DummyExternalTrait for StringHolder {
+    fn do_something(&self) {}
 }
 
 impl<'a> PartialEq<StringHolder> for &'a str {


### PR DESCRIPTION
Hello, 

I am trying to use trustfall with rust doc to get all implementors of a given trait. 
Unfortunately, only trait from the crate and trait from std are queried. 

Instead of an issue I opened this as a pull request containing a reproducer, hoping that you might guide me through a fix.
This might just be me missing something really obvious in the query though. 

Let me know ! 