### PR TITLE
Add enum discriminants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+name: CI
+
 on:
   pull_request:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: ["1.77", "beta"]
+        toolchain: ["1.77", "1.78"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: ["1.77", "beta", "nightly"]
+        toolchain: ["1.77", "beta"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -299,7 +299,7 @@ pub(super) fn resolve_variant_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 
             if let Some(discriminant) = &item.discriminant {
                 Box::new(std::iter::once(
-                    origin.make_discriminant_vertex(discriminant.clone()),
+                    origin.make_discriminant_vertex(discriminant),
                 ))
             } else {
                 Box::new(std::iter::empty())

--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -1,5 +1,5 @@
 use rustdoc_types::{GenericBound::TraitBound, Id, ItemEnum, Variant, VariantKind};
-use std::sync::Arc;
+use std::rc::Rc;
 use trustfall::provider::{
     resolve_neighbors_with, AsVertex, ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo,
     VertexIterator,
@@ -340,7 +340,7 @@ pub(super) fn resolve_enum_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
                         }
                     })
                     .collect();
-                Arc::new(LazyDiscriminants::new(variants))
+                Rc::new(LazyDiscriminants::new(variants))
             };
 
             Box::new(

--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -298,9 +298,19 @@ pub(super) fn resolve_variant_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
         }),
         "discriminant" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
-            let enum_var = vertex.as_enum_variant().expect("vertex was not a Variant");
+            // HACK: to get around closure bounds
+            let enum_var = match &vertex.kind {
+                super::VertexKind::Variant(var) => var,
+                _ => unreachable!("vertex was not a Variant"),
+            };
+            let discriminant = enum_var
+                .discriminants
+                .get_discriminants()
+                .get(enum_var.index)
+                .unwrap()
+                .clone();
             Box::new(std::iter::once(
-                origin.make_discriminant_vertex(enum_var.discriminant().clone()),
+                origin.make_discriminant_vertex(discriminant),
             ))
         }),
         _ => unreachable!("resolve_variant_edge {edge_name}"),

--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -1,4 +1,5 @@
-use rustdoc_types::{GenericBound::TraitBound, Id, ItemEnum, VariantKind};
+use rustdoc_types::{GenericBound::TraitBound, Id, ItemEnum, Variant, VariantKind};
+use std::sync::Arc;
 use trustfall::provider::{
     resolve_neighbors_with, AsVertex, ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo,
     VertexIterator,
@@ -6,7 +7,9 @@ use trustfall::provider::{
 
 use crate::{adapter::supported_item_kind, attributes::Attribute, IndexedCrate};
 
-use super::{optimizations, origin::Origin, vertex::Vertex, RustdocAdapter};
+use super::{
+    enum_variant::LazyDiscriminants, optimizations, origin::Origin, vertex::Vertex, RustdocAdapter,
+};
 
 pub(super) fn resolve_crate_diff_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
@@ -295,15 +298,10 @@ pub(super) fn resolve_variant_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
         }),
         "discriminant" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
-            let item = vertex.as_variant().expect("vertex was not a Variant");
-
-            if let Some(discriminant) = &item.discriminant {
-                Box::new(std::iter::once(
-                    origin.make_discriminant_vertex(discriminant),
-                ))
-            } else {
-                Box::new(std::iter::empty())
-            }
+            let enum_var = vertex.as_enum_variant().expect("vertex was not a Variant");
+            Box::new(std::iter::once(
+                origin.make_discriminant_vertex(enum_var.discriminant().clone()),
+            ))
         }),
         _ => unreachable!("resolve_variant_edge {edge_name}"),
     }
@@ -329,9 +327,35 @@ pub(super) fn resolve_enum_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
                         .index
                 }
             };
-            Box::new(enum_item.variants.iter().map(move |field_id| {
-                origin.make_item_vertex(item_index.get(field_id).expect("missing item"))
-            }))
+
+            let discriminants = {
+                let variants: Vec<&Variant> = enum_item
+                    .variants
+                    .iter()
+                    .map(move |field_id| {
+                        let inner = &item_index.get(field_id).expect("missing item").inner;
+                        match inner {
+                            ItemEnum::Variant(v) => v,
+                            _ => unreachable!("Item {inner:?} not a Variant"),
+                        }
+                    })
+                    .collect();
+                Arc::new(LazyDiscriminants::new(variants))
+            };
+
+            Box::new(
+                enum_item
+                    .variants
+                    .iter()
+                    .enumerate()
+                    .map(move |(index, field_id)| {
+                        origin.make_variant_vertex(
+                            item_index.get(field_id).expect("missing item"),
+                            discriminants.clone(),
+                            index,
+                        )
+                    }),
+            )
         }),
         _ => unreachable!("resolve_enum_edge {edge_name}"),
     }

--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -293,6 +293,18 @@ pub(super) fn resolve_variant_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
                 })),
             }
         }),
+        "discriminant" => resolve_neighbors_with(contexts, move |vertex| {
+            let origin = vertex.origin;
+            let item = vertex.as_variant().expect("vertex was not a Variant");
+
+            if let Some(discriminant) = &item.discriminant {
+                Box::new(std::iter::once(
+                    origin.make_discriminant_vertex(discriminant.clone()),
+                ))
+            } else {
+                Box::new(std::iter::empty())
+            }
+        }),
         _ => unreachable!("resolve_variant_edge {edge_name}"),
     }
 }

--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -306,7 +306,7 @@ pub(super) fn resolve_variant_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
                 .expect("vertex was not a Variant");
             let discriminant = enum_var.discriminant();
             Box::new(std::iter::once(
-                origin.make_discriminant_vertex(std::borrow::Cow::Borrowed(discriminant)),
+                origin.make_discriminant_vertex(discriminant),
             ))
         }),
         _ => unreachable!("resolve_variant_edge {edge_name}"),

--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -301,9 +301,7 @@ pub(super) fn resolve_variant_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
         }),
         "discriminant" => resolve_neighbors_with(contexts, move |vertex: &'_ Vertex<'a>| {
             let origin = vertex.origin;
-            let enum_var = vertex
-                .as_variant()
-                .expect("vertex was not a Variant");
+            let enum_var = vertex.as_variant().expect("vertex was not a Variant");
             let discriminant = enum_var.discriminant();
             Box::new(std::iter::once(
                 origin.make_discriminant_vertex(discriminant),
@@ -335,7 +333,6 @@ pub(super) fn resolve_enum_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
             };
 
             let discriminants = {
-                let len = enum_item.variants.len();
                 let variants = enum_item
                     .variants
                     .iter()
@@ -347,7 +344,7 @@ pub(super) fn resolve_enum_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
                         }
                     })
                     .collect();
-                Rc::new(LazyDiscriminants::new(variants, len))
+                Rc::new(LazyDiscriminants::new(variants))
             };
 
             Box::new(

--- a/src/adapter/enum_variant.rs
+++ b/src/adapter/enum_variant.rs
@@ -66,7 +66,7 @@ impl<'a> EnumVariant<'a> {
         }
     }
 
-    pub(super) fn discriminant(&'a self) -> Cow<'a, str> {
+    pub(super) fn discriminant(&self) -> Cow<'a, str> {
         self.discriminants
             .get_discriminants()
             .get(self.index)

--- a/src/adapter/enum_variant.rs
+++ b/src/adapter/enum_variant.rs
@@ -66,11 +66,12 @@ impl<'a> EnumVariant<'a> {
         }
     }
 
-    pub(super) fn discriminant(&'a self) -> &'a Cow<'a, str> {
+    pub(super) fn discriminant(&'a self) -> Cow<'a, str> {
         self.discriminants
             .get_discriminants()
             .get(self.index)
             .expect("self.index should exist in self.discriminants")
+            .clone()
     }
 
     #[inline]

--- a/src/adapter/enum_variant.rs
+++ b/src/adapter/enum_variant.rs
@@ -1,0 +1,304 @@
+use rustdoc_types::{Item, ItemEnum, Variant};
+use std::fmt;
+use std::num::ParseIntError;
+use std::sync::Arc;
+use std::{str::FromStr, sync::OnceLock};
+
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub(super) struct EnumVariant<'a> {
+    item: &'a Item,
+    discriminants: Arc<LazyDiscriminants<'a>>,
+    index: usize,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub(super) struct LazyDiscriminants<'a> {
+    variants: Vec<&'a Variant>,
+    discriminants: OnceLock<Vec<String>>,
+}
+
+impl<'a> LazyDiscriminants<'a> {
+    pub(super) fn new(variants: Vec<&'a Variant>) -> Self {
+        Self {
+            variants,
+            discriminants: OnceLock::new(),
+        }
+    }
+
+    pub(super) fn get_discriminants(&self) -> &Vec<String> {
+        self.discriminants
+            .get_or_init(|| assign_discriminants(&self.variants))
+    }
+}
+
+impl<'a> EnumVariant<'a> {
+    pub(super) fn new(
+        item: &'a Item,
+        discriminants: Arc<LazyDiscriminants<'a>>,
+        index: usize,
+    ) -> Self {
+        Self {
+            item,
+            discriminants,
+            index,
+        }
+    }
+
+    pub(super) fn variant(&self) -> Option<&'a Variant> {
+        match &self.item.inner {
+            ItemEnum::Variant(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    pub(super) fn discriminant(&'a self) -> &'a String {
+        self.discriminants
+            .get_discriminants()
+            .get(self.index)
+            .unwrap()
+    }
+}
+
+enum DiscriminantValue {
+    I64(i64),
+    U64(u64),
+    I128(i128),
+    U128(u128),
+}
+
+impl DiscriminantValue {
+    pub fn max(&self) -> bool {
+        matches!(self, DiscriminantValue::U128(u128::MAX))
+    }
+
+    pub fn increment(&self) -> DiscriminantValue {
+        match self {
+            DiscriminantValue::I64(i) => {
+                match i.checked_add_unsigned(1) {
+                    // No overflow
+                    Some(i) => i.into(),
+                    // Overflow, number will fit in a u64
+                    None => DiscriminantValue::from(u64::try_from(*i).unwrap()).increment(),
+                }
+            }
+            DiscriminantValue::U64(i) => {
+                match i.checked_add(1) {
+                    // No overflow
+                    Some(i) => i.into(),
+                    // Overflow, number will fit in a i128
+                    None => DiscriminantValue::from(i128::from(*i)).increment(),
+                }
+            }
+            DiscriminantValue::I128(i) => {
+                match i.checked_add_unsigned(1) {
+                    // No overflow
+                    Some(i) => i.into(),
+                    // Overflow, number will fit in a u128
+                    None => DiscriminantValue::from(u128::try_from(*i).unwrap()).increment(),
+                }
+            }
+            DiscriminantValue::U128(i) => (i + 1).into(),
+        }
+    }
+}
+
+impl fmt::Display for DiscriminantValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DiscriminantValue::I64(i) => write!(f, "{}", i),
+            DiscriminantValue::U64(i) => write!(f, "{}", i),
+            DiscriminantValue::I128(i) => write!(f, "{}", i),
+            DiscriminantValue::U128(i) => write!(f, "{}", i),
+        }
+    }
+}
+
+impl From<i64> for DiscriminantValue {
+    fn from(value: i64) -> Self {
+        DiscriminantValue::I64(value)
+    }
+}
+
+impl From<i128> for DiscriminantValue {
+    fn from(value: i128) -> Self {
+        DiscriminantValue::I128(value)
+    }
+}
+
+impl From<u64> for DiscriminantValue {
+    fn from(value: u64) -> Self {
+        DiscriminantValue::U64(value)
+    }
+}
+
+impl From<u128> for DiscriminantValue {
+    fn from(value: u128) -> Self {
+        DiscriminantValue::U128(value)
+    }
+}
+
+impl FromStr for DiscriminantValue {
+    type Err = ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(i) = i64::from_str(s) {
+            return Ok(i.into());
+        }
+        if let Ok(i) = u64::from_str(s) {
+            return Ok(i.into());
+        }
+        if let Ok(i) = i128::from_str(s) {
+            return Ok(i.into());
+        }
+        match u128::from_str(s) {
+            Ok(i) => Ok(i.into()),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/// <https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values>
+pub(super) fn assign_discriminants(variants: &Vec<&Variant>) -> Vec<String> {
+    let mut last: DiscriminantValue = DiscriminantValue::I64(0);
+    let mut discriminants: Vec<String> = Vec::with_capacity(variants.len());
+    for v in variants {
+        discriminants.push(match &v.discriminant {
+            Some(d) => {
+                last = DiscriminantValue::from_str(&d.value).unwrap();
+                d.value.clone()
+            }
+            None => last.to_string(),
+        });
+        if !last.max() {
+            last = last.increment();
+        }
+    }
+    discriminants
+}
+
+#[cfg(test)]
+mod tests {
+    use rustdoc_types::{Discriminant, VariantKind};
+
+    use super::*;
+
+    #[test]
+    fn i64() {
+        let explicit_1 = Variant {
+            discriminant: Some(Discriminant {
+                value: "5".into(),
+                expr: "".into(),
+            }),
+            kind: VariantKind::Plain,
+        };
+        let explicit_2 = Variant {
+            discriminant: Some(Discriminant {
+                value: "7".into(),
+                expr: "".into(),
+            }),
+            kind: VariantKind::Plain,
+        };
+        let explicit_3 = Variant {
+            discriminant: Some(Discriminant {
+                value: "-59999".into(),
+                expr: "".into(),
+            }),
+            kind: VariantKind::Plain,
+        };
+        let variants = vec![
+            &Variant {
+                discriminant: None,
+                kind: VariantKind::Plain,
+            },
+            &Variant {
+                discriminant: None,
+                kind: VariantKind::Plain,
+            },
+            &explicit_1,
+            &explicit_2,
+            &Variant {
+                discriminant: None,
+                kind: VariantKind::Plain,
+            },
+            &explicit_3,
+            &Variant {
+                discriminant: None,
+                kind: VariantKind::Plain,
+            },
+        ];
+        let actual = assign_discriminants(&variants);
+        let expected: Vec<String> = vec![
+            "0".into(),
+            "1".into(),
+            "5".into(),
+            "7".into(),
+            "8".into(),
+            "-59999".into(),
+            "-59998".into(),
+        ];
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn max() {
+        let explicit_1 = Variant {
+            discriminant: Some(Discriminant {
+                value: i64::MAX.to_string(),
+                expr: "".into(),
+            }),
+            kind: VariantKind::Plain,
+        };
+        let explicit_2 = Variant {
+            discriminant: Some(Discriminant {
+                value: u64::MAX.to_string(),
+                expr: "".into(),
+            }),
+            kind: VariantKind::Plain,
+        };
+        let explicit_3 = Variant {
+            discriminant: Some(Discriminant {
+                value: i128::MAX.to_string(),
+                expr: "".into(),
+            }),
+            kind: VariantKind::Plain,
+        };
+        let explicit_4 = Variant {
+            discriminant: Some(Discriminant {
+                value: u128::MAX.to_string(),
+                expr: "".into(),
+            }),
+            kind: VariantKind::Plain,
+        };
+        let variants = vec![
+            &explicit_1,
+            &Variant {
+                discriminant: None,
+                kind: VariantKind::Plain,
+            },
+            &explicit_2,
+            &Variant {
+                discriminant: None,
+                kind: VariantKind::Plain,
+            },
+            &explicit_3,
+            &Variant {
+                discriminant: None,
+                kind: VariantKind::Plain,
+            },
+            &explicit_4,
+        ];
+        let actual = assign_discriminants(&variants);
+        let expected: Vec<String> = vec![
+            "9223372036854775807".into(),
+            "9223372036854775808".into(),
+            "18446744073709551615".into(),
+            "18446744073709551616".into(),
+            "170141183460469231731687303715884105727".into(),
+            "170141183460469231731687303715884105728".into(),
+            "340282366920938463463374607431768211455".into(),
+        ];
+        assert_eq!(actual, expected);
+    }
+}

--- a/src/adapter/enum_variant.rs
+++ b/src/adapter/enum_variant.rs
@@ -1,14 +1,15 @@
 use rustdoc_types::{Item, ItemEnum, Variant};
 use std::fmt;
 use std::num::ParseIntError;
-use std::sync::Arc;
-use std::{str::FromStr, sync::OnceLock};
+use std::rc::Rc;
+use std::cell::OnceCell;
+use std::str::FromStr;
 
 #[non_exhaustive]
 #[derive(Debug, Clone)]
 pub(super) struct EnumVariant<'a> {
     item: &'a Item,
-    discriminants: Arc<LazyDiscriminants<'a>>,
+    discriminants: Rc<LazyDiscriminants<'a>>,
     index: usize,
 }
 
@@ -16,14 +17,14 @@ pub(super) struct EnumVariant<'a> {
 #[derive(Debug, Clone)]
 pub(super) struct LazyDiscriminants<'a> {
     variants: Vec<&'a Variant>,
-    discriminants: OnceLock<Vec<String>>,
+    discriminants: OnceCell<Vec<String>>,
 }
 
 impl<'a> LazyDiscriminants<'a> {
     pub(super) fn new(variants: Vec<&'a Variant>) -> Self {
         Self {
             variants,
-            discriminants: OnceLock::new(),
+            discriminants: OnceCell::new(),
         }
     }
 
@@ -36,7 +37,7 @@ impl<'a> LazyDiscriminants<'a> {
 impl<'a> EnumVariant<'a> {
     pub(super) fn new(
         item: &'a Item,
-        discriminants: Arc<LazyDiscriminants<'a>>,
+        discriminants: Rc<LazyDiscriminants<'a>>,
         index: usize,
     ) -> Self {
         Self {

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -17,6 +17,7 @@ use self::{
 };
 
 mod edges;
+mod enum_variant;
 mod optimizations;
 mod origin;
 mod properties;

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -150,6 +150,9 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                     properties::resolve_associated_constant_property(contexts, property_name)
                 }
                 "Constant" => properties::resolve_constant_property(contexts, property_name),
+                "Discriminant" => {
+                    properties::resolve_discriminant_property(contexts, property_name)
+                }
                 _ => unreachable!("resolve_property {type_name} {property_name}"),
             }
         }

--- a/src/adapter/origin.rs
+++ b/src/adapter/origin.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::{borrow::Cow, rc::Rc};
 
 use rustdoc_types::{Abi, Item, Span};
 
@@ -100,7 +100,7 @@ impl Origin {
         }
     }
 
-    pub(super) fn make_discriminant_vertex<'a>(&self, value: String) -> Vertex<'a> {
+    pub(super) fn make_discriminant_vertex<'a>(&self, value: Cow<'a, str>) -> Vertex<'a> {
         Vertex {
             origin: *self,
             kind: VertexKind::Discriminant(value),

--- a/src/adapter/origin.rs
+++ b/src/adapter/origin.rs
@@ -1,4 +1,4 @@
-use std::{rc::Rc, sync::Arc};
+use std::rc::Rc;
 
 use rustdoc_types::{Abi, Item, Span};
 
@@ -110,7 +110,7 @@ impl Origin {
     pub(super) fn make_variant_vertex<'a>(
         &self,
         item: &'a Item,
-        discriminants: Arc<LazyDiscriminants<'a>>,
+        discriminants: Rc<LazyDiscriminants<'a>>,
         index: usize,
     ) -> Vertex<'a> {
         Vertex {

--- a/src/adapter/origin.rs
+++ b/src/adapter/origin.rs
@@ -96,4 +96,14 @@ impl Origin {
             kind: abi.into(),
         }
     }
+
+    pub(super) fn make_discriminant_vertex<'a>(
+        &self,
+        discriminant: rustdoc_types::Discriminant,
+    ) -> Vertex<'a> {
+        Vertex {
+            origin: *self,
+            kind: discriminant.into(),
+        }
+    }
 }

--- a/src/adapter/origin.rs
+++ b/src/adapter/origin.rs
@@ -99,7 +99,7 @@ impl Origin {
 
     pub(super) fn make_discriminant_vertex<'a>(
         &self,
-        discriminant: rustdoc_types::Discriminant,
+        discriminant: &'a rustdoc_types::Discriminant,
     ) -> Vertex<'a> {
         Vertex {
             origin: *self,

--- a/src/adapter/origin.rs
+++ b/src/adapter/origin.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::{rc::Rc, sync::Arc};
 
 use rustdoc_types::{Abi, Item, Span};
 
@@ -7,7 +7,10 @@ use crate::{
     indexed_crate::ImportablePath,
 };
 
-use super::vertex::{Vertex, VertexKind};
+use super::{
+    enum_variant::{EnumVariant, LazyDiscriminants},
+    vertex::{Vertex, VertexKind},
+};
 
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy)]
@@ -97,13 +100,22 @@ impl Origin {
         }
     }
 
-    pub(super) fn make_discriminant_vertex<'a>(
+    pub(super) fn make_discriminant_vertex<'a>(&self, value: String) -> Vertex<'a> {
+        Vertex {
+            origin: *self,
+            kind: VertexKind::Discriminant(value),
+        }
+    }
+
+    pub(super) fn make_variant_vertex<'a>(
         &self,
-        discriminant: &'a rustdoc_types::Discriminant,
+        item: &'a Item,
+        discriminants: Arc<LazyDiscriminants<'a>>,
+        index: usize,
     ) -> Vertex<'a> {
         Vertex {
             origin: *self,
-            kind: discriminant.into(),
+            kind: VertexKind::Variant(EnumVariant::new(item, discriminants, index)),
         }
     }
 }

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -570,7 +570,7 @@ pub(crate) fn resolve_discriminant_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
             vertex
                 .as_discriminant()
                 .expect("vertex was not a Discriminant")
-                .clone()
+                .to_string()
                 .into()
         }),
         _ => unreachable!("Discriminant property {property_name}"),

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -566,8 +566,13 @@ pub(crate) fn resolve_discriminant_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
     property_name: &str,
 ) -> ContextOutcomeIterator<'a, V, FieldValue> {
     match property_name {
-        "expr" => resolve_property_with(contexts, field_property!(as_discriminant, expr)),
-        "value" => resolve_property_with(contexts, field_property!(as_discriminant, value)),
-        _ => unreachable!("AssociatedConstant property {property_name}"),
+        "value" => resolve_property_with(contexts, |vertex| {
+            vertex
+                .as_discriminant()
+                .expect("vertex was not a Discriminant")
+                .clone()
+                .into()
+        }),
+        _ => unreachable!("Discriminant property {property_name}"),
     }
 }

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -560,3 +560,26 @@ pub(crate) fn resolve_constant_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
         _ => unreachable!("Constant property {property_name}"),
     }
 }
+
+pub(crate) fn resolve_discriminant_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
+    contexts: ContextIterator<'a, V>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, V, FieldValue> {
+    match property_name {
+        "expr" => resolve_property_with(contexts, |vertex| {
+            vertex
+                .as_discriminant()
+                .expect("vertex was not a Discriminant")
+                .expr
+                .into()
+        }),
+        "value" => resolve_property_with(contexts, |vertex| {
+            vertex
+                .as_discriminant()
+                .expect("vertex was not a Discriminant")
+                .value
+                .into()
+        }),
+        _ => unreachable!("AssociatedConstant property {property_name}"),
+    }
+}

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -566,20 +566,8 @@ pub(crate) fn resolve_discriminant_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
     property_name: &str,
 ) -> ContextOutcomeIterator<'a, V, FieldValue> {
     match property_name {
-        "expr" => resolve_property_with(contexts, |vertex| {
-            vertex
-                .as_discriminant()
-                .expect("vertex was not a Discriminant")
-                .expr
-                .into()
-        }),
-        "value" => resolve_property_with(contexts, |vertex| {
-            vertex
-                .as_discriminant()
-                .expect("vertex was not a Discriminant")
-                .value
-                .into()
-        }),
+        "expr" => resolve_property_with(contexts, field_property!(as_discriminant, expr)),
+        "value" => resolve_property_with(contexts, field_property!(as_discriminant, value)),
         _ => unreachable!("AssociatedConstant property {property_name}"),
     }
 }

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -1674,9 +1674,10 @@ fn enum_discriminants() {
     Crate {
         item {
             ... on Enum {
-                name @output
+                enum_name: name @output
                 variant {
-                    discriminant {
+                    variant_name: name @output
+                    discriminant @optional {
                         value @output
                     }
                 }
@@ -1692,8 +1693,9 @@ fn enum_discriminants() {
 
     #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
     struct Output {
-        name: String,
-        value: String,
+        enum_name: String,
+        variant_name: String,
+        value: Option<String>,
     }
 
     let mut results: Vec<Output> =
@@ -1706,81 +1708,115 @@ fn enum_discriminants() {
     similar_asserts::assert_eq!(
         vec![
             Output {
-                name: "A".into(),
-                value: "0".into(),
+                enum_name: "A".into(),
+                variant_name: "Five".into(),
+                value: Some("100".into(),),
             },
             Output {
-                name: "A".into(),
-                value: "1".into(),
+                enum_name: "A".into(),
+                variant_name: "Four".into(),
+                value: Some("99".into(),),
             },
             Output {
-                name: "A".into(),
-                value: "100".into(),
+                enum_name: "A".into(),
+                variant_name: "One".into(),
+                value: Some("1".into(),),
             },
             Output {
-                name: "A".into(),
-                value: "2".into(),
+                enum_name: "A".into(),
+                variant_name: "Three".into(),
+                value: Some("3".into(),),
             },
             Output {
-                name: "A".into(),
-                value: "3".into(),
+                enum_name: "A".into(),
+                variant_name: "Two".into(),
+                value: Some("2".into(),),
             },
             Output {
-                name: "A".into(),
-                value: "99".into(),
+                enum_name: "A".into(),
+                variant_name: "Zero".into(),
+                value: Some("0".into(),),
             },
             Output {
-                name: "Fieldful".into(),
-                value: "0".into(),
+                enum_name: "Fieldful".into(),
+                variant_name: "Struct".into(),
+                value: Some("2".into(),),
             },
             Output {
-                name: "Fieldful".into(),
-                value: "1".into(),
+                enum_name: "Fieldful".into(),
+                variant_name: "Tuple".into(),
+                value: Some("1".into(),),
             },
             Output {
-                name: "Fieldful".into(),
-                value: "2".into(),
+                enum_name: "Fieldful".into(),
+                variant_name: "Unit".into(),
+                value: Some("0".into(),),
             },
             Output {
-                name: "Fieldful".into(),
-                value: "9".into(),
+                enum_name: "Fieldful".into(),
+                variant_name: "Unit2".into(),
+                value: Some("9".into(),),
             },
             Output {
-                name: "FieldlessWithDiscrimants".into(),
-                value: "10".into(),
+                enum_name: "FieldfulNoRepr".into(),
+                variant_name: "Struct".into(),
+                value: Some("2".into(),),
             },
             Output {
-                name: "FieldlessWithDiscrimants".into(),
-                value: "11".into(),
+                enum_name: "FieldfulNoRepr".into(),
+                variant_name: "Tuple".into(),
+                value: Some("1".into(),),
             },
             Output {
-                name: "FieldlessWithDiscrimants".into(),
-                value: "20".into(),
+                enum_name: "FieldfulNoRepr".into(),
+                variant_name: "Unit".into(),
+                value: Some("0".into(),),
             },
             Output {
-                name: "FieldlessWithDiscrimants".into(),
-                value: "21".into(),
+                enum_name: "FieldlessWithDiscrimants".into(),
+                variant_name: "First".into(),
+                value: Some("10".into(),),
             },
             Output {
-                name: "FieldlessWithDiscrimants".into(),
-                value: "22".into(),
+                enum_name: "FieldlessWithDiscrimants".into(),
+                variant_name: "Second".into(),
+                value: Some("20".into(),),
             },
             Output {
-                name: "Pathological".into(),
-                value: "-170141183460469231731687303715884105726".into(),
+                enum_name: "FieldlessWithDiscrimants".into(),
+                variant_name: "Struct".into(),
+                value: Some("21".into(),),
             },
             Output {
-                name: "Pathological".into(),
-                value: "-170141183460469231731687303715884105727".into(),
+                enum_name: "FieldlessWithDiscrimants".into(),
+                variant_name: "Tuple".into(),
+                value: Some("11".into(),),
             },
             Output {
-                name: "Pathological".into(),
-                value: "-170141183460469231731687303715884105728".into(),
+                enum_name: "FieldlessWithDiscrimants".into(),
+                variant_name: "Unit".into(),
+                value: Some("22".into(),),
             },
             Output {
-                name: "Pathological".into(),
-                value: "170141183460469231731687303715884105727".into(),
-            }
+                enum_name: "Pathological".into(),
+                variant_name: "Max".into(),
+                value: Some("170141183460469231731687303715884105727".into(),),
+            },
+            Output {
+                enum_name: "Pathological".into(),
+                variant_name: "Min".into(),
+                value: Some("-170141183460469231731687303715884105728".into(),),
+            },
+            Output {
+                enum_name: "Pathological".into(),
+                variant_name: "MinPlusOne".into(),
+                value: Some("-170141183460469231731687303715884105727".into(),),
+            },
+            Output {
+                enum_name: "Pathological".into(),
+                variant_name: "MinPlusTwo".into(),
+                value: Some("-170141183460469231731687303715884105726".into(),),
+            },
         ],
         results
     );

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -1674,6 +1674,7 @@ fn enum_discriminants() {
     Crate {
         item {
             ... on Enum {
+                name @output
                 variant {
                     discriminant {
                         expr @output
@@ -1692,6 +1693,7 @@ fn enum_discriminants() {
 
     #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
     struct Output {
+        name: String,
         expr: String,
         value: String,
     }
@@ -1706,12 +1708,34 @@ fn enum_discriminants() {
     similar_asserts::assert_eq!(
         vec![
             Output {
+                name: "A".into(),
                 expr: "1".into(),
                 value: "1".into(),
             },
             Output {
+                name: "A".into(),
+                expr: "99".into(),
+                value: "99".into(),
+            },
+            Output {
+                name: "A".into(),
                 expr: "{ _ }".into(),
                 value: "2".into(),
+            },
+            Output {
+                name: "Fieldful".into(),
+                expr: "9".into(),
+                value: "9".into(),
+            },
+            Output {
+                name: "FieldlessWithDiscrimants".into(),
+                expr: "10".into(),
+                value: "10".into(),
+            },
+            Output {
+                name: "FieldlessWithDiscrimants".into(),
+                expr: "20".into(),
+                value: "20".into(),
             },
         ],
         results

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -1677,7 +1677,6 @@ fn enum_discriminants() {
                 name @output
                 variant {
                     discriminant {
-                        expr @output
                         value @output
                     }
                 }
@@ -1694,7 +1693,6 @@ fn enum_discriminants() {
     #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
     struct Output {
         name: String,
-        expr: String,
         value: String,
     }
 
@@ -1709,34 +1707,80 @@ fn enum_discriminants() {
         vec![
             Output {
                 name: "A".into(),
-                expr: "1".into(),
+                value: "0".into(),
+            },
+            Output {
+                name: "A".into(),
                 value: "1".into(),
             },
             Output {
                 name: "A".into(),
-                expr: "99".into(),
-                value: "99".into(),
+                value: "100".into(),
             },
             Output {
                 name: "A".into(),
-                expr: "{ _ }".into(),
+                value: "2".into(),
+            },
+            Output {
+                name: "A".into(),
+                value: "3".into(),
+            },
+            Output {
+                name: "A".into(),
+                value: "99".into(),
+            },
+            Output {
+                name: "Fieldful".into(),
+                value: "0".into(),
+            },
+            Output {
+                name: "Fieldful".into(),
+                value: "1".into(),
+            },
+            Output {
+                name: "Fieldful".into(),
                 value: "2".into(),
             },
             Output {
                 name: "Fieldful".into(),
-                expr: "9".into(),
                 value: "9".into(),
             },
             Output {
                 name: "FieldlessWithDiscrimants".into(),
-                expr: "10".into(),
                 value: "10".into(),
             },
             Output {
                 name: "FieldlessWithDiscrimants".into(),
-                expr: "20".into(),
+                value: "11".into(),
+            },
+            Output {
+                name: "FieldlessWithDiscrimants".into(),
                 value: "20".into(),
             },
+            Output {
+                name: "FieldlessWithDiscrimants".into(),
+                value: "21".into(),
+            },
+            Output {
+                name: "FieldlessWithDiscrimants".into(),
+                value: "22".into(),
+            },
+            Output {
+                name: "Pathological".into(),
+                value: "-170141183460469231731687303715884105726".into(),
+            },
+            Output {
+                name: "Pathological".into(),
+                value: "-170141183460469231731687303715884105727".into(),
+            },
+            Output {
+                name: "Pathological".into(),
+                value: "-170141183460469231731687303715884105728".into(),
+            },
+            Output {
+                name: "Pathological".into(),
+                value: "170141183460469231731687303715884105727".into(),
+            }
         ],
         results
     );

--- a/src/adapter/vertex.rs
+++ b/src/adapter/vertex.rs
@@ -117,8 +117,9 @@ impl<'a> Vertex<'a> {
     }
 
     pub(super) fn as_item(&self) -> Option<&'a Item> {
-        match self.kind {
+        match &self.kind {
             VertexKind::Item(item) => Some(item),
+            VertexKind::Variant(variant) => Some(variant.item()),
             _ => None,
         }
     }

--- a/src/adapter/vertex.rs
+++ b/src/adapter/vertex.rs
@@ -1,8 +1,8 @@
 use std::rc::Rc;
 
 use rustdoc_types::{
-    Abi, Constant, Crate, Enum, Function, Impl, Item, Module, Path, Span, Static, Struct, Trait,
-    Type, Union, Variant, VariantKind,
+    Abi, Constant, Crate, Discriminant, Enum, Function, Impl, Item, Module, Path, Span, Static,
+    Struct, Trait, Type, Union, Variant, VariantKind,
 };
 use trustfall::provider::Typename;
 
@@ -36,6 +36,7 @@ pub enum VertexKind<'a> {
     ImplementedTrait(&'a Path, &'a Item),
     FunctionParameter(&'a str),
     FunctionAbi(&'a Abi),
+    Discriminant(Discriminant),
 }
 
 impl<'a> Typename for Vertex<'a> {
@@ -77,6 +78,7 @@ impl<'a> Typename for Vertex<'a> {
             },
             VertexKind::FunctionParameter(..) => "FunctionParameter",
             VertexKind::FunctionAbi(..) => "FunctionAbi",
+            VertexKind::Discriminant(..) => "Discriminant",
         }
     }
 }
@@ -254,6 +256,13 @@ impl<'a> Vertex<'a> {
             _ => None,
         }
     }
+
+    pub(super) fn as_discriminant(&self) -> Option<rustdoc_types::Discriminant> {
+        match &self.kind {
+            VertexKind::Discriminant(discriminant) => Some(discriminant.clone()),
+            _ => None,
+        }
+    }
 }
 
 impl<'a> From<&'a Item> for VertexKind<'a> {
@@ -277,5 +286,11 @@ impl<'a> From<&'a Span> for VertexKind<'a> {
 impl<'a> From<&'a Abi> for VertexKind<'a> {
     fn from(a: &'a Abi) -> Self {
         Self::FunctionAbi(a)
+    }
+}
+
+impl<'a> From<Discriminant> for VertexKind<'a> {
+    fn from(d: Discriminant) -> Self {
+        Self::Discriminant(d)
     }
 }

--- a/src/adapter/vertex.rs
+++ b/src/adapter/vertex.rs
@@ -80,7 +80,7 @@ impl<'a> Typename for Vertex<'a> {
             VertexKind::FunctionParameter(..) => "FunctionParameter",
             VertexKind::FunctionAbi(..) => "FunctionAbi",
             VertexKind::Discriminant(..) => "Discriminant",
-            VertexKind::Variant(ev) => match ev.variant().unwrap().kind {
+            VertexKind::Variant(ev) => match ev.variant().kind {
                 VariantKind::Plain => "PlainVariant",
                 VariantKind::Tuple(..) => "TupleVariant",
                 VariantKind::Struct { .. } => "StructVariant",
@@ -172,14 +172,7 @@ impl<'a> Vertex<'a> {
         })
     }
 
-    pub(super) fn as_variant(&self) -> Option<&'a Variant> {
-        match &self.kind {
-            VertexKind::Variant(variant) => variant.variant(),
-            _ => None,
-        }
-    }
-
-    pub(super) fn as_enum_variant(&self) -> Option<&'a EnumVariant> {
+    pub(super) fn as_variant(&self) -> Option<&'_ EnumVariant<'a>> {
         match &self.kind {
             VertexKind::Variant(variant) => Some(variant),
             _ => None,

--- a/src/adapter/vertex.rs
+++ b/src/adapter/vertex.rs
@@ -36,7 +36,7 @@ pub enum VertexKind<'a> {
     ImplementedTrait(&'a Path, &'a Item),
     FunctionParameter(&'a str),
     FunctionAbi(&'a Abi),
-    Discriminant(Discriminant),
+    Discriminant(&'a Discriminant),
 }
 
 impl<'a> Typename for Vertex<'a> {
@@ -257,9 +257,9 @@ impl<'a> Vertex<'a> {
         }
     }
 
-    pub(super) fn as_discriminant(&self) -> Option<rustdoc_types::Discriminant> {
+    pub(super) fn as_discriminant(&self) -> Option<&'a rustdoc_types::Discriminant> {
         match &self.kind {
-            VertexKind::Discriminant(discriminant) => Some(discriminant.clone()),
+            VertexKind::Discriminant(discriminant) => Some(discriminant),
             _ => None,
         }
     }
@@ -289,8 +289,8 @@ impl<'a> From<&'a Abi> for VertexKind<'a> {
     }
 }
 
-impl<'a> From<Discriminant> for VertexKind<'a> {
-    fn from(d: Discriminant) -> Self {
+impl<'a> From<&'a Discriminant> for VertexKind<'a> {
+    fn from(d: &'a Discriminant) -> Self {
         Self::Discriminant(d)
     }
 }

--- a/src/adapter/vertex.rs
+++ b/src/adapter/vertex.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, rc::Rc};
 
 use rustdoc_types::{
     Abi, Constant, Crate, Enum, Function, Impl, Item, Module, Path, Span, Static, Struct, Trait,
-    Type, Union, Variant, VariantKind,
+    Type, Union, VariantKind,
 };
 use trustfall::provider::Typename;
 

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -444,7 +444,7 @@ type Discriminant {
   """
   The expression that produced the discriminant. Preserves the original formatting seen in source code (e.g. suffixes, hexadecimal, and underscores).
 
-  In some cases, when the value is to complex, this may be "`{ _ }`".
+  In some cases, when the value is too complex, this may be a placeholder value such as `"{ _ }"`.
   """
   expr: String!
 

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -514,6 +514,25 @@ type PlainVariant implements Item & Variant {
 
   # edges from Variant
   field: [StructField!]
+  
+  """
+  The discriminant value of this variant, if its value is well-defined.
+  
+  A discriminant is an integer value that is logically associated with an enum variant,
+  and is used to determine which variant an enum value holds.
+
+  Discriminant values are not always well-defined.
+
+  In order for variants to have well-defined discriminants, their enum must either
+  - define a primitive representation (e.g., `#[repr(u8)]`), or
+  - be "unit-only" i.e. consisting solely of unit variants.
+
+  The variants of such enums may be explicitly assigned a discriminant value, or
+  the discriminant may be defined implicitly:
+  - The first variant has a discriminant of zero, unless explicitly assigned a value.
+  - Subsequent variants have a discriminant one higher than the previous variant,
+    unless explicitly assigned a value.
+  """
   discriminant: Discriminant
 }
 
@@ -569,6 +588,25 @@ type TupleVariant implements Item & Variant {
 
   # edges from Variant
   field: [StructField!]
+
+  """
+  The discriminant value of this variant, if its value is well-defined.
+  
+  A discriminant is an integer value that is logically associated with an enum variant,
+  and is used to determine which variant an enum value holds.
+
+  Discriminant values are not always well-defined.
+
+  In order for variants to have well-defined discriminants, their enum must either
+  - define a primitive representation (e.g., `#[repr(u8)]`), or
+  - be "unit-only" i.e. consisting solely of unit variants.
+
+  The variants of such enums may be explicitly assigned a discriminant value, or
+  the discriminant may be defined implicitly:
+  - The first variant has a discriminant of zero, unless explicitly assigned a value.
+  - Subsequent variants have a discriminant one higher than the previous variant,
+    unless explicitly assigned a value.
+  """
   discriminant: Discriminant
 }
 
@@ -624,6 +662,25 @@ type StructVariant implements Item & Variant {
 
   # edges from Variant
   field: [StructField!]
+
+  """
+  The discriminant value of this variant, if its value is well-defined.
+  
+  A discriminant is an integer value that is logically associated with an enum variant,
+  and is used to determine which variant an enum value holds.
+
+  Discriminant values are not always well-defined.
+
+  In order for variants to have well-defined discriminants, their enum must either
+  - define a primitive representation (e.g., `#[repr(u8)]`), or
+  - be "unit-only" i.e. consisting solely of unit variants.
+
+  The variants of such enums may be explicitly assigned a discriminant value, or
+  the discriminant may be defined implicitly:
+  - The first variant has a discriminant of zero, unless explicitly assigned a value.
+  - Subsequent variants have a discriminant one higher than the previous variant,
+    unless explicitly assigned a value.
+  """
   discriminant: Discriminant
 }
 

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -429,14 +429,28 @@ interface Variant implements Item {
 
   # own edges
   field: [StructField!]
+
+  """
+  The discriminant, if explicitly specified.
+  """
   discriminant: Discriminant
 }
 
 """
-https://docs.rs/rustdoc-types/latest/rustdoc_types/struct.Discriminant.html
+https://docs.rs/rustdoc-types/0.28.0/rustdoc_types/struct.Discriminant.html
+https://doc.rust-lang.org/reference/items/enumerations.html
 """
 type Discriminant {
+  """
+  The expression that produced the discriminant. Preserves the original formatting seen in source code (e.g. suffixes, hexadecimal, and underscores).
+
+  In some cases, when the value is to complex, this may be "`{ _ }`".
+  """
   expr: String!
+
+  """
+  The numerical value of the discriminant. Stored as a string. Ranges from `i128::MIN` to `u128::MAX`.
+  """
   value: String!
 }
 

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -442,13 +442,6 @@ https://doc.rust-lang.org/reference/items/enumerations.html
 """
 type Discriminant {
   """
-  The expression that produced the discriminant. Preserves the original formatting seen in source code (e.g. suffixes, hexadecimal, and underscores).
-
-  In some cases, when the value is too complex, this may be a placeholder value such as `"{ _ }"`.
-  """
-  expr: String!
-
-  """
   The numerical value of the discriminant. Stored as a string. Ranges from `i128::MIN` to `u128::MAX`.
   """
   value: String!

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -429,6 +429,15 @@ interface Variant implements Item {
 
   # own edges
   field: [StructField!]
+  discriminant: Discriminant
+}
+
+"""
+https://docs.rs/rustdoc-types/latest/rustdoc_types/struct.Discriminant.html
+"""
+type Discriminant {
+  expr: String!
+  value: String!
 }
 
 """
@@ -483,6 +492,7 @@ type PlainVariant implements Item & Variant {
 
   # edges from Variant
   field: [StructField!]
+  discriminant: Discriminant
 }
 
 """
@@ -537,6 +547,7 @@ type TupleVariant implements Item & Variant {
 
   # edges from Variant
   field: [StructField!]
+  discriminant: Discriminant
 }
 
 """
@@ -591,6 +602,7 @@ type StructVariant implements Item & Variant {
 
   # edges from Variant
   field: [StructField!]
+  discriminant: Discriminant
 }
 
 """

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -431,7 +431,22 @@ interface Variant implements Item {
   field: [StructField!]
 
   """
-  The discriminant, if explicitly specified.
+  The discriminant value of this variant, if its value is well-defined.
+  
+  A discriminant is an integer value that is logically associated with an enum variant,
+  and is used to determine which variant an enum value holds.
+
+  Discriminant values are not always well-defined.
+
+  In order for variants to have well-defined discriminants, their enum must either
+  - define a primitive representation (e.g., `#[repr(u8)]`), or
+  - be "unit-only" i.e. consisting solely of unit variants.
+
+  The variants of such enums may be explicitly assigned a discriminant value, or
+  the discriminant may be defined implicitly:
+  - The first variant has a discriminant of zero, unless explicitly assigned a value.
+  - Subsequent variants have a discriminant one higher than the previous variant,
+    unless explicitly assigned a value.
   """
   discriminant: Discriminant
 }

--- a/test_crates/enum_discriminants/Cargo.toml
+++ b/test_crates/enum_discriminants/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+publish = false
+name = "enum_discriminants"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/test_crates/enum_discriminants/src/lib.rs
+++ b/test_crates/enum_discriminants/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(incomplete_features)]
+#![feature(repr128)]
 /// Some examples from <https://doc.rust-lang.org/reference/items/enumerations.html#implicit-discriminants>
 
 #[repr(C)]
@@ -27,3 +29,10 @@ pub enum Fieldful {
     Unit2 = 9
 }
 
+#[repr(i128)]
+pub enum Pathological {
+    Min = i128::MIN,
+    MinPlusOne,
+    MinPlusTwo,
+    Max = i128::MAX,
+}

--- a/test_crates/enum_discriminants/src/lib.rs
+++ b/test_crates/enum_discriminants/src/lib.rs
@@ -1,5 +1,29 @@
+/// Some examples from <https://doc.rust-lang.org/reference/items/enumerations.html#implicit-discriminants>
+
 #[repr(C)]
 pub enum A {
+    Zero,
     One = 1,
     Two = 1 + 1,
+    Three,
+    Four = 99,
+    Five
 }
+
+#[repr(u8)]
+pub enum FieldlessWithDiscrimants {
+    First = 10,
+    Tuple(),
+    Second = 20,
+    Struct{},
+    Unit,
+}
+
+#[repr(i64)]
+pub enum Fieldful {
+    Unit,
+    Tuple(bool),
+    Struct{a: bool},
+    Unit2 = 9
+}
+

--- a/test_crates/enum_discriminants/src/lib.rs
+++ b/test_crates/enum_discriminants/src/lib.rs
@@ -29,6 +29,12 @@ pub enum Fieldful {
     Unit2 = 9
 }
 
+pub enum FieldfulNoRepr {
+    Unit,
+    Tuple(bool),
+    Struct{a: bool},
+}
+
 #[repr(i128)]
 pub enum Pathological {
     Min = i128::MIN,

--- a/test_crates/enum_discriminants/src/lib.rs
+++ b/test_crates/enum_discriminants/src/lib.rs
@@ -1,0 +1,5 @@
+#[repr(C)]
+pub enum A {
+    One = 1,
+    Two = 1 + 1,
+}


### PR DESCRIPTION
Adds information about enum discriminants to the schema.

Refs:
- https://docs.rs/rustdoc-types/latest/rustdoc_types/struct.Variant.html
- https://docs.rs/rustdoc-types/latest/rustdoc_types/struct.Discriminant.html
- https://doc.rust-lang.org/reference/items/enumerations.html