### PR TITLE
feat: Add rustdoc format v32 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: ["beta", "nightly"]
+        toolchain: ["nightly"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,9 +222,9 @@ checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "rustdoc-types"
-version = "0.26.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9be1bc4a0ec3445cfa2e4ba112827544890d43d68b7d1eda5359a9c09d2cd8"
+checksum = "92b1b819622d1b7f20e0bd80d548cb0eb3bb157748411afc83335573a2de1f50"
 dependencies = [
  "serde",
 ]
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "30.0.0"
+version = "32.0.0"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustfall-rustdoc-adapter"
-version = "30.0.0"
+version = "32.0.0"
 edition = "2021"
 authors = ["Predrag Gruevski <obi1kenobi82@gmail.com>"]
 license = "Apache-2.0 OR MIT"
@@ -12,7 +12,7 @@ readme = "./README.md"
 
 [dependencies]
 trustfall = "0.7.1"
-rustdoc-types = "0.26.0"
+rustdoc-types = "0.28.0"
 
 [dev-dependencies]
 anyhow = "1.0.58"


### PR DESCRIPTION
Hi, @obi1kenobi, this PR will add rustdoc format v32 format. My plan is to make `cargo-semver-checks` finally support this format too so the failing CI can be addressed.

The PR's base might need to change.