### PR TITLE
Implement sealed trait analysis and expose it in the adapter.

### DIFF
--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -134,7 +134,12 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                 "AttributeMetaItem" => {
                     properties::resolve_attribute_meta_item_property(contexts, property_name)
                 }
-                "Trait" => properties::resolve_trait_property(contexts, property_name),
+                "Trait" => properties::resolve_trait_property(
+                    contexts,
+                    property_name,
+                    self.current_crate,
+                    self.previous_crate,
+                ),
                 "ImplementedTrait" => {
                     properties::resolve_implemented_trait_property(contexts, property_name)
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
 mod adapter;
 mod attributes;
 mod indexed_crate;
+mod sealed_trait;
+mod visibility_tracker;
 
 #[cfg(test)]
 pub(crate) mod test_util;
-
-mod visibility_tracker;
 
 // Re-export the Crate type so we can deserialize it.
 pub use rustdoc_types::Crate;

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -902,8 +902,23 @@ type Trait implements Item & Importable {
   visibility_limit: String!
 
   # own properties
+  """
+  Whether this trait is defined as `unsafe` and requires the `unsafe` keyword when implementing.
+  """
   unsafe: Boolean!
+
+  """
+  Whether this trait can be used as `dyn Trait`.
+  """
   object_safe: Boolean!
+
+  """
+  Whether downstream crates are prevented from implementing this trait themselves.
+
+  Required implementation items can be added to sealed traits without causing a breaking change,
+  since no implementations of that trait may exist in other crates.
+  """
+  sealed: Boolean!
 
   # edges from Item
   span: Span

--- a/src/sealed_trait.rs
+++ b/src/sealed_trait.rs
@@ -1,0 +1,187 @@
+use rustdoc_types::{Item, Trait};
+
+use crate::IndexedCrate;
+
+pub(crate) fn is_trait_sealed<'a>(indexed_crate: &IndexedCrate<'a>, trait_item: &'a Item) -> bool {
+    let trait_inner = unwrap_trait(trait_item);
+
+    // If the trait is pub-in-priv, trivially sealed.
+    if is_pub_in_priv_item(indexed_crate, &trait_item.id) {
+        return true;
+    }
+
+    // Does the trait have a supertrait that is:
+    // - defined in this crate
+    // - pub-in-priv, or otherwise sealed
+    if has_sealed_supertrait(indexed_crate, trait_inner) {
+        return true;
+    }
+
+    // Does the trait have a method that:
+    // - does not have a default impl, and either:
+    //   a. takes at least one non-`self` argument that is pub-in-priv, or
+    //   b. has a generic parameter that causes it to be generic-sealed
+    // If so, the trait is method-sealed or generic-sealed, per:
+    // https://predr.ag/blog/definitive-guide-to-sealed-traits-in-rust/#sealing-traits-via-method-signatures
+    // https://jack.wrenn.fyi/blog/private-trait-methods/
+    // https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=3393c3ae143cb75c9da7bfe6e8ff8084
+    if is_method_sealed(indexed_crate, trait_inner) {
+        return true;
+    }
+
+    false
+}
+
+fn is_pub_in_priv_item<'a>(indexed_crate: &IndexedCrate<'a>, id: &'a rustdoc_types::Id) -> bool {
+    // TODO: We don't need all names here, one is plenty. See if this is worth optimizing.
+    indexed_crate.publicly_importable_names(id).is_empty()
+}
+
+fn unwrap_trait(item: &Item) -> &'_ Trait {
+    match &item.inner {
+        rustdoc_types::ItemEnum::Trait(t) => t,
+        _ => unreachable!(),
+    }
+}
+
+fn has_sealed_supertrait<'a>(indexed_crate: &IndexedCrate<'a>, inner: &'a Trait) -> bool {
+    for bound in &inner.bounds {
+        let supertrait = match bound {
+            rustdoc_types::GenericBound::TraitBound {
+                trait_: trait_path, ..
+            } => {
+                match indexed_crate.inner.index.get(&trait_path.id) {
+                    Some(item) => item,
+                    None => {
+                        // Item from another crate, so clearly not pub-in-priv.
+                        //
+                        // TODO: Once we have the ability to do cross-crate analysis, consider
+                        //       whether this external trait is sealed. That can have
+                        //       some interesting SemVer implications as well.
+                        return false;
+                    }
+                }
+            }
+            rustdoc_types::GenericBound::Outlives(_) | rustdoc_types::GenericBound::Use(_) => {
+                continue;
+            }
+        };
+
+        // Otherwise, check if the supertrait is itself sealed.
+        // This catches cases like:
+        // ```rust
+        // mod priv {
+        //     pub trait Sealed {}
+        // }
+        //
+        // pub trait First: Sealed {}
+        //
+        // pub trait Second: First {}
+        // ```
+        //
+        // Here, both `First` and `Second` are sealed.
+        if is_trait_sealed(indexed_crate, supertrait) {
+            // N.B.: This cannot infinite-loop, since rustc denies cyclic trait bounds.
+            return true;
+        }
+    }
+
+    false
+}
+
+fn is_method_sealed<'a>(indexed_crate: &IndexedCrate<'a>, trait_inner: &'a Trait) -> bool {
+    for inner_item_id in &trait_inner.items {
+        let inner_item = &indexed_crate.inner.index[inner_item_id];
+        if let rustdoc_types::ItemEnum::Function(func) = &inner_item.inner {
+            if func.has_body {
+                // This trait function has a default implementation.
+                // An implementation is not required in order to implement this trait on a type.
+                // Therefore, it cannot on its own cause the trait to be sealed.
+                continue;
+            }
+
+            // Check for pub-in-priv function parameters.
+            for (_, param) in &func.decl.inputs {
+                if let rustdoc_types::Type::ResolvedPath(path) = param {
+                    if is_local_pub_in_priv_path(indexed_crate, path) {
+                        return true;
+                    }
+                }
+            }
+
+            // Check for generics-sealed methods, as described in:
+            // https://jack.wrenn.fyi/blog/private-trait-methods/
+            // https://www.reddit.com/r/rust/comments/12cj6as/comment/jf21zsm/
+            for generic_param in &func.generics.params {
+                match &generic_param.kind {
+                    rustdoc_types::GenericParamDefKind::Type {
+                        bounds, default, ..
+                    } => {
+                        // If the generic parameter has a default, it can't be used to seal.
+                        if default.is_none() {
+                            for bound in bounds {
+                                if is_generic_type_bound_sealed(indexed_crate, bound) {
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+                    _ => continue,
+                }
+            }
+        }
+    }
+
+    false
+}
+
+fn is_generic_type_bound_sealed<'a>(
+    indexed_crate: &IndexedCrate<'a>,
+    bound: &'a rustdoc_types::GenericBound,
+) -> bool {
+    match bound {
+        rustdoc_types::GenericBound::TraitBound {
+            trait_: trait_path, ..
+        } => {
+            // For the bound to be sealing, it needs to:
+            // - point to a pub-in-priv trait in this crate.
+            // - all supertraits of the pub-in-priv trait must also be pub-in-priv
+            let Some(item) = indexed_crate.inner.index.get(&trait_path.id) else {
+                // Not an item in this crate.
+                return false;
+            };
+            if !is_pub_in_priv_item(indexed_crate, &item.id) {
+                return false;
+            }
+
+            let trait_item = unwrap_trait(item);
+
+            // Check all supertraits to ensure they are pub-in-priv as well.
+            for trait_bounds in &trait_item.bounds {
+                if let rustdoc_types::GenericBound::TraitBound {
+                    trait_: inner_trait_path,
+                    ..
+                } = trait_bounds
+                {
+                    if !is_local_pub_in_priv_path(indexed_crate, inner_trait_path) {
+                        return false;
+                    }
+                }
+            }
+
+            true
+        }
+        _ => false,
+    }
+}
+
+fn is_local_pub_in_priv_path<'a>(
+    indexed_crate: &IndexedCrate<'a>,
+    path: &'a rustdoc_types::Path,
+) -> bool {
+    let Some(item) = indexed_crate.inner.index.get(&path.id) else {
+        // Not an item in this crate.
+        return false;
+    };
+    is_pub_in_priv_item(indexed_crate, &item.id)
+}

--- a/test_crates/sealed_traits/Cargo.toml
+++ b/test_crates/sealed_traits/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "sealed_traits"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/sealed_traits/src/lib.rs
+++ b/test_crates/sealed_traits/src/lib.rs
@@ -1,0 +1,85 @@
+mod private {
+    pub trait Sealed {}
+
+    pub struct Token;
+
+    pub trait InternalMarker {}
+}
+
+/// This trait is sealed since nobody can implement its pub-in-priv supertrait.
+pub trait DirectlyTraitSealed: private::Sealed {}
+
+/// This trait is sealed since nobody can implement its supertrait.
+pub trait TransitivelyTraitSealed: DirectlyTraitSealed {}
+
+pub trait Unsealed {}
+
+/// This trait is sealed because its argument type is pub-in-priv,
+/// so external implementers cannot name it.
+pub trait MethodSealed {
+    fn method(&self, token: private::Token) -> i64;
+}
+
+/// This trait is sealed since nobody can implement its supertrait.
+pub trait TransitivelyMethodSealed: MethodSealed {}
+
+/// This trait is *not* sealed. Its method cannot be overridden,
+/// but implementing it is not required since the trait offers a default impl.
+pub trait NotMethodSealedBecauseOfDefaultImpl {
+    fn method(&self, _token: private::Token) -> i64 {
+        0
+    }
+}
+
+/// This trait is *not* sealed. Its supertrait is also not sealed.
+pub trait NotTransitivelySealed: NotMethodSealedBecauseOfDefaultImpl {}
+
+/// This trait's method is generic-sealed: downstream implementors are not able
+/// to write the trait bound since the internal marker trait is pub-in-priv.
+pub trait GenericSealed {
+    fn method<IM: private::InternalMarker>(&self);
+}
+
+/// This trait is *not* sealed. Its method cannot be overridden,
+/// but implementing it is not required since the trait offers a default impl.
+pub trait NotGenericSealedBecauseOfDefaultImpl {
+    fn private_method<IM: private::InternalMarker>(&self) {}
+}
+
+/// This trait is *not* sealed. It merely depends on a trait from another crate.
+pub trait IteratorExt: Iterator {}
+
+pub mod shadow_builtins {
+    /// This trait shadows the built-in (prelude) `Iterator` trait.
+    /// However, it is supertrait-sealed.
+    pub trait Iterator: super::private::Sealed {}
+
+    /// This trait is also supertrait-sealed.
+    pub trait ShadowedSubIterator: Iterator {}
+}
+
+pub mod generic_seal {
+    pub trait Super {}
+
+    mod private {
+        pub trait Marker: super::Super {}
+    }
+
+    /// This trait is *not* generic-sealed.
+    ///
+    /// While the `Marker` trait bound is pub-in-priv, it has a public supertrait `Super`.
+    /// The `Super` bound can be used downstream to implement this trait:
+    /// ```rust
+    /// use sealed_traits::generic_seal::Super;
+    /// use sealed_traits::generic_seal::NotGenericSealedBecauseOfPubSupertrait;
+    ///
+    /// struct Example;
+    ///
+    /// impl NotGenericSealedBecauseOfPubSupertrait for Example {
+    ///     fn method<IM: Super>(&self) {}
+    /// }
+    /// ```
+    pub trait NotGenericSealedBecauseOfPubSupertrait {
+        fn method<IM: private::Marker>(&self);
+    }
+}


### PR DESCRIPTION
Make it possible to execute queries like:
```graphql
{
    Crate {
        item {
            ... on Trait {
                name @output
                sealed @output
            }
        }
    }
}
```

Under the hood, the `sealed` property on the `Trait` vertex type does a fair bit of computation to determine whether the trait is sealed in a variety of ways.