### PR TITLE
feat: make has_body queryable on methods

### DIFF
--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -120,7 +120,10 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                     properties::resolve_importable_path_property(contexts, property_name)
                 }
                 "FunctionLike" | "Function" | "Method"
-                    if matches!(property_name.as_ref(), "const" | "unsafe" | "async") =>
+                    if matches!(
+                        property_name.as_ref(),
+                        "const" | "unsafe" | "async" | "has_body"
+                    ) =>
                 {
                     properties::resolve_function_like_property(contexts, property_name)
                 }

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -247,6 +247,10 @@ pub(super) fn resolve_function_like_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
             contexts,
             field_property!(as_function, header, { header.unsafe_.into() }),
         ),
+        "has_body" => resolve_property_with(
+            contexts,
+            field_property!(as_function, has_body, { (*has_body).into() }),
+        ),
         _ => unreachable!("FunctionLike property {property_name}"),
     }
 }

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -1818,8 +1818,6 @@ fn function_has_body() {
     let indexed_crate = IndexedCrate::new(&crate_);
     let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
 
-    // Part 1: make sure unions have correct visibility (similart to importable_paths
-
     let query = r#"
 {
     Crate {

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -1868,7 +1868,7 @@ fn function_has_body() {
         },
         Output {
             name: "trait_with_body".into(),
-            has_body: false,
+            has_body: true,
         },
         Output {
             name: "extern_no_body".into(),

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -1011,6 +1011,7 @@ interface FunctionLike {
   const: Boolean!
   unsafe: Boolean!
   async: Boolean!
+  has_body: Boolean!
 
   # own edges
   parameter: [FunctionParameter!]
@@ -1123,6 +1124,7 @@ type Function implements Item & FunctionLike & Importable {
   const: Boolean!
   unsafe: Boolean!
   async: Boolean!
+  has_body: Boolean!
 
   # own properties
   """
@@ -1211,6 +1213,7 @@ type Method implements Item & FunctionLike {
   const: Boolean!
   unsafe: Boolean!
   async: Boolean!
+  has_body: Boolean!
 
   # edge from Item
   span: Span

--- a/test_crates/function_has_body/Cargo.toml
+++ b/test_crates/function_has_body/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "function_has_body"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/function_has_body/src/lib.rs
+++ b/test_crates/function_has_body/src/lib.rs
@@ -1,0 +1,17 @@
+pub fn top_level() {}
+
+pub struct Foo;
+
+impl Foo {
+    pub fn inside_impl_block() {}
+}
+
+pub trait Bar {
+    fn trait_no_body();
+
+    fn trait_with_body();
+}
+
+extern "C" {
+    pub fn extern_no_body();
+}

--- a/test_crates/function_has_body/src/lib.rs
+++ b/test_crates/function_has_body/src/lib.rs
@@ -9,7 +9,7 @@ impl Foo {
 pub trait Bar {
     fn trait_no_body();
 
-    fn trait_with_body();
+    fn trait_with_body() {}
 }
 
 extern "C" {


### PR DESCRIPTION
Hi 👋🏻,

Retrieve the `has_body` property on function like items and expose it to queries.

If I understand correctly, this is what's blocking for some lints in obi1kenobi/cargo-semver-checks#870.