### PR TITLE
feat: faster IndexedCrate::new with rayon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,12 @@ jobs:
       - name: test
         run: cargo test
 
+      - name: compile with rayon
+        run: cargo test --no-run --features rayon
+
+      - name: test with rayon
+        run: cargo test --features rayon
+
   publish:
     name: Publish to crates.io
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,6 +635,7 @@ dependencies = [
  "criterion",
  "itertools 0.12.1",
  "maplit",
+ "rayon",
  "rustdoc-types",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,15 @@ readme = "./README.md"
 
 [dependencies]
 trustfall = "0.7.1"
+rayon = { version = "1.10.0", optional = true }
 rustdoc-types = "0.29.1"
+
+[features]
+default = []
+# Enable rayon for speeding up building `IndexedCrate`, this massively improves
+# performance on big crates, but may impact performance on small crates and
+# definitely increases the memory usage
+rayon = ["dep:rayon"]
 
 [[bench]]
 name = "indexed_crate"


### PR DESCRIPTION
Added a new *optional* rayon feature that improves performance.

```console
$ cargo criterion --bench indexed_crate
IndexedCrate/new(aws-sdk-ec2)
                        time:   [1.3074 s 1.3080 s 1.3085 s]

$ cargo criterion --bench indexed_crate --features rayon
IndexedCrate/new(aws-sdk-ec2)
                        time:   [568.84 ms 569.98 ms 571.14 ms]
                        change: [-56.521% -56.422% -56.333%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Split off from #402 