### PR TITLE
feat: introduce internal IdRef type (#435)

### DIFF
--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -512,7 +512,7 @@ pub(super) fn resolve_trait_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 
             let trait_vertex = vertex.as_trait().expect("not a Trait vertex");
             Box::new(trait_vertex.bounds.iter().filter_map(move |bound| {
-                if let TraitBound { trait_, .. } = bound {
+                if let TraitBound { trait_, .. } = &bound {
                     item_index
                         .get(&trait_.id)
                         .as_ref()

--- a/src/adapter/optimizations/method_lookup.rs
+++ b/src/adapter/optimizations/method_lookup.rs
@@ -181,7 +181,7 @@ fn resolve_methods_slow_path<'a>(
             if let Some(trait_item) = trait_item {
                 if let ItemEnum::Trait(trait_item) = &trait_item.inner {
                     Box::new(trait_item.items.iter().filter(move |item_id| {
-                        let next_item = &item_index.get(item_id);
+                        let next_item = item_index.get(item_id.as_ref());
                         if let Some(name) = next_item.and_then(|x| x.name.as_deref()) {
                             method_names.contains(name)
                         } else {

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -279,7 +279,7 @@ impl<'a> IndexedCrate<'a> {
     pub fn publicly_importable_names(&self, id: &'a Id) -> Vec<ImportablePath<'a>> {
         if self.inner.index.contains_key(id) {
             self.visibility_tracker
-                .collect_publicly_importable_names(id)
+                .collect_publicly_importable_names(id.as_ref())
         } else {
             Default::default()
         }
@@ -593,23 +593,23 @@ mod tests {
         assert!(indexed_crate
             .visibility_tracker
             .visible_parent_ids()
-            .contains_key(top_level_function));
+            .contains_key(top_level_function.as_ref()));
         assert!(indexed_crate
             .visibility_tracker
             .visible_parent_ids()
-            .contains_key(method));
+            .contains_key(method.as_ref()));
         assert!(indexed_crate
             .visibility_tracker
             .visible_parent_ids()
-            .contains_key(associated_fn));
+            .contains_key(associated_fn.as_ref()));
         assert!(indexed_crate
             .visibility_tracker
             .visible_parent_ids()
-            .contains_key(field));
+            .contains_key(field.as_ref()));
         assert!(indexed_crate
             .visibility_tracker
             .visible_parent_ids()
-            .contains_key(const_item));
+            .contains_key(const_item.as_ref()));
 
         // But only `top_level_function` is importable.
         assert_eq!(
@@ -655,23 +655,23 @@ mod tests {
         assert!(indexed_crate
             .visibility_tracker
             .visible_parent_ids()
-            .contains_key(top_level_function));
+            .contains_key(top_level_function.as_ref()));
         assert!(indexed_crate
             .visibility_tracker
             .visible_parent_ids()
-            .contains_key(variant));
+            .contains_key(variant.as_ref()));
         assert!(indexed_crate
             .visibility_tracker
             .visible_parent_ids()
-            .contains_key(method));
+            .contains_key(method.as_ref()));
         assert!(indexed_crate
             .visibility_tracker
             .visible_parent_ids()
-            .contains_key(associated_fn));
+            .contains_key(associated_fn.as_ref()));
         assert!(indexed_crate
             .visibility_tracker
             .visible_parent_ids()
-            .contains_key(const_item));
+            .contains_key(const_item.as_ref()));
 
         // But only `top_level_function` and `Foo::variant` is importable.
         assert_eq!(
@@ -721,27 +721,27 @@ mod tests {
         assert!(indexed_crate
             .visibility_tracker
             .visible_parent_ids()
-            .contains_key(top_level_function));
+            .contains_key(top_level_function.as_ref()));
         assert!(indexed_crate
             .visibility_tracker
             .visible_parent_ids()
-            .contains_key(method));
+            .contains_key(method.as_ref()));
         assert!(indexed_crate
             .visibility_tracker
             .visible_parent_ids()
-            .contains_key(associated_fn));
+            .contains_key(associated_fn.as_ref()));
         assert!(indexed_crate
             .visibility_tracker
             .visible_parent_ids()
-            .contains_key(left_field));
+            .contains_key(left_field.as_ref()));
         assert!(indexed_crate
             .visibility_tracker
             .visible_parent_ids()
-            .contains_key(right_field));
+            .contains_key(right_field.as_ref()));
         assert!(indexed_crate
             .visibility_tracker
             .visible_parent_ids()
-            .contains_key(const_item));
+            .contains_key(const_item.as_ref()));
 
         // But only `top_level_function` is importable.
         assert_eq!(

--- a/src/sealed_trait.rs
+++ b/src/sealed_trait.rs
@@ -274,7 +274,7 @@ fn blanket_type_might_cover_types_in_downstream_crate(blanket_type: &rustdoc_typ
             true
         }
         rustdoc_types::Type::BorrowedRef { type_, .. } => {
-            // Blanket implementatio over a reference, like `&T`.
+            // Blanket implementation over a reference, like `&T`.
             // It matches if the underlying type beheath the reference matches.
             blanket_type_might_cover_types_in_downstream_crate(type_)
         }

--- a/src/visibility_tracker.rs
+++ b/src/visibility_tracker.rs
@@ -5,6 +5,33 @@ use rustdoc_types::{Crate, GenericArgs, Id, Item, ItemEnum, TypeAlias, Visibilit
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
 
+#[repr(transparent)]
+#[derive(Debug, Hash, PartialEq, Eq)]
+pub(crate) struct IdRef(str);
+
+impl IdRef {
+    fn new(id: &Id) -> &Self {
+        // Safety: due to IdRef being #[repr(transparent)] &str and &IdRef have the same Layout
+        unsafe { std::mem::transmute(id.0.as_str()) }
+    }
+
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::borrow::Borrow<IdRef> for Id {
+    fn borrow(&self) -> &IdRef {
+        IdRef::new(self)
+    }
+}
+
+impl AsRef<IdRef> for Id {
+    fn as_ref(&self) -> &IdRef {
+        IdRef::new(self)
+    }
+}
+
 use crate::{attributes::Attribute, ImportablePath};
 
 #[derive(Debug, Clone)]
@@ -13,7 +40,7 @@ pub(crate) struct VisibilityTracker<'a> {
     inner: &'a Crate,
 
     /// For an Id, give the list of item Ids under which it is publicly visible.
-    visible_parent_ids: HashMap<&'a Id, Vec<&'a Id>>,
+    visible_parent_ids: HashMap<&'a IdRef, Vec<&'a IdRef>>,
 }
 
 impl<'a> VisibilityTracker<'a> {
@@ -28,8 +55,8 @@ impl<'a> VisibilityTracker<'a> {
         // Sort and deduplicate parent ids.
         // This ensures a consistent order, since queries can observe this order directly.
         iter.for_each(|(_id, parent_ids)| {
-            parent_ids.sort_unstable_by_key(|id| id.0.as_str());
-            parent_ids.dedup_by_key(|id| id.0.as_str());
+            parent_ids.sort_unstable_by_key(|id| id.as_str());
+            parent_ids.dedup_by_key(|id| id.as_str());
         });
 
         Self {
@@ -38,7 +65,10 @@ impl<'a> VisibilityTracker<'a> {
         }
     }
 
-    pub(crate) fn collect_publicly_importable_names(&self, id: &'a Id) -> Vec<ImportablePath<'a>> {
+    pub(crate) fn collect_publicly_importable_names(
+        &self,
+        id: &'a IdRef,
+    ) -> Vec<ImportablePath<'a>> {
         let mut already_visited_ids = Default::default();
         let mut result = Default::default();
 
@@ -56,8 +86,8 @@ impl<'a> VisibilityTracker<'a> {
 
     pub(crate) fn collect_publicly_importable_names_inner(
         &self,
-        next_id: &'a Id,
-        already_visited_ids: &mut HashSet<&'a Id>,
+        next_id: &'a IdRef,
+        already_visited_ids: &mut HashSet<&'a IdRef>,
         stack: &mut Vec<&'a str>,
         currently_doc_hidden: bool,
         currently_deprecated: bool,
@@ -155,14 +185,14 @@ impl<'a> VisibilityTracker<'a> {
 
     fn collect_publicly_importable_names_recurse(
         &self,
-        next_id: &'a Id,
-        already_visited_ids: &mut HashSet<&'a Id>,
+        next_id: &'a IdRef,
+        already_visited_ids: &mut HashSet<&'a IdRef>,
         stack: &mut Vec<&'a str>,
         currently_doc_hidden: bool,
         currently_deprecated: bool,
         output: &mut Vec<ImportablePath<'a>>,
     ) {
-        if next_id == &self.inner.root {
+        if next_id == self.inner.root.as_ref() {
             let final_name = stack.iter().rev().copied().collect();
             output.push(ImportablePath::new(
                 final_name,
@@ -184,7 +214,7 @@ impl<'a> VisibilityTracker<'a> {
     }
 
     #[cfg(test)]
-    pub(super) fn visible_parent_ids(&self) -> &HashMap<&'a Id, Vec<&'a Id>> {
+    pub(super) fn visible_parent_ids(&self) -> &HashMap<&'a IdRef, Vec<&'a IdRef>> {
         &self.visible_parent_ids
     }
 }
@@ -213,22 +243,22 @@ struct Definition<'a> {
     /// When the definition is an import, the `current_id` is the Id of the import,
     /// to account for possible renamings.
     /// Otherwise, the `current_id` should be the same as the `underlying_id`.
-    current_id: &'a Id,
+    current_id: &'a IdRef,
 
     /// The actual underlying item this definition resolves to, like a struct or function.
     /// This Id must not point to an import item.
-    final_underlying_id: &'a Id,
+    final_underlying_id: &'a IdRef,
 }
 
 impl<'a> Definition<'a> {
-    fn new(current_id: &'a Id, final_underlying_id: &'a Id) -> Self {
+    fn new(current_id: &'a IdRef, final_underlying_id: &'a IdRef) -> Self {
         Self {
             current_id,
             final_underlying_id,
         }
     }
 
-    fn new_direct(id: &'a Id) -> Self {
+    fn new_direct(id: &'a IdRef) -> Self {
         Self {
             current_id: id,
             final_underlying_id: id,
@@ -242,21 +272,22 @@ impl<'a> Definition<'a> {
 struct NameResolution<'a> {
     /// Module Id -> { name -> (id, is_public) } for items directly defined in that module.
     /// Not just public names, since private names can shadow pub glob-exported names.
-    names_defined_in_module: HashMap<&'a Id, HashMap<NamespacedName<'a>, (Definition<'a>, bool)>>,
+    names_defined_in_module:
+        HashMap<&'a IdRef, HashMap<NamespacedName<'a>, (Definition<'a>, bool)>>,
 
     /// Modules and the glob imports they contain.
-    modules_with_glob_imports: HashMap<&'a Id, HashSet<&'a Id>>,
+    modules_with_glob_imports: HashMap<&'a IdRef, HashSet<&'a IdRef>>,
 
     /// Names that were glob-imported and re-exported into a module, together with
     /// the item Id to which they refer. This is because glob-glob name shadowing doesn't apply
     /// if both names point to the same item.
-    glob_imported_names_in_module: HashMap<&'a Id, HashMap<NamespacedName<'a>, Definition<'a>>>,
+    glob_imported_names_in_module: HashMap<&'a IdRef, HashMap<NamespacedName<'a>, Definition<'a>>>,
 
     /// Names in a module that were glob-imported more than once, and are therefore unusable.
-    duplicated_glob_names_in_module: HashMap<&'a Id, HashSet<NamespacedName<'a>>>,
+    duplicated_glob_names_in_module: HashMap<&'a IdRef, HashSet<NamespacedName<'a>>>,
 }
 
-fn compute_parent_ids_for_public_items(crate_: &Crate) -> HashMap<&Id, Vec<&Id>> {
+fn compute_parent_ids_for_public_items(crate_: &Crate) -> HashMap<&IdRef, Vec<&IdRef>> {
     let root_id = &crate_.root;
 
     if let Some(root_module) = crate_.index.get(root_id) {
@@ -264,7 +295,7 @@ fn compute_parent_ids_for_public_items(crate_: &Crate) -> HashMap<&Id, Vec<&Id>>
             let traversal_state = resolve_crate_names(crate_);
 
             // Avoid cycles by keeping track of which items we're in the middle of visiting.
-            let mut currently_visited_items: HashSet<&Id> = Default::default();
+            let mut currently_visited_items: HashSet<&IdRef> = Default::default();
 
             let mut result = Default::default();
 
@@ -377,9 +408,9 @@ fn resolve_crate_names(crate_: &Crate) -> NameResolution<'_> {
                 if imp.glob {
                     result
                         .modules_with_glob_imports
-                        .entry(&item.id)
+                        .entry(item.id.as_ref())
                         .or_default()
-                        .insert(inner_id);
+                        .insert(inner_id.as_ref());
                 } else if let Some(target) = imp.id.as_ref().and_then(|id| crate_.index.get(id)) {
                     if imp.name == "_" {
                         // `_` is a special name which causes the imported item to be available
@@ -416,11 +447,12 @@ fn resolve_crate_names(crate_: &Crate) -> NameResolution<'_> {
                         let Some(final_underlying_id) = final_underlying_id else {
                             continue;
                         };
-                        let definition = Definition::new(inner_id, final_underlying_id);
+                        let definition =
+                            Definition::new(inner_id.as_ref(), final_underlying_id.as_ref());
 
                         result
                             .names_defined_in_module
-                            .entry(&item.id)
+                            .entry(item.id.as_ref())
                             .or_default()
                             .insert(
                                 name,
@@ -438,12 +470,12 @@ fn resolve_crate_names(crate_: &Crate) -> NameResolution<'_> {
                 for name in get_names_for_item(crate_, inner_item) {
                     result
                         .names_defined_in_module
-                        .entry(&item.id)
+                        .entry(item.id.as_ref())
                         .or_default()
                         .insert(
                             name,
                             (
-                                Definition::new_direct(&inner_item.id),
+                                Definition::new_direct(inner_item.id.as_ref()),
                                 matches!(
                                     inner_item.visibility,
                                     Visibility::Public | Visibility::Default
@@ -462,7 +494,7 @@ fn resolve_crate_names(crate_: &Crate) -> NameResolution<'_> {
 
 fn resolve_glob_imported_names<'a>(crate_: &'a Crate, traversal_state: &mut NameResolution<'a>) {
     for (&module_id, globs) in &traversal_state.modules_with_glob_imports {
-        let mut visited: HashSet<&Id> = Default::default();
+        let mut visited: HashSet<&IdRef> = Default::default();
         let mut names = Default::default();
         let mut duplicated_names = Default::default();
 
@@ -504,10 +536,10 @@ fn resolve_glob_imported_names<'a>(crate_: &'a Crate, traversal_state: &mut Name
 
 fn recursively_compute_visited_names_for_glob<'a>(
     crate_: &'a Crate,
-    glob_parent_module_id: &'a Id,
-    glob_id: &'a Id,
+    glob_parent_module_id: &'a IdRef,
+    glob_id: &'a IdRef,
     traversal_state: &NameResolution<'a>,
-    visited: &mut HashSet<&'a Id>,
+    visited: &mut HashSet<&'a IdRef>,
     names: &mut HashMap<NamespacedName<'a>, Definition<'a>>,
     duplicated_names: &mut HashSet<NamespacedName<'a>>,
 ) {
@@ -536,7 +568,7 @@ fn recursively_compute_visited_names_for_glob<'a>(
                 register_name(
                     module_local_items,
                     name,
-                    Definition::new_direct(variant_id),
+                    Definition::new_direct(variant_id.as_ref()),
                     names,
                     duplicated_names,
                 );
@@ -545,7 +577,7 @@ fn recursively_compute_visited_names_for_glob<'a>(
         return;
     }
 
-    let module_id = target_id;
+    let module_id = target_id.as_ref();
     if !visited.insert(module_id) {
         // Already checked this module.
         return;
@@ -616,11 +648,11 @@ fn register_name<'a>(
 /// Collect all public items that are reachable from the crate root and record their parent Ids.
 fn visit_root_reachable_public_items<'a>(
     crate_: &'a Crate,
-    parents: &mut HashMap<&'a Id, Vec<&'a Id>>,
+    parents: &mut HashMap<&'a IdRef, Vec<&'a IdRef>>,
     traversal_state: &NameResolution<'a>,
-    currently_visited_items: &mut HashSet<&'a Id>,
+    currently_visited_items: &mut HashSet<&'a IdRef>,
     item: &'a Item,
-    parent_id: Option<&'a Id>,
+    parent_id: Option<&'a IdRef>,
 ) {
     match item.visibility {
         Visibility::Crate | Visibility::Restricted { .. } => {
@@ -636,18 +668,18 @@ fn visit_root_reachable_public_items<'a>(
         }
     }
 
-    let item_parents = parents.entry(&item.id).or_default();
+    let item_parents = parents.entry(item.id.as_ref()).or_default();
     if let Some(parent_id) = parent_id {
         item_parents.push(parent_id);
     }
 
-    if !currently_visited_items.insert(&item.id) {
+    if !currently_visited_items.insert(item.id.as_ref()) {
         // We found a cycle in the import graph, and we've already processed this item.
         // Nothing more to do here.
         return;
     }
 
-    let next_parent_id = Some(&item.id);
+    let next_parent_id = Some(item.id.as_ref());
     match &item.inner {
         rustdoc_types::ItemEnum::Module(m) => {
             for inner in m.items.iter().filter_map(|id| crate_.index.get(id)) {
@@ -664,7 +696,9 @@ fn visit_root_reachable_public_items<'a>(
             // Explicitly process items imported via globs inside this module,
             // since the logic there is not item-wise: it requires
             // knowledge of the other names defined in the module.
-            if let Some(glob_imports) = traversal_state.glob_imported_names_in_module.get(&item.id)
+            if let Some(glob_imports) = traversal_state
+                .glob_imported_names_in_module
+                .get(item.id.as_ref())
             {
                 for inner_defn in glob_imports.values() {
                     if let Some(inner_item) = crate_.index.get(inner_defn.current_id) {
@@ -806,7 +840,7 @@ fn visit_root_reachable_public_items<'a>(
     }
 
     // We are leaving this item. Remove it from the visited set.
-    let removed = currently_visited_items.remove(&item.id);
+    let removed = currently_visited_items.remove(item.id.as_ref());
     assert!(removed);
 }
 


### PR DESCRIPTION
We use `&Id` in many places. As `Id` is defined as `struct Id(pub
String)` this is a ptr-to-ptr situation. By using `&IdRef(str)` we
remove that indirection, this increases memory usage as `&IdRef` is now
a "wide" ptr (ptr and length) instead of a "thin" ptr, but the perf win
is worth it:

```console
(32418dd)❯ cargo criterion --bench indexed_crate
                        time:   [1.3590 s 1.3599 s 1.3609 s]

(changes)❯ cargo criterion --bench indexed_crate
IndexedCrate/new(aws-sdk-ec2)
                        time:   [1.2456 s 1.2466 s 1.2478 s]
                        change: [-8.4413% -8.3275% -8.2222%] (p = 0.00 < 0.05)
                        Performance has improved.

(32418dd)❯ cargo criterion --bench indexed_crate --features rayon
IndexedCrate/new(aws-sdk-ec2)
                        time:   [571.63 ms 572.93 ms 574.23 ms]

(changes)❯ cargo criterion --bench indexed_crate --features rayon
IndexedCrate/new(aws-sdk-ec2)
                        time:   [501.28 ms 502.32 ms 503.34 ms]
                        change: [-12.596% -12.324% -12.053%] (p = 0.00 < 0.05)
                        Performance has improved.
```

The discussions on Zulip propose changing the `Id` definition in
`rustdoc-types` to `u64` or even `u32`, but while we wait for this
change to land (and for older `rustdoc` versions), this should be a nice
perf improvement.

The improvements are bigger when using `rayon`, because we spend more
time on `visibility_tracker` stuff (which is where the biggest
improvements are).

Co-authored-by: Predrag Gruevski <2348618+obi1kenobi@users.noreply.github.com>
