### PR TITLE
feat: add feature to use rustc-hash (#423)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,6 +496,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+
+[[package]]
 name = "rustdoc-types"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,6 +647,7 @@ dependencies = [
  "itertools 0.12.1",
  "maplit",
  "rayon",
+ "rustc-hash",
  "rustdoc-types",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ readme = "./README.md"
 trustfall = "0.7.1"
 rustdoc-types = "0.28.0"
 rayon = { version = "1.10.0", optional = true }
+rustc-hash = { version = "2.0.0", optional = true }
 
 [features]
 default = []
@@ -21,6 +22,8 @@ default = []
 # performance on big crates, but may impact performance on small crates and
 # definitely increases the memory usage
 rayon = ["dep:rayon"]
+# Use rustc-hash::{FxHashMap, FxHashSet} internally for improved performance
+rustc-hash = ["dep:rustc-hash"]
 
 [[bench]]
 name = "indexed_crate"

--- a/src/visibility_tracker.rs
+++ b/src/visibility_tracker.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "rustc-hash")]
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+#[cfg(not(feature = "rustc-hash"))]
 use std::collections::{HashMap, HashSet};
 
 use rustdoc_types::{Crate, GenericArgs, Id, Item, ItemEnum, TypeAlias, Visibility};


### PR DESCRIPTION
We use `rustc-hash::FxHashMap/Set` on src/visibility_tracker.rs this is
an implementation detail as AFAIK all types there are `pub(crate)` so we
never return an `FxHashMap` or `FxHashSet` on a public interface.

This bring a nice perf increase:

```console
❯ cargo criterion --bench indexed_crate
IndexedCrate/new(aws-sdk-ec2)
                        time:   [1.3474 s 1.3506 s 1.3537 s]
                        change: [+4.4411% +4.8278% +5.2381%] (p = 0.00 < 0.05)
                        Performance has regressed.

❯ cargo criterion --bench indexed_crate --features rustc-hash
IndexedCrate/new(aws-sdk-ec2)
                        time:   [1.1555 s 1.1561 s 1.1567 s]
                        change: [-14.603% -14.405% -14.192%] (p = 0.00 < 0.05)
                        Performance has improved.

❯ cargo criterion --bench indexed_crate --features rayon
IndexedCrate/new(aws-sdk-ec2)
                        time:   [577.26 ms 578.45 ms 579.70 ms]
                        change: [-50.083% -49.964% -49.852%] (p = 0.00 < 0.05)
                        Performance has improved.

❯ cargo criterion --bench indexed_crate --features rayon,rustc-hash
IndexedCrate/new(aws-sdk-ec2)
                        time:   [486.94 ms 488.49 ms 490.13 ms]
                        change: [-15.862% -15.552% -15.212%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Co-authored-by: Predrag Gruevski <2348618+obi1kenobi@users.noreply.github.com>
