### PR TITLE
Allow `supertrait` edge to resolve to common built-in traits too.

### DIFF
--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -487,10 +487,11 @@ pub(super) fn resolve_implemented_trait_property<'a, V: AsVertex<Vertex<'a>> + '
 ) -> ContextOutcomeIterator<'a, V, FieldValue> {
     match property_name {
         "name" => resolve_property_with(contexts, |vertex| {
-            let (path, _) = vertex
+            let (_, item) = vertex
                 .as_implemented_trait()
                 .expect("not an ImplementedTrait");
-            path.name.clone().into()
+
+            item.name.clone().into()
         }),
         _ => unreachable!("ImplementedTrait property {property_name}"),
     }

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -135,8 +135,10 @@ fn rustdoc_finds_supertrait() {
     Crate {
         item {
             ... on Trait {
+                name @output
+
                 supertrait {
-                    name @output
+                    supertrait: name @output
                 }
             }
         }
@@ -152,6 +154,7 @@ fn rustdoc_finds_supertrait() {
     #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
     struct Output {
         name: String,
+        supertrait: String,
     }
 
     let mut results: Vec<_> =
@@ -164,10 +167,23 @@ fn rustdoc_finds_supertrait() {
     similar_asserts::assert_eq!(
         vec![
             Output {
-                name: "Supertrait".into(),
+                name: "DebugPartialOrd".into(),
+                // We *specifically* require the supertrait name to be "Debug",
+                // not "std::fmt::Debug" or any other option. Failing to do this
+                // could cause false-positives in cargo-semver-checks.
+                supertrait: "Debug".into(),
             },
             Output {
-                name: "Supertrait2".into(),
+                name: "DebugPartialOrd".into(),
+                supertrait: "PartialOrd".into(),
+            },
+            Output {
+                name: "MyTrait".into(),
+                supertrait: "Supertrait".into(),
+            },
+            Output {
+                name: "MyTrait".into(),
+                supertrait: "Supertrait2".into(),
             },
         ],
         results

--- a/test_crates/supertrait/src/lib.rs
+++ b/test_crates/supertrait/src/lib.rs
@@ -2,4 +2,9 @@ pub trait Supertrait {}
 
 pub trait Supertrait2 {}
 
-pub trait BaseTrait : Supertrait2 + Supertrait {}
+pub trait MyTrait : Supertrait2 + Supertrait {}
+
+// Ensure `std::fmt::Debug` is a supertrait here, verbatim.
+// It's a load-bearing part of the test, since we want our query output names to be invariant
+// to how they are written down in the source.
+pub trait DebugPartialOrd : std::fmt::Debug + PartialOrd {}


### PR DESCRIPTION
Resolves the issue observed in https://github.com/obi1kenobi/cargo-semver-checks/pull/892#issuecomment-2316625767