### PR TITLE
Re-apply missing commits onto rustdoc-v33

### DIFF
--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -723,3 +723,25 @@ pub(super) fn resolve_attribute_meta_item_edge<'a, V: AsVertex<Vertex<'a>> + 'a>
         _ => unreachable!("resolve_attribute_meta_item_edge {edge_name}"),
     }
 }
+
+pub(super) fn resolve_derive_proc_macro_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
+    contexts: ContextIterator<'a, V>,
+    edge_name: &str,
+) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
+    match edge_name {
+        "helper_attribute" => resolve_neighbors_with(contexts, move |vertex| {
+            let origin = vertex.origin;
+
+            let proc_macro = vertex
+                .as_proc_macro()
+                .expect("vertex was not a DeriveProcMacro");
+            Box::new(
+                proc_macro
+                    .helpers
+                    .iter()
+                    .map(move |helper| origin.make_derive_helper_attr_vertex(helper)),
+            )
+        }),
+        _ => unreachable!("resolve_derive_proc_macro_edge {edge_name}"),
+    }
+}

--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -188,6 +188,29 @@ pub(super) fn resolve_function_like_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     }
 }
 
+pub(super) fn resolve_generic_parameter_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
+    contexts: ContextIterator<'a, V>,
+    edge_name: &str,
+) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
+    match edge_name {
+        "generic_parameter" => resolve_neighbors_with(contexts, move |vertex| {
+            let origin = vertex.origin;
+            Box::new(
+                vertex
+                    .as_generics()
+                    .map(move |g| {
+                        g.params
+                            .iter()
+                            .map(move |param| origin.make_generic_parameter_vertex(param))
+                    })
+                    .into_iter()
+                    .flatten(),
+            )
+        }),
+        _ => unreachable!("resolve_generic_parameter_edge {edge_name}"),
+    }
+}
+
 pub(super) fn resolve_module_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     edge_name: &str,
@@ -741,6 +764,70 @@ pub(super) fn resolve_derive_proc_macro_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
                     .iter()
                     .map(move |helper| origin.make_derive_helper_attr_vertex(helper)),
             )
+        }),
+        _ => unreachable!("resolve_derive_proc_macro_edge {edge_name}"),
+    }
+}
+
+pub(super) fn resolve_generic_type_parameter_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
+    contexts: ContextIterator<'a, V>,
+    edge_name: &str,
+    current_crate: &'a IndexedCrate<'a>,
+    previous_crate: Option<&'a IndexedCrate<'a>>,
+) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
+    match edge_name {
+        "type_bound" => resolve_neighbors_with(contexts, move |vertex| {
+            let origin = vertex.origin;
+            let item_index = match origin {
+                Origin::CurrentCrate => &current_crate.inner.index,
+                Origin::PreviousCrate => {
+                    &previous_crate
+                        .expect("no previous crate provided")
+                        .inner
+                        .index
+                }
+            };
+
+            let generic = vertex
+                .as_generic_parameter()
+                .expect("vertex was not a GenericTypeParameter");
+
+            match &generic.kind {
+                rustdoc_types::GenericParamDefKind::Type { bounds, .. } => {
+                    Box::new(bounds.iter().filter_map(move |bound| {
+                        if let TraitBound { trait_, .. } = &bound {
+                            // When the implemented trait is from the same crate
+                            // as its definition, the trait is expected to be present
+                            // in `item_index`. Otherwise, the
+                            // `rustdoc_types::Trait` is not in this rustdoc,
+                            // even if the trait is part of Rust `core` or `std`.
+                            // As a temporary workaround, some common
+                            // Rust built-in traits are manually "inlined"
+                            // with items stored in `manually_inlined_builtin_traits`.
+                            let found_item = item_index.get(&trait_.id).or_else(|| {
+                                let manually_inlined_builtin_traits = match origin {
+                                    Origin::CurrentCrate => {
+                                        &current_crate.manually_inlined_builtin_traits
+                                    }
+                                    Origin::PreviousCrate => {
+                                        &previous_crate
+                                            .expect("no previous crate provided")
+                                            .manually_inlined_builtin_traits
+                                    }
+                                };
+                                manually_inlined_builtin_traits.get(&trait_.id)
+                            });
+
+                            found_item.map(|next_item| {
+                                origin.make_implemented_trait_vertex(trait_, next_item)
+                            })
+                        } else {
+                            None
+                        }
+                    }))
+                }
+                _ => unreachable!("vertex was not a GenericTypeParameter: {vertex:?}"),
+            }
         }),
         _ => unreachable!("resolve_derive_proc_macro_edge {edge_name}"),
     }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -95,7 +95,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                 "ImplOwner" | "Struct" | "StructField" | "Enum" | "Variant" | "PlainVariant"
                 | "TupleVariant" | "StructVariant" | "Union" | "Trait" | "Function" | "Method"
                 | "Impl" | "GlobalValue" | "Constant" | "Static" | "AssociatedType"
-                | "AssociatedConstant" | "Module"
+                | "AssociatedConstant" | "Module" | "Macro"
                     if matches!(
                         property_name.as_ref(),
                         "id" | "crate_id"
@@ -192,7 +192,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
             "Item" | "ImplOwner" | "Struct" | "StructField" | "Enum" | "Variant"
             | "PlainVariant" | "TupleVariant" | "Union" | "StructVariant" | "Trait"
             | "Function" | "Method" | "Impl" | "GlobalValue" | "Constant" | "Static"
-            | "AssociatedType" | "AssociatedConstant" | "Module"
+            | "AssociatedType" | "AssociatedConstant" | "Module" | "Macro"
                 if matches!(edge_name.as_ref(), "span" | "attribute") =>
             {
                 edges::resolve_item_edge(contexts, edge_name)
@@ -304,5 +304,6 @@ pub(crate) fn supported_item_kind(item: &Item) -> bool {
             | rustdoc_types::ItemEnum::Static(..)
             | rustdoc_types::ItemEnum::AssocType { .. }
             | rustdoc_types::ItemEnum::Module { .. }
+            | rustdoc_types::ItemEnum::Macro { .. }
     )
 }

--- a/src/adapter/origin.rs
+++ b/src/adapter/origin.rs
@@ -118,4 +118,11 @@ impl Origin {
             kind: VertexKind::Variant(EnumVariant::new(item, discriminants, index)),
         }
     }
+
+    pub(super) fn make_derive_helper_attr_vertex<'a>(&self, helper: &'a str) -> Vertex<'a> {
+        Vertex {
+            origin: *self,
+            kind: VertexKind::DeriveHelperAttr(helper),
+        }
+    }
 }

--- a/src/adapter/origin.rs
+++ b/src/adapter/origin.rs
@@ -125,4 +125,14 @@ impl Origin {
             kind: VertexKind::DeriveHelperAttr(helper),
         }
     }
+
+    pub(super) fn make_generic_parameter_vertex<'a>(
+        &self,
+        param: &'a rustdoc_types::GenericParamDef,
+    ) -> Vertex<'a> {
+        Vertex {
+            origin: *self,
+            kind: VertexKind::GenericParameter(param),
+        }
+    }
 }

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -594,3 +594,19 @@ pub(crate) fn resolve_discriminant_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
         _ => unreachable!("Discriminant property {property_name}"),
     }
 }
+
+pub(crate) fn resolve_derive_macro_helper_attribute_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
+    contexts: ContextIterator<'a, V>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, V, FieldValue> {
+    match property_name {
+        "name" => resolve_property_with(contexts, |vertex| {
+            vertex
+                .as_derive_helper_attr()
+                .expect("vertex was not a DeriveMacroHelperAttribute")
+                .to_string()
+                .into()
+        }),
+        _ => unreachable!("DeriveMacroHelperAttribute property {property_name}"),
+    }
+}

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -651,9 +651,7 @@ pub(crate) fn resolve_generic_type_parameter_property<'a, V: AsVertex<Vertex<'a>
                 .expect("vertex was not a GenericTypeParameter");
 
             match &generic.kind {
-                rustdoc_types::GenericParamDefKind::Type { is_synthetic, .. } => {
-                    (*is_synthetic).into()
-                }
+                rustdoc_types::GenericParamDefKind::Type { synthetic, .. } => (*synthetic).into(),
                 _ => unreachable!("vertex was not a GenericTypeParameter: {vertex:?}"),
             }
         }),

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -610,3 +610,74 @@ pub(crate) fn resolve_derive_macro_helper_attribute_property<'a, V: AsVertex<Ver
         _ => unreachable!("DeriveMacroHelperAttribute property {property_name}"),
     }
 }
+
+pub(crate) fn resolve_generic_parameter_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
+    contexts: ContextIterator<'a, V>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, V, FieldValue> {
+    match property_name {
+        "name" => resolve_property_with(contexts, |vertex| {
+            vertex
+                .as_generic_parameter()
+                .expect("vertex was not a GenericParameter")
+                .name
+                .clone()
+                .into()
+        }),
+        _ => unreachable!("GenericParameter property {property_name}"),
+    }
+}
+
+pub(crate) fn resolve_generic_type_parameter_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
+    contexts: ContextIterator<'a, V>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, V, FieldValue> {
+    match property_name {
+        "has_default" => resolve_property_with(contexts, |vertex| {
+            let generic = vertex
+                .as_generic_parameter()
+                .expect("vertex was not a GenericTypeParameter");
+
+            match &generic.kind {
+                rustdoc_types::GenericParamDefKind::Type { default, .. } => {
+                    default.is_some().into()
+                }
+                _ => unreachable!("vertex was not a GenericTypeParameter: {vertex:?}"),
+            }
+        }),
+        "synthetic" => resolve_property_with(contexts, |vertex| {
+            let generic = vertex
+                .as_generic_parameter()
+                .expect("vertex was not a GenericTypeParameter");
+
+            match &generic.kind {
+                rustdoc_types::GenericParamDefKind::Type { is_synthetic, .. } => {
+                    (*is_synthetic).into()
+                }
+                _ => unreachable!("vertex was not a GenericTypeParameter: {vertex:?}"),
+            }
+        }),
+        _ => unreachable!("GenericTypeParameter property {property_name}"),
+    }
+}
+
+pub(crate) fn resolve_generic_const_parameter_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
+    contexts: ContextIterator<'a, V>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, V, FieldValue> {
+    match property_name {
+        "has_default" => resolve_property_with(contexts, |vertex| {
+            let generic = vertex
+                .as_generic_parameter()
+                .expect("vertex was not a GenericConstParameter");
+
+            match &generic.kind {
+                rustdoc_types::GenericParamDefKind::Const { default, .. } => {
+                    default.is_some().into()
+                }
+                _ => unreachable!("vertex was not a GenericConstParameter: {vertex:?}"),
+            }
+        }),
+        _ => unreachable!("GenericConstParameter property {property_name}"),
+    }
+}

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -2277,3 +2277,138 @@ fn declarative_macros() {
 
     similar_asserts::assert_eq!(expected_results, results);
 }
+
+#[test]
+fn proc_macros() {
+    let path = "./localdata/test_data/proc_macros/rustdoc.json";
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
+        .expect("failed to load rustdoc");
+
+    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
+    let indexed_crate = IndexedCrate::new(&crate_);
+    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on ProcMacro {
+                kind: __typename @output
+                name @output
+                public_api_eligible @output
+                visibility_limit @output
+            }
+        }
+    }
+}
+"#;
+
+    let variables: BTreeMap<&str, &str> = BTreeMap::default();
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        kind: String,
+        name: String,
+        public_api_eligible: bool,
+        visibility_limit: String,
+    }
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    // We write the results in the order the items appear in the test file,
+    // and sort them afterward in order to compare with the (sorted) query results.
+    // This makes it easier to verify that the expected data here is correct
+    // by reading it side-by-side with the file.
+    let mut expected_results = vec![
+        Output {
+            kind: "FunctionLikeProcMacro".into(),
+            name: "make_answer".into(),
+            public_api_eligible: true,
+            visibility_limit: "public".into(),
+        },
+        Output {
+            kind: "AttributeProcMacro".into(),
+            name: "return_as_is".into(),
+            public_api_eligible: true,
+            visibility_limit: "public".into(),
+        },
+        Output {
+            kind: "DeriveProcMacro".into(),
+            name: "AnswerFn".into(),
+            public_api_eligible: true,
+            visibility_limit: "public".into(),
+        },
+        Output {
+            kind: "DeriveProcMacro".into(),
+            name: "HelperAttr".into(),
+            public_api_eligible: true,
+            visibility_limit: "public".into(),
+        },
+        Output {
+            kind: "FunctionLikeProcMacro".into(),
+            name: "hidden".into(),
+            public_api_eligible: false,
+            visibility_limit: "public".into(),
+        },
+    ];
+    expected_results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+
+    // Ensure that derive macro helper attributes can be queried correctly.
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on DeriveProcMacro {
+                name @output
+
+                helper_attribute {
+                    attr: name @output
+                }
+            }
+        }
+    }
+}
+"#;
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct DeriveOutput {
+        name: String,
+        attr: String,
+    }
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    // We write the results in the order the items appear in the test file,
+    // and sort them afterward in order to compare with the (sorted) query results.
+    // This makes it easier to verify that the expected data here is correct
+    // by reading it side-by-side with the file.
+    let mut expected_results = vec![
+        DeriveOutput {
+            name: "HelperAttr".into(),
+            attr: "helper".into(),
+        },
+        DeriveOutput {
+            name: "HelperAttr".into(),
+            attr: "second".into(),
+        },
+    ];
+    expected_results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+}

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -254,6 +254,10 @@ fn rustdoc_sealed_traits() {
             sealed: true,
         },
         Output {
+            name: "SealedWithWhereSelfBound".into(),
+            sealed: true,
+        },
+        Output {
             name: "PrivateSealed".into(),
             sealed: true,
         },

--- a/src/adapter/vertex.rs
+++ b/src/adapter/vertex.rs
@@ -63,6 +63,7 @@ impl Typename for Vertex<'_> {
                 rustdoc_types::ItemEnum::Constant { .. } => "Constant",
                 rustdoc_types::ItemEnum::Static(..) => "Static",
                 rustdoc_types::ItemEnum::AssocType { .. } => "AssociatedType",
+                rustdoc_types::ItemEnum::Macro { .. } => "Macro",
                 _ => unreachable!("unexpected item.inner for item: {item:?}"),
             },
             VertexKind::Span(..) => "Span",

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -92,6 +92,66 @@ interface Item {
 }
 
 """
+An item that can have generic parameters.
+"""
+interface GenericItem implements Item {
+  id: String!
+  crate_id: Int!
+  name: String
+  docs: String
+
+  """
+  A list of all the attributes applied to this item.
+
+  The attributes are also available through the `attribute` edge,
+  which makes certain operations easier.
+  """
+  attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
+  # stringified version of the visibility struct field
+  visibility_limit: String!
+
+  attribute: [Attribute!]
+  span: Span
+
+  """
+  Generic type, lifetime, or const parameters by which this item is parameterized.
+  """
+  generic_parameter: [GenericParameter]
+}
+
+"""
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Item.html
 https://docs.rs/rustdoc-types/0.16.0/rustdoc_types/struct.Module.html
 """
@@ -157,7 +217,7 @@ https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Item.html
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/enum.ItemEnum.html
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Struct.html
 """
-type Struct implements Item & Importable & ImplOwner {
+type Struct implements Item & Importable & ImplOwner & GenericItem {
   # properties from Item
   id: String!
   crate_id: Int!
@@ -234,6 +294,12 @@ type Struct implements Item & Importable & ImplOwner {
   """
   inherent_impl: [Impl!]
 
+  # edges from GenericItem
+  """
+  Generic type, lifetime, or const parameters by which this struct is parameterized.
+  """
+  generic_parameter: [GenericParameter]
+
   # own edges
   field: [StructField!]
 }
@@ -297,7 +363,7 @@ https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Item.html
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/enum.ItemEnum.html
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Enum.html
 """
-type Enum implements Item & Importable & ImplOwner {
+type Enum implements Item & Importable & ImplOwner & GenericItem {
   # properties from Item
   id: String!
   crate_id: Int!
@@ -372,6 +438,12 @@ type Enum implements Item & Importable & ImplOwner {
   When Trustfall supports macro edges, this should just become a macro edge.
   """
   inherent_impl: [Impl!]
+
+  # edges from GenericItem
+  """
+  Generic type, lifetime, or const parameters by which this enum is parameterized.
+  """
+  generic_parameter: [GenericParameter]
 
   # own edges
   variant: [Variant!]
@@ -689,7 +761,7 @@ https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Item.html
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/enum.ItemEnum.html
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Union.html
 """
-type Union implements Item & Importable & ImplOwner {
+type Union implements Item & Importable & ImplOwner & GenericItem {
   # properties from Item
   id: String!
   crate_id: Int!
@@ -764,6 +836,12 @@ type Union implements Item & Importable & ImplOwner {
   When Trustfall supports macro edges, this should just become a macro edge.
   """
   inherent_impl: [Impl!]
+
+  # edges from GenericItem
+  """
+  Generic type, lifetime, or const parameters by which this union is parameterized.
+  """
+  generic_parameter: [GenericParameter]
 
   # own edges
   field: [StructField!]
@@ -951,7 +1029,7 @@ https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Item.html
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/enum.ItemEnum.html
 https://docs.rs/rustdoc-types/latest/rustdoc_types/struct.Trait.html
 """
-type Trait implements Item & Importable {
+type Trait implements Item & Importable & GenericItem {
   # properties from Item
   id: String!
   crate_id: Int!
@@ -1018,6 +1096,12 @@ type Trait implements Item & Importable {
   # edges from Importable
   importable_path: [ImportablePath!]
   canonical_path: Path
+
+  # edges from GenericItem
+  """
+  Generic type, lifetime, or const parameters by which this trait is parameterized.
+  """
+  generic_parameter: [GenericParameter]
 
   # own edges
   """
@@ -1170,7 +1254,7 @@ https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Item.html
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/enum.ItemEnum.html
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Function.html
 """
-type Function implements Item & FunctionLike & Importable {
+type Function implements Item & FunctionLike & Importable & GenericItem {
   # properties from Item
   id: String!
   crate_id: Int!
@@ -1252,6 +1336,12 @@ type Function implements Item & FunctionLike & Importable {
   # edges from Importable
   importable_path: [ImportablePath!]
   canonical_path: Path
+
+  # edges from GenericItem
+  """
+  Generic type, lifetime, or const parameters by which this function is parameterized.
+  """
+  generic_parameter: [GenericParameter]
 }
 
 """
@@ -1259,7 +1349,7 @@ https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Item.html
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/enum.ItemEnum.html
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Method.html
 """
-type Method implements Item & FunctionLike {
+type Method implements Item & FunctionLike & GenericItem {
   # properties from Item
   id: String!
   crate_id: Int!
@@ -1313,6 +1403,15 @@ type Method implements Item & FunctionLike {
   # edges from FunctionLike
   parameter: [FunctionParameter!]
   abi: FunctionAbi!
+
+  # edges from GenericItem
+  """
+  Generic type, lifetime, or const parameters by which this method is parameterized.
+
+  This only includes the *method's own* generic parameters. It does not include
+  any generic parameters that may be part of the definition of the type that owns the method.
+  """
+  generic_parameter: [GenericParameter]
 }
 
 """
@@ -2088,6 +2187,106 @@ type DeriveMacroHelperAttribute {
   The name of the helper attribute.
   """
   name: String!
+}
+
+interface GenericParameter {
+  """
+  The name of the generic parameter.
+
+  For example:
+  - `"T"` as a generic type
+  - `"'a"` as a generic lifetime
+  - `"N"` as a generic constant
+  """
+  name: String!
+}
+
+type GenericTypeParameter implements GenericParameter {
+  # properties from GenericParameter
+  """
+  The name of the generic parameter.
+
+  For example:
+  - `"T"` as a generic type
+  - `"'a"` as a generic lifetime
+  - `"N"` as a generic constant
+  """
+  name: String!
+
+  """
+  Whether the generic type parameter has a default value.
+  """
+  has_default: Boolean!
+
+  """
+  Whether the type parameter is synthetic.
+
+  This is normally `false`, which means that this generic parameter is
+  declared in the Rust source text.
+
+  If it is `true`, this generic parameter has been introduced by the
+  compiler behind the scenes, for example in `impl Trait` uses:
+  `fn f(_: impl Trait) {}` is transformed by the compiler into (pseudo-Rust)
+  `fn f<impl Trait: Trait>(_: impl Trait) {}`. In this example,
+  the generic parameter named `impl Trait` is synthetic because
+  it was not originally in the Rust source text.
+  """
+  synthetic: Boolean!
+
+  # own edges
+  """
+  Type bounds applied specifically to this generic type parameter.
+
+  For example:
+  - For `<T: Clone + PartialEq<i64>>`, this edge would have two instances
+    pointing to each of `Clone` and `PartialEq<i64>`.
+  - For `impl Trait<'a, T, i64>`, this edge would point to `Trait<'a, T, i64>`.
+
+  Bounds involving this type parameter but not specifically applying to it are not included.
+  For example, for type parameter `T`, a bound like `Arc<T>: Clone` wouldn't be included here.
+  """
+  type_bound: [ImplementedTrait!]
+
+  # TODO: needs lifetime bounds
+  # lifetime_bound: ?
+}
+
+type GenericLifetimeParameter implements GenericParameter {
+  # properties from GenericParameter
+  """
+  The name of the generic parameter.
+
+  For example:
+  - `"T"` as a generic type
+  - `"'a"` as a generic lifetime
+  - `"N"` as a generic constant
+  """
+  name: String!
+
+  # own edges
+  # TODO: needs lifetime bounds
+  # lifetime_bound: ?
+}
+
+type GenericConstParameter implements GenericParameter {
+  # properties from GenericParameter
+  """
+  The name of the generic parameter.
+
+  For example:
+  - `"T"` as a generic type
+  - `"'a"` as a generic lifetime
+  - `"N"` as a generic constant
+  """
+  name: String!
+
+  """
+  Whether the generic const parameter has a default value.
+  """
+  has_default: Boolean!
+
+  # own edges
+  # TODO: needs type and value
 }
 
 """

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -432,7 +432,7 @@ interface Variant implements Item {
 
   """
   The discriminant value of this variant, if its value is well-defined.
-  
+
   A discriminant is an integer value that is logically associated with an enum variant,
   and is used to determine which variant an enum value holds.
 
@@ -514,10 +514,10 @@ type PlainVariant implements Item & Variant {
 
   # edges from Variant
   field: [StructField!]
-  
+
   """
   The discriminant value of this variant, if its value is well-defined.
-  
+
   A discriminant is an integer value that is logically associated with an enum variant,
   and is used to determine which variant an enum value holds.
 
@@ -591,7 +591,7 @@ type TupleVariant implements Item & Variant {
 
   """
   The discriminant value of this variant, if its value is well-defined.
-  
+
   A discriminant is an integer value that is logically associated with an enum variant,
   and is used to determine which variant an enum value holds.
 
@@ -665,7 +665,7 @@ type StructVariant implements Item & Variant {
 
   """
   The discriminant value of this variant, if its value is well-defined.
-  
+
   A discriminant is an integer value that is logically associated with an enum variant,
   and is used to determine which variant an enum value holds.
 
@@ -1781,6 +1781,63 @@ type AssociatedConstant implements Item {
   # edges from Item
   span: Span
   attribute: [Attribute!]
+}
+
+"""
+A `macro_rules` declarative macro.
+
+When such macros are exported by a crate, they are always exported at the top level of the crate,
+even if the macro's definition is located inside a `mod`. In essence, the `#[macro_export]`
+attribute behaves as a `pub use` of the macro into the crate's root module.
+
+This is why we don't model macro items as `Importable`:
+- They always have only one importable path: `the_crate::macro_name`.
+- Their names are in their own namespace, and do not mix with the types or values namespaces.
+"""
+type Macro implements Item {
+  # properties from Item
+  id: String!
+  crate_id: Int!
+  name: String
+  docs: String
+  attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
+  visibility_limit: String!
+
+  # edges from Item
+  attribute: [Attribute!]
+  span: Span
 }
 
 """

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -1841,6 +1841,256 @@ type Macro implements Item {
 }
 
 """
+A procedural macro. Unlike declarative macros (`Macro`), expanding these macros runs Rust code.
+
+There are multiple kinds of procedural macros.
+More info: https://doc.rust-lang.org/reference/procedural-macros.html
+
+When such macros are exported by a crate, they are always exported at the top level of the crate.
+
+This is why we don't model macro items as `Importable`:
+- They always have only one importable path: `the_crate::macro_name`.
+- Their names are in their own namespace, and do not mix with the types or values namespaces.
+"""
+interface ProcMacro implements Item {
+  # properties from Item
+  id: String!
+  crate_id: Int!
+  name: String
+  docs: String
+  attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
+  visibility_limit: String!
+
+  # edges from Item
+  attribute: [Attribute!]
+  span: Span
+}
+
+"""
+A proc macro meant to be used as `my_macro!();`.
+
+More info:
+https://doc.rust-lang.org/reference/procedural-macros.html#function-like-procedural-macros
+
+When such macros are exported by a crate, they are always exported at the top level of the crate.
+
+This is why we don't model macro items as `Importable`:
+- They always have only one importable path: `the_crate::macro_name`.
+- Their names are in their own namespace, and do not mix with the types or values namespaces.
+"""
+type FunctionLikeProcMacro implements Item & ProcMacro {
+  # properties from Item
+  id: String!
+  crate_id: Int!
+  name: String
+  docs: String
+  attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
+  visibility_limit: String!
+
+  # edges from Item
+  attribute: [Attribute!]
+  span: Span
+}
+
+"""
+A proc macro meant to be used as `#[item_attribute]`.
+
+More info: https://doc.rust-lang.org/reference/procedural-macros.html#attribute-macros
+
+When such macros are exported by a crate, they are always exported at the top level of the crate.
+
+This is why we don't model macro items as `Importable`:
+- They always have only one importable path: `the_crate::macro_name`.
+- Their names are in their own namespace, and do not mix with the types or values namespaces.
+"""
+type AttributeProcMacro implements Item & ProcMacro {
+  # properties from Item
+  id: String!
+  crate_id: Int!
+  name: String
+  docs: String
+  attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
+  visibility_limit: String!
+
+  # edges from Item
+  attribute: [Attribute!]
+  span: Span
+}
+
+"""
+A proc macro meant to be used as a `#[derive(MyMacro)]`.
+
+More info: https://doc.rust-lang.org/reference/procedural-macros.html#derive-macros
+
+When such macros are exported by a crate, they are always exported at the top level of the crate.
+
+This is why we don't model macro items as `Importable`:
+- They always have only one importable path: `the_crate::MacroName`.
+- Their names are in their own namespace, and do not mix with the types or values namespaces.
+"""
+type DeriveProcMacro implements Item & ProcMacro {
+  # properties from Item
+  id: String!
+  crate_id: Int!
+  name: String
+  docs: String
+  attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
+  visibility_limit: String!
+
+  # edges from Item
+  attribute: [Attribute!]
+  span: Span
+
+  # own edges
+  """
+  Any additional helper attributes defined by this macro.
+  """
+  helper_attribute: [DeriveMacroHelperAttribute]
+}
+
+"""
+Derive proc macros may add additional attributes into the scope of the item where they are applied.
+Such additional attributes are called "derive macro helper attributes" and their only purpose is to
+be read by the derive proc macro.
+
+More info: https://doc.rust-lang.org/reference/procedural-macros.html#derive-macro-helper-attributes
+"""
+type DeriveMacroHelperAttribute {
+  """
+  The name of the helper attribute.
+  """
+  name: String!
+}
+
+"""
 A type represented in the "raw" rustdoc JSON representation.
 
 Copiously detailed, but not the easiest to use due to its complexity.

--- a/src/sealed_trait.rs
+++ b/src/sealed_trait.rs
@@ -1,4 +1,4 @@
-use rustdoc_types::{Item, Trait};
+use rustdoc_types::{GenericBound, Item, Trait};
 
 use crate::IndexedCrate;
 
@@ -69,53 +69,91 @@ fn is_method_sealed<'a>(indexed_crate: &IndexedCrate<'a>, trait_inner: &'a Trait
 }
 
 fn has_sealed_supertrait<'a>(indexed_crate: &IndexedCrate<'a>, inner: &'a Trait) -> bool {
-    for bound in &inner.bounds {
-        let supertrait = match bound {
-            rustdoc_types::GenericBound::TraitBound {
-                trait_: trait_path, ..
-            } => {
-                match indexed_crate.inner.index.get(&trait_path.id) {
-                    Some(item) => item,
-                    None => {
-                        // Item from another crate, so clearly not pub-in-priv.
+    for predicate in &inner.generics.where_predicates {
+        match predicate {
+            // Only `where Self: SomeTrait` predicates are relevant for sealed trait analysis.
+            // Ignore all other predicate types.
+            rustdoc_types::WherePredicate::BoundPredicate { type_, bounds, .. } => {
+                // If the predicate isn't over `Self`, it isn't relevant.
+                if matches!(type_, rustdoc_types::Type::Generic(generic) if generic.as_str() == "Self")
+                {
+                    for bound in bounds {
+                        // We found a trait similar to:
+                        // `pub trait Example where Self: SealedTrait { ... }`
                         //
-                        // TODO: Once we have the ability to do cross-crate analysis, consider
-                        //       whether this external trait is sealed. That can have
-                        //       some interesting SemVer implications as well.
-                        continue;
+                        // Even though `SealedTrait` isn't *explicitly* a supertrait,
+                        // any implementer of `Example` would still have to implement it too.
+                        // This makes it equivalent to a supertrait bound for purposes
+                        // of trait sealing. Apply the equivalent logic here.
+                        if is_sealed_supertrait_bound(indexed_crate, bound) {
+                            return true;
+                        }
                     }
                 }
             }
-            rustdoc_types::GenericBound::Outlives(_) | rustdoc_types::GenericBound::Use(_) => {
-                continue;
-            }
-        };
+            _ => continue,
+        }
+    }
 
-        // Otherwise, check if the supertrait is itself sealed.
-        // This catches cases like:
-        // ```rust
-        // mod priv {
-        //     pub trait Sealed {}
-        // }
-        //
-        // pub trait First: Sealed {}
-        //
-        // pub trait Second: First {}
-        // ```
-        //
-        // Here, both `First` and `Second` are sealed.
-        //
-        // N.B.: This cannot infinite-loop, since rustc denies cyclic trait bounds.
-        if is_trait_sealed(indexed_crate, supertrait) {
-            // The supertrait is sealed, so a downstream crate cannot add a direct impl for it
-            // on any of its own types.
-            //
-            // However, this isn't the same thing as "downstream types cannot impl this trait"!
-            // We must check the supertrait for blanket impls that might result in
-            // a downstream type gaining an impl for that trait.
-            if has_no_externally_satisfiable_blanket_impls(indexed_crate, supertrait) {
-                return true;
+    for bound in &inner.bounds {
+        if is_sealed_supertrait_bound(indexed_crate, bound) {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn is_sealed_supertrait_bound<'a>(
+    indexed_crate: &IndexedCrate<'a>,
+    bound: &'a GenericBound,
+) -> bool {
+    let supertrait = match bound {
+        rustdoc_types::GenericBound::TraitBound {
+            trait_: trait_path, ..
+        } => {
+            match indexed_crate.inner.index.get(&trait_path.id) {
+                Some(item) => item,
+                None => {
+                    // Item from another crate, so clearly not pub-in-priv.
+                    //
+                    // TODO: Once we have the ability to do cross-crate analysis, consider
+                    //       whether this external trait is sealed. That can have
+                    //       some interesting SemVer implications as well.
+                    return false;
+                }
             }
+        }
+        rustdoc_types::GenericBound::Outlives(_) | rustdoc_types::GenericBound::Use(_) => {
+            // Not a trait bound of any kind, nothing to check.
+            return false;
+        }
+    };
+
+    // Otherwise, check if the supertrait is itself sealed.
+    // This catches cases like:
+    // ```rust
+    // mod priv {
+    //     pub trait Sealed {}
+    // }
+    //
+    // pub trait First: Sealed {}
+    //
+    // pub trait Second: First {}
+    // ```
+    //
+    // Here, both `First` and `Second` are sealed.
+    //
+    // N.B.: This cannot infinite-loop, since rustc denies cyclic trait bounds.
+    if is_trait_sealed(indexed_crate, supertrait) {
+        // The supertrait is sealed, so a downstream crate cannot add a direct impl for it
+        // on any of its own types.
+        //
+        // However, this isn't the same thing as "downstream types cannot impl this trait"!
+        // We must check the supertrait for blanket impls that might result in
+        // a downstream type gaining an impl for that trait.
+        if has_no_externally_satisfiable_blanket_impls(indexed_crate, supertrait) {
+            return true;
         }
     }
 

--- a/test_crates/declarative_macros/Cargo.toml
+++ b/test_crates/declarative_macros/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "declarative_macros"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/declarative_macros/src/lib.rs
+++ b/test_crates/declarative_macros/src/lib.rs
@@ -1,0 +1,126 @@
+/// Usable externally as:
+/// ```rust
+/// declarative_macros::top_level!();
+/// ```
+///
+/// Also usable with `#[macro_use]`:
+/// ```rust
+/// #[macro_use] extern crate declarative_macros;
+///
+/// top_level!();
+/// ```
+#[macro_export]
+macro_rules! top_level {
+    () => {}
+}
+
+mod private {
+    /// Usable at the top level of the crate, due to `#[macro_export]`:
+    /// ```rust
+    /// declarative_macros::nested_private!();
+    /// ```
+    ///
+    /// Also usable with `#[macro_use]`:
+    /// ```rust
+    /// #[macro_use] extern crate declarative_macros;
+    ///
+    /// nested_private!();
+    /// ```
+    ///
+    /// But the following doesn't work due to the fact that exported macros
+    /// are always exported at the root of the crate. Besides, this module is private
+    /// so that path is not accessible outside the crate in general.
+    /// ```rust,compile_fail
+    /// declarative_macros::private::nested_private!();
+    /// ```
+    #[macro_export]
+    macro_rules! nested_private {
+        () => {}
+    }
+}
+
+pub mod public {
+    /// Usable at the top level of the crate, due to `#[macro_export]`:
+    /// ```rust
+    /// declarative_macros::nested_public!();
+    /// ```
+    ///
+    /// Also usable with `#[macro_use]`:
+    /// ```rust
+    /// #[macro_use] extern crate declarative_macros;
+    ///
+    /// nested_public!();
+    /// ```
+    ///
+    /// But exported macros are always exported at the crate root,
+    /// not at the path where they happend to be defined. So the following doesn't work:
+    /// ```rust,compile_fail
+    /// extern crate declarative_macros;
+    ///
+    /// declarative_macros::public::nested_public!();
+    /// ```
+    #[macro_export]
+    macro_rules! nested_public {
+        () => {}
+    }
+}
+
+/// Macros without `#[macro_export]` are not exported nor visible outside the crate:
+/// ```rust,compile_fail
+/// declarative_macros::not_exported!();
+/// ```
+///
+/// They aren't usable with explicit `#[macro_use]` either:
+/// ```rust,compile_fail
+/// #[macro_use] extern crate declarative_macros;
+///
+/// not_exported!();
+/// ```
+#[allow(unused_macros)]
+macro_rules! not_exported {
+    () => {}
+}
+
+#[doc(hidden)]
+pub mod hidden {
+    /// This macro is *not* hidden, even though its defining module is hidden.
+    /// This is because `#[macro_export]` behaves as a `pub use` of the macro item
+    /// at the crate's top level.
+    ///
+    /// Usable at the top level of the crate, due to `#[macro_export]`:
+    /// ```rust
+    /// declarative_macros::hidden_parent!();
+    /// ```
+    ///
+    /// Also usable with `#[macro_use]`:
+    /// ```rust
+    /// #[macro_use] extern crate declarative_macros;
+    ///
+    /// hidden_parent!();
+    /// ```
+    #[macro_export]
+    macro_rules! hidden_parent {
+        () => {}
+    }
+}
+
+/// This macro is hidden since `#[doc(hidden)]` appears on it directly.
+/// The `#[macro_export]` behaves as a `pub use` of the macro item
+/// at the crate's top level, but the item itself is hidden so the end result is hidden.
+///
+/// Usable at the top level of the crate, due to `#[macro_export]`:
+/// ```rust
+/// declarative_macros::hidden!();
+/// ```
+///
+/// Also usable with `#[macro_use]`:
+/// ```rust
+/// #[macro_use] extern crate declarative_macros;
+///
+/// hidden!();
+/// ```
+#[doc(hidden)]
+#[macro_export]
+macro_rules! hidden {
+    () => {}
+}

--- a/test_crates/generic_parameters/Cargo.toml
+++ b/test_crates/generic_parameters/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "generic_parameters"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/generic_parameters/src/lib.rs
+++ b/test_crates/generic_parameters/src/lib.rs
@@ -1,0 +1,38 @@
+use std::hash::Hash;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+pub struct GenericStruct<'a, T: Clone + PartialOrd<i64>, const N: usize> {
+    _marker: &'a PhantomData<[T; N]>,
+}
+
+pub enum GenericEnum<'a, T: Clone + PartialOrd<i64>, const N: usize> {
+    Variant(&'a PhantomData<[T; N]>),
+}
+
+pub union GenericUnion<'a, T: Clone + PartialOrd<i64>, const N: usize> {
+    field: &'a PhantomData<[T; N]>,
+}
+
+pub trait GenericTrait<'a, T: Clone + PartialOrd<i64>, const N: usize> {
+    fn method<'b, U: Hash, const M: usize>(value: &'a PhantomData<&'b ([T; N], [U; M])>);
+}
+
+pub fn generic_fn<'a, T: Clone + PartialOrd<i64>, const N: usize>(x: &'a PhantomData<[T; N]>) {}
+
+pub fn impl_trait<'a, T: Clone + PartialOrd<i64>, const N: usize>(
+    value: impl GenericTrait<'a, T, N>,
+) {
+}
+
+// Only the `T: Clone` bound should be present in `T`'s own type bounds.
+// The `Arc<T>: Clone` bound involves `T` but isn't `T`'s own bound.
+pub fn non_included_bound<T: Unpin>(value: T) where Arc<T>: Clone {}
+
+// The generics here are equivalent to `<T: Iterator> where T::Item: Clone`,
+// so `T: Iterator` should be `T`'s own type bound even though it's written in the `where` portion.
+pub fn explicit_where_bound<T>(value: T) where T: Iterator, T::Item: Clone {}
+
+pub struct DefaultGenerics<T: Copy = i64, const N: usize = 2> {
+    value: [T; N],
+}

--- a/test_crates/proc_macros/Cargo.toml
+++ b/test_crates/proc_macros/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "proc_macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]

--- a/test_crates/proc_macros/src/lib.rs
+++ b/test_crates/proc_macros/src/lib.rs
@@ -1,0 +1,90 @@
+//! Notes on test completeness, as of Rust 1.81:
+//! - Functions annotated with `#[proc_macro]` must be private, or else it's a compile error.
+//! - All proc macros must be defined at the root of the crate, or else it's a compile error.
+//! - Proc macro crates cannot export any other items other than proc macros. Not even pub modules
+//!   are allowed!
+
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+/// Example from
+/// <https://doc.rust-lang.org/reference/procedural-macros.html#function-like-procedural-macros>
+///
+/// Use:
+/// ```rust
+/// extern crate proc_macros;
+/// use proc_macros::make_answer;
+///
+/// make_answer!();
+///
+/// fn main() {
+///     println!("{}", answer());
+/// }
+/// ```
+#[proc_macro]
+pub fn make_answer(_item: TokenStream) -> TokenStream {
+    "fn answer() -> u32 { 42 }".parse().unwrap()
+}
+
+/// Example from <https://doc.rust-lang.org/reference/procedural-macros.html#attribute-macros>
+///
+/// Use:
+/// ```rust
+/// #[proc_macros::return_as_is]
+/// struct Unit;
+/// ```
+#[proc_macro_attribute]
+pub fn return_as_is(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    item
+}
+
+/// Example from <https://doc.rust-lang.org/reference/procedural-macros.html#derive-macros>
+///
+/// Use:
+/// ```rust
+/// extern crate proc_macros;
+/// use proc_macros::AnswerFn;
+///
+/// #[derive(AnswerFn)]
+/// struct Struct;
+///
+/// fn main() {
+///     assert_eq!(42, answer());
+/// }
+/// ```
+#[proc_macro_derive(AnswerFn)]
+pub fn derive_answer_fn(_item: TokenStream) -> TokenStream {
+    "fn answer() -> u32 { 42 }".parse().unwrap()
+}
+
+/// Example tweaked from
+/// <https://doc.rust-lang.org/reference/procedural-macros.html#derive-macro-helper-attributes>
+///
+/// Use:
+/// ```rust
+/// #[derive(proc_macros::HelperAttr)]
+/// struct Struct {
+///     #[helper] field: (),
+///     #[second] other: (),
+/// }
+/// ```
+#[proc_macro_derive(HelperAttr, attributes(helper, second))]
+pub fn derive_helper_attr(_item: TokenStream) -> TokenStream {
+    TokenStream::new()
+}
+
+/// Usable but hidden:
+/// ```rust
+/// extern crate proc_macros;
+///
+/// proc_macros::hidden!();
+///
+/// fn main() {
+///     println!("{}", answer());
+/// }
+/// ```
+#[doc(hidden)]
+#[proc_macro]
+pub fn hidden(_item: TokenStream) -> TokenStream {
+    "fn answer() -> u32 { 42 }".parse().unwrap()
+}

--- a/test_crates/sealed_traits/src/lib.rs
+++ b/test_crates/sealed_traits/src/lib.rs
@@ -15,6 +15,10 @@ pub trait TransitivelyTraitSealed: DirectlyTraitSealed {}
 /// This trait is sealed, and happens to have more than one supertrait.
 pub trait SealedTraitWithStdSupertrait: AsRef<()> + private::Sealed {}
 
+/// This trait is sealed, since `Self: private::Sealed` still requires that `Self` implement
+/// a sealed trait, even though the sealed trait isn't *exactly* a supertrait.
+pub trait SealedWithWhereSelfBound where Self: private::Sealed {}
+
 trait PrivateSealed {}
 
 /// This trait is sealed with a supertrait that is private, not pub-in-priv.


### PR DESCRIPTION
Due to a script failure, the following commits were accidentally excluded from rustdoc-v33 releases. I've yanked the affected published version, I'm re-adding the commits here, and will be releasing a patch shortly.
- **Add support for querying declarative (macro-by-example) macros. (#481)**
- **Support querying proc macros of all three kinds. (#486)**
- **Traits can be sealed with `where Self: SealedTrait` predicate as well. (#497)**
- **Expose generic type, lifetime, and const parameters in the schema. (#514)**
