### PR TITLE
Ensure item IDs continue to be strings, even if they are u32 underneath.

### DIFF
--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -37,7 +37,10 @@ pub(super) fn resolve_item_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
     property_name: &str,
 ) -> ContextOutcomeIterator<'a, V, FieldValue> {
     match property_name {
-        "id" => resolve_property_with(contexts, field_property!(as_item, id, { id.0.into() })),
+        "id" => resolve_property_with(
+            contexts,
+            field_property!(as_item, id, { id.0.to_string().into() }),
+        ),
         "crate_id" => resolve_property_with(contexts, field_property!(as_item, crate_id)),
         "name" => resolve_property_with(contexts, field_property!(as_item, name)),
         "docs" => resolve_property_with(contexts, field_property!(as_item, docs)),


### PR DESCRIPTION
In rustdoc v35, the ID type for items became `u32`. But our schema says it's `String!` so we stringify it.

We may eventually convert to `Int!` once `cargo-semver-checks` no longer supports any rustdoc format where the ID is a string. But that's months away at least.