### PR TITLE
Add `instantiated_name` and `bare_name` for `ImplementedTrait`. (#554)

### DIFF
--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -485,7 +485,7 @@ pub(super) fn resolve_implemented_trait_property<'a, V: AsVertex<Vertex<'a>> + '
     previous_crate: Option<&'a IndexedCrate<'a>>,
 ) -> ContextOutcomeIterator<'a, V, FieldValue> {
     match property_name {
-        "name" => resolve_property_with(contexts, move |vertex| {
+        "name" | "bare_name" => resolve_property_with(contexts, move |vertex| {
             let origin_crate = match vertex.origin {
                 Origin::CurrentCrate => current_crate,
                 Origin::PreviousCrate => {
@@ -524,6 +524,13 @@ pub(super) fn resolve_implemented_trait_property<'a, V: AsVertex<Vertex<'a>> + '
             } else {
                 info.name.clone().into()
             }
+        }),
+        "instantiated_name" => resolve_property_with(contexts, |vertex| {
+            let (info, _) = vertex
+                .as_implemented_trait()
+                .expect("not an ImplementedTrait");
+
+            super::rust_type_name::rust_type_name_from_path(info).into()
         }),
         "trait_id" => resolve_property_with(contexts, |vertex| {
             let (info, _) = vertex

--- a/src/adapter/rust_type_name.rs
+++ b/src/adapter/rust_type_name.rs
@@ -6,6 +6,19 @@ pub(crate) fn rust_type_name(ty: &rustdoc_types::Type) -> String {
     Type(ty, false).to_string()
 }
 
+pub(crate) fn rust_type_name_from_path(path: &rustdoc_types::Path) -> String {
+    assert!(
+        // No type should have code akin to `impl Fn() -> i64 for Type`,
+        // or else this code has a fundamental misunderstanding of what Rust can do.
+        !matches!(
+            path.args.as_deref(),
+            Some(rustdoc_types::GenericArgs::Parenthesized { .. })
+        ),
+        "printing parenthesized args for a type or trait, which should be impossible: {path:?}"
+    );
+    Path(path, false).to_string()
+}
+
 /// Creates a struct named `$t` that wraps a `rustdoc_types::$t` reference,
 /// and implements `Display` on it by calling the given `$formatter` function.
 macro_rules! display_wrapper {
@@ -545,7 +558,11 @@ mod tests {
                 Output {
                     name: "g".into(),
                     typename: "Box<dyn for<'b> MyTrait2<'b, b'a', B = &'b ()> + Send + 'a>".into(),
-                }
+                },
+                Output {
+                    name: "h".into(),
+                    typename: "Box<dyn Fn(&'a i64) -> &'a i64>".into(),
+                },
             ]
         );
     }

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use maplit::btreemap;
-use trustfall::{Schema, TryIntoStruct};
+use trustfall::{FieldValue, Schema, TryIntoStruct};
 
 use crate::{IndexedCrate, RustdocAdapter};
 
@@ -3164,6 +3164,142 @@ fn generic_const_parameters() {
             name: "DefaultGenerics".into(),
             generic_name: "N".into(),
             has_default: true,
+        },
+    ];
+    expected_results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
+#[test]
+fn implemented_trait_instantiated_name() {
+    let path = "./localdata/test_data/rust_type_name/rustdoc.json";
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
+        .expect("failed to load rustdoc");
+
+    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
+    let indexed_crate = IndexedCrate::new(&crate_);
+    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Struct {
+                name @filter(op: "=", value: ["$struct"])
+
+                impl {
+                    implemented_trait {
+                        bare_name @output @filter(op: "one_of", value: ["$traits"])
+                        instantiated_name @output
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+
+    let mut variables: BTreeMap<&str, FieldValue> = BTreeMap::default();
+    variables.insert("struct", "A".into());
+    variables.insert(
+        "traits",
+        vec![
+            "MyTrait",
+            "MyTrait2",
+            "Any",
+            "Borrow",
+            "BorrowMut",
+            "From",
+            "Into",
+            "RefUnwindSafe",
+            "Send",
+            "Sync",
+            "TryFrom",
+            "TryInto",
+            "Unpin",
+            "UnwindSafe",
+        ]
+        .into(),
+    );
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        bare_name: String,
+        instantiated_name: String,
+    }
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    // We write the results in the order the items appear in the test file,
+    // and sort them afterward in order to compare with the (sorted) query results.
+    // This makes it easier to verify that the expected data here is correct
+    // by reading it side-by-side with the file.
+    let mut expected_results = vec![
+        Output {
+            bare_name: "Any".into(),
+            instantiated_name: "Any".into(),
+        },
+        Output {
+            bare_name: "Borrow".into(),
+            instantiated_name: "Borrow<T>".into(),
+        },
+        Output {
+            bare_name: "BorrowMut".into(),
+            instantiated_name: "BorrowMut<T>".into(),
+        },
+        Output {
+            bare_name: "From".into(),
+            instantiated_name: "From<T>".into(),
+        },
+        Output {
+            bare_name: "Into".into(),
+            instantiated_name: "Into<U>".into(),
+        },
+        Output {
+            bare_name: "MyTrait".into(),
+            instantiated_name: "MyTrait".into(),
+        },
+        Output {
+            bare_name: "MyTrait2".into(),
+            instantiated_name: "MyTrait2<'a, N, i64>".into(),
+        },
+        Output {
+            bare_name: "RefUnwindSafe".into(),
+            instantiated_name: "RefUnwindSafe".into(),
+        },
+        Output {
+            bare_name: "Send".into(),
+            instantiated_name: "Send".into(),
+        },
+        Output {
+            bare_name: "Sync".into(),
+            instantiated_name: "Sync".into(),
+        },
+        Output {
+            bare_name: "TryFrom".into(),
+            instantiated_name: "TryFrom<U>".into(),
+        },
+        Output {
+            bare_name: "TryInto".into(),
+            instantiated_name: "TryInto<U>".into(),
+        },
+        Output {
+            bare_name: "Unpin".into(),
+            instantiated_name: "Unpin".into(),
+        },
+        Output {
+            bare_name: "UnwindSafe".into(),
+            instantiated_name: "UnwindSafe".into(),
         },
     ];
     expected_results.sort_unstable();

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -1709,11 +1709,27 @@ In `impl Foo<u64> for Bar`, this is the `Foo<u64>` part.
 """
 type ImplementedTrait {
   """
+  The name of the trait being implemented, without any generic parameters. Just the name.
+
+  In `impl Foo<u64> for Bar`, this is `"Foo"`.
+  """
+  bare_name: String!
+
+  """
+  Deprecated alias of `bare_name`.
+
   The name of the trait being implemented.
 
   In `impl Foo<u64> for Bar`, this is `"Foo"`.
   """
-  name: String!
+  name: String! @deprecated(reason: "Renamed to `bare_name`, please use that instead.")
+
+  """
+  The trait being implemented together with any generic parameters.
+
+  In `impl Foo<u64> for Bar`, this is `"Foo<u64>"`.
+  """
+  instantiated_name: String!
 
   """
   The item identifier of the trait being implemented here.

--- a/test_crates/rust_type_name/src/lib.rs
+++ b/test_crates/rust_type_name/src/lib.rs
@@ -11,6 +11,10 @@ pub trait MyTrait2<'a, const N: u8, T = ()> {
     type B;
 }
 
+impl<'a, const N: u8> MyTrait2<'a, N, i64> for A {
+    type B = i64;
+}
+
 mod a {
     pub type B = ();
 }
@@ -23,6 +27,7 @@ pub struct Struct<'a, T> {
     pub e: a::B,
     pub f: unsafe extern "C-unwind" fn() -> T,
     pub g: Box<dyn for<'b> MyTrait2<'b, b'a', B = &'b ()> + Send + 'a>,
+    pub h: Box<dyn Fn(&'a i64) -> &'a i64>,
 }
 
 const unsafe fn x() {}


### PR DESCRIPTION
In `impl Foo<u64> for Bar`, `ImplementedTrait` as a vertex is `Foo<u64>`.
When we just want the bare trait name, we use the `bare_name` property
with value `"Foo"`. If we want the generic parameters too, we can use
the `instantiated_name` property whose value is `"Foo<u64>"`.

Deprecate the older, ambiguous, `name` property. `bare_name` is the same
thing and should be used instead.
