### PR TITLE
Allow generating just specified rustdocs in `regenerate_test_rustdocs.sh`

### DIFF
--- a/scripts/regenerate_test_rustdocs.sh
+++ b/scripts/regenerate_test_rustdocs.sh
@@ -10,13 +10,27 @@ TARGET_DIR="$TOPLEVEL/localdata/test_data"
 
 # Allow setting an explicit toolchain, like +nightly or +beta.
 set +u
-TOOLCHAIN="$1"
+case "$1" in
+    "+"*)
+        TOOLCHAIN="$1"
+        shift
+        ;;
+    *)
+        TOOLCHAIN=""
+        ;;
+esac
 set -u
 echo "Generating rustdoc with: $(cargo $TOOLCHAIN --version)"
 RUSTDOC_CMD="cargo $TOOLCHAIN rustdoc"
 
+if [ "$#" -eq 0 ]; then
+    CRATES="$(find "$TOPLEVEL/test_crates/" -maxdepth 1 -mindepth 1 -type d)"
+else
+    CRATES="$@"
+fi
+
 # Run rustdoc on test_crates/*/
-for crate_path in $(find "$TOPLEVEL/test_crates/" -maxdepth 1 -mindepth 1 -type d); do
+for crate_path in $CRATES; do
     # Removing path prefix, leaving only the directory name without forward slashes
     crate=${crate_path#"$TOPLEVEL/test_crates/"}
 

--- a/scripts/regenerate_test_rustdocs.sh
+++ b/scripts/regenerate_test_rustdocs.sh
@@ -10,6 +10,9 @@ TARGET_DIR="$TOPLEVEL/localdata/test_data"
 
 # Allow setting an explicit toolchain, like +nightly or +beta.
 set +u
+# If the first argument starts with +, it's specifying a toolchain,
+# and we need to not count it when checking if the user is running
+# `regenerate_test_rustdocs.sh crate1 crate2 ...`
 case "$1" in
     "+"*)
         TOOLCHAIN="$1"
@@ -23,13 +26,14 @@ set -u
 echo "Generating rustdoc with: $(cargo $TOOLCHAIN --version)"
 RUSTDOC_CMD="cargo $TOOLCHAIN rustdoc"
 
+# If there are no arguments, run rustdoc on test_crates/*
 if [ "$#" -eq 0 ]; then
     CRATES="$(find "$TOPLEVEL/test_crates/" -maxdepth 1 -mindepth 1 -type d)"
+# If there are arguments, just regenerate test_crates/$arg for each argument
 else
     CRATES="$@"
 fi
 
-# Run rustdoc on test_crates/*/
 for crate_path in $CRATES; do
     # Removing path prefix, leaving only the directory name without forward slashes
     crate=${crate_path#"$TOPLEVEL/test_crates/"}


### PR DESCRIPTION
Updates `regenerate_test_rustdocs.sh` to have the following behavior

1. if no args are passed (except an optional `+toolchain`), renerates all rustdocs in the `test_crates` directory
2. if the script is called with `regenerate_test_rustdocs.sh crate1 crate2 ...`, only regenerate `test_crates/crate1`, `test_crates/crate2`, etc.