### PR TITLE
Only regenerate stale rustdoc.json files

### DIFF
--- a/scripts/regenerate_test_rustdocs.sh
+++ b/scripts/regenerate_test_rustdocs.sh
@@ -58,7 +58,7 @@ for crate_path in $CRATES; do
         pushd "$TOPLEVEL/test_crates/$crate"
         RUSTC_BOOTSTRAP=1 $RUSTDOC_CMD -- -Zunstable-options --document-private-items --document-hidden-items --output-format=json
         mkdir -p "$TARGET_DIR/$crate"
-        mv "$RUSTDOC_OUTPUT_DIR/$crate.json" "$TARGET_DIR/$crate/rustdoc.json"
+        mv "$RUSTDOC_OUTPUT_DIR/$crate.json" "$target"
         popd
     fi
 done

--- a/scripts/regenerate_test_rustdocs.sh
+++ b/scripts/regenerate_test_rustdocs.sh
@@ -8,6 +8,12 @@ RUSTDOC_OUTPUT_DIR="$CARGO_TARGET_DIR/doc"
 TOPLEVEL="$(git rev-parse --show-toplevel)"
 TARGET_DIR="$TOPLEVEL/localdata/test_data"
 
+dir_is_newer_than_file() {
+    local dir="$1"
+    local file="$2"
+    [[ ! -e $file ]] || [[ $(find "$dir" -newer "$file" -exec sh -c 'printf found; kill "$PPID"' \;) ]]
+}
+
 # Allow setting an explicit toolchain, like +nightly or +beta.
 set +u
 # If the first argument starts with +, it's specifying a toolchain,
@@ -29,9 +35,11 @@ RUSTDOC_CMD="cargo $TOOLCHAIN rustdoc"
 # If there are no arguments, run rustdoc on test_crates/*
 if [ "$#" -eq 0 ]; then
     CRATES="$(find "$TOPLEVEL/test_crates/" -maxdepth 1 -mindepth 1 -type d)"
+    ALWAYS_UPDATE=
 # If there are arguments, just regenerate test_crates/$arg for each argument
 else
     CRATES="$@"
+    ALWAYS_UPDATE=1
 fi
 
 for crate_path in $CRATES; do
@@ -39,7 +47,13 @@ for crate_path in $CRATES; do
     crate=${crate_path#"$TOPLEVEL/test_crates/"}
 
     if [[ -f "$TOPLEVEL/test_crates/$crate/Cargo.toml" ]]; then
+        target="$TARGET_DIR/$crate/rustdoc.json"
         echo "Generating: $crate"
+
+        if [[ -z "$ALWAYS_UPDATE" ]] && ! dir_is_newer_than_file "$crate_path" "$target"; then
+            printf 'No updates needed for %s.\n' "$crate"
+            continue
+        fi
 
         pushd "$TOPLEVEL/test_crates/$crate"
         RUSTC_BOOTSTRAP=1 $RUSTDOC_CMD -- -Zunstable-options --document-private-items --document-hidden-items --output-format=json


### PR DESCRIPTION
As suggested, `scripts/regenerate_test_rustdocs.sh` when called with no arguments only regenerates rustdocs where the `rustdoc.json` is older than the test crate directory.  Logic copied from the c-s-c script.