### PR TITLE
Do not return methods when querying top-level functions. (#614)

### DIFF
--- a/src/adapter/optimizations/item_lookup.rs
+++ b/src/adapter/optimizations/item_lookup.rs
@@ -112,7 +112,20 @@ fn resolve_items_slow_path<'a>(
         .inner
         .index
         .values()
-        .filter(move |item| item.crate_id == own_crate_id);
+        .filter(move |item| item.crate_id == own_crate_id)
+        .filter(move |item| {
+            // We don't consider methods as top-level items in a crate.
+            // We should only return methods as owned items within a trait or impl.
+            // If we are to return this item, then either the item isn't a function at all,
+            // or it's a top-level function (i.e. has no owner listed in the index).
+            !matches!(item.inner, rustdoc_types::ItemEnum::Function(..))
+                || crate_vertex
+                    .fn_owner_index
+                    .as_ref()
+                    .expect("no fn_owner_index defined")
+                    .get(&item.id)
+                    .is_none()
+        });
 
     resolve_item_vertices(origin, items)
 }

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -1958,6 +1958,11 @@ fn function_has_body() {
     let indexed_crate = IndexedCrate::new(&crate_);
     let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
 
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    // This query should only return functions defined at top level,
+    // not ones inside traits or `impl` blocks. Those are supposed to be of type `Method` instead.
     let query = r#"
 {
     Crate {
@@ -1970,11 +1975,7 @@ fn function_has_body() {
     }
 }
 "#;
-
     let variables: BTreeMap<&str, &str> = BTreeMap::default();
-
-    let schema =
-        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
 
     #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
     struct Output {
@@ -1999,22 +2000,97 @@ fn function_has_body() {
             has_body: true,
         },
         Output {
-            name: "inside_impl_block".into(),
-            has_body: true,
-        },
-        Output {
-            name: "trait_no_body".into(),
-            has_body: false,
-        },
-        Output {
-            name: "trait_with_body".into(),
-            has_body: true,
-        },
-        Output {
             name: "extern_no_body".into(),
             has_body: false,
         },
     ];
+    expected_results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Trait {
+                owner: name @output
+
+                method {
+                    name @output
+                    has_body @output
+                }
+            }
+        }
+    }
+}
+"#;
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct OutputWithOwner {
+        owner: String,
+        name: String,
+        has_body: bool,
+    }
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    // We write the results in the order the items appear in the test file,
+    // and sort them afterward in order to compare with the (sorted) query results.
+    // This makes it easier to verify that the expected data here is correct
+    // by reading it side-by-side with the file.
+    let mut expected_results = vec![
+        OutputWithOwner {
+            owner: "Bar".into(),
+            name: "trait_no_body".into(),
+            has_body: false,
+        },
+        OutputWithOwner {
+            owner: "Bar".into(),
+            name: "trait_with_body".into(),
+            has_body: true,
+        },
+    ];
+    expected_results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on ImplOwner {
+                owner: name @output
+
+                inherent_impl {
+                    method {
+                        name @output
+                        has_body @output
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    // We write the results in the order the items appear in the test file,
+    // and sort them afterward in order to compare with the (sorted) query results.
+    // This makes it easier to verify that the expected data here is correct
+    // by reading it side-by-side with the file.
+    let mut expected_results = vec![OutputWithOwner {
+        owner: "Foo".into(),
+        name: "inside_impl_block".into(),
+        has_body: true,
+    }];
     expected_results.sort_unstable();
 
     similar_asserts::assert_eq!(expected_results, results);

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -27,6 +27,10 @@ pub struct IndexedCrate<'a> {
     /// index: impl owner + impl'd item name -> list of (impl itself, the named item))
     pub(crate) impl_index: Option<HashMap<ImplEntry<'a>, Vec<(&'a Item, &'a Item)>>>,
 
+    /// index: method ("owned function") `Id` -> the struct/enum/union/trait that defines it;
+    /// functions at top level will not have an index entry here
+    pub(crate) fn_owner_index: Option<HashMap<Id, &'a Item>>,
+
     /// Trait items defined in external crates are not present in the `inner: &Crate` field,
     /// even if they are implemented by a type in that crate. This also includes
     /// Rust's built-in traits like `Debug, Send, Eq` etc.
@@ -238,6 +242,7 @@ impl<'a> IndexedCrate<'a> {
             manually_inlined_builtin_traits: create_manually_inlined_builtin_traits(crate_),
             imports_index: None,
             impl_index: None,
+            fn_owner_index: None,
         };
 
         debug_assert!(
@@ -276,6 +281,7 @@ impl<'a> IndexedCrate<'a> {
         );
 
         value.impl_index = Some(build_impl_index(&crate_.index).into_inner());
+        value.fn_owner_index = Some(build_fn_owner_index(&crate_.index));
 
         value
     }
@@ -328,6 +334,80 @@ impl<'a> IndexedCrate<'a> {
         let trait_item = &self.inner.index[id];
         sealed_trait::is_trait_sealed(self, trait_item)
     }
+}
+
+fn build_fn_owner_index(index: &HashMap<Id, Item>) -> HashMap<Id, &Item> {
+    #[cfg(feature = "rayon")]
+    let iter = index.par_iter().map(|(_, value)| value);
+    #[cfg(not(feature = "rayon"))]
+    let iter = index.values();
+
+    iter.flat_map(|owner_item| {
+        if let rustdoc_types::ItemEnum::Trait(value) = &owner_item.inner {
+            #[cfg(feature = "rayon")]
+            let trait_items = value.items.par_iter();
+            #[cfg(not(feature = "rayon"))]
+            let trait_items = value.items.iter();
+
+            let output = trait_items
+                // Try to resolve each trait item ID to an item in the index.
+                // In principle, this *should* always find a match, but we don't want to crash
+                // if rustdoc happens to omit an item due to a bug.
+                .filter_map(|id| index.get(id))
+                // Only keep the functions inside.
+                .filter_map(move |inner_item| match &inner_item.inner {
+                    rustdoc_types::ItemEnum::Function(..) => Some((inner_item.id, owner_item)),
+                    _ => None,
+                });
+
+            #[cfg(feature = "rayon")]
+            let return_value = rayon::iter::Either::Left(output);
+            #[cfg(not(feature = "rayon"))]
+            let return_value: Box<dyn Iterator<Item = (Id, &Item)>> = Box::new(output);
+
+            return_value
+        } else {
+            let impls = match &owner_item.inner {
+                rustdoc_types::ItemEnum::Union(value) => value.impls.as_slice(),
+                rustdoc_types::ItemEnum::Struct(value) => value.impls.as_slice(),
+                rustdoc_types::ItemEnum::Enum(value) => value.impls.as_slice(),
+                _ => &[],
+            };
+
+            #[cfg(feature = "rayon")]
+            let impl_iter = impls.into_par_iter();
+            #[cfg(not(feature = "rayon"))]
+            let impl_iter = impls.into_iter();
+
+            // Resolve the impl block, if we can find it in the index.
+            // In principle, this *should* always find a match, but we don't want to crash
+            // if rustdoc happens to omit an item due to a bug.
+            let output = impl_iter
+                .filter_map(|id| index.get(id))
+                // Get the IDs of the items inside it.
+                .flat_map(|impl_item| match &impl_item.inner {
+                    rustdoc_types::ItemEnum::Impl(contents) => contents.items.as_slice(),
+                    _ => &[],
+                })
+                // Resolve each item, if we can find it in the index.
+                // In principle, this *should* always find a match, but we don't want to crash
+                // if rustdoc happens to omit an item due to a bug.
+                .filter_map(|id| index.get(id))
+                // Only keep the functions inside.
+                .filter_map(move |item| match &item.inner {
+                    rustdoc_types::ItemEnum::Function(..) => Some((item.id, owner_item)),
+                    _ => None,
+                });
+
+            #[cfg(feature = "rayon")]
+            let return_value = rayon::iter::Either::Right(output);
+            #[cfg(not(feature = "rayon"))]
+            let return_value: Box<dyn Iterator<Item = (Id, &Item)>> = Box::new(output);
+
+            return_value
+        }
+    })
+    .collect()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
Fixes #400 by adding an index of function item ID -> owning item i.e.
the struct, enum, union, or trait with which the function is associated.
