### PR TITLE
Add support for querying manifest information. (#628)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "cargo_toml"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88da5a13c620b4ca0078845707ea9c3faf11edbc3ffd8497d11d686211cd1ac0"
+dependencies = [
+ "serde",
+ "toml",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,6 +553,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +590,15 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
  "serde",
 ]
 
@@ -614,6 +674,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "trustfall"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +723,8 @@ name = "trustfall-rustdoc-adapter"
 version = "32.2.2"
 dependencies = [
  "anyhow",
+ "cargo_metadata",
+ "cargo_toml",
  "criterion",
  "itertools 0.13.0",
  "maplit",
@@ -859,3 +955,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,16 @@ readme = "./README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-trustfall = "0.8.0"
-rustdoc-types = "0.28.0"
 rayon = { version = "1.10.0", optional = true }
 rustc-hash = { version = "2.0.0", optional = true }
+cargo_toml = { version = "0.20.4", features = ["features"] }
+
+# Packages in our public API, where bumping a major version is a breaking change.
+# Extra spacing included to minimize the chance of merge conflicts.
+#
+trustfall = "0.8.0"
+cargo_metadata = "0.18.1"
+rustdoc-types = "0.28.0"
 
 [features]
 default = []

--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -5,10 +5,14 @@ use trustfall::provider::{
     VertexIterator,
 };
 
-use crate::{adapter::supported_item_kind, attributes::Attribute, IndexedCrate};
+use crate::{adapter::supported_item_kind, attributes::Attribute, PackageIndex};
 
 use super::{
-    enum_variant::LazyDiscriminants, optimizations, origin::Origin, vertex::Vertex, RustdocAdapter,
+    enum_variant::LazyDiscriminants,
+    optimizations,
+    origin::Origin,
+    vertex::{Feature, Vertex},
+    RustdocAdapter,
 };
 
 pub(super) fn resolve_crate_diff_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
@@ -31,7 +35,7 @@ pub(super) fn resolve_crate_diff_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 }
 
 pub(super) fn resolve_crate_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
-    adapter: &RustdocAdapter<'a>,
+    adapter: &'a RustdocAdapter<'a>,
     contexts: ContextIterator<'a, V>,
     edge_name: &str,
     resolve_info: &ResolveEdgeInfo,
@@ -46,10 +50,11 @@ pub(super) fn resolve_crate_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
                 let origin = vertex.origin;
                 let crate_ = vertex.as_crate().expect("vertex was not a crate!");
                 let item_index = match origin {
-                    Origin::CurrentCrate => &current_crate.inner.index,
+                    Origin::CurrentCrate => &current_crate.own_crate.inner.index,
                     Origin::PreviousCrate => {
                         &previous_crate
                             .expect("no previous crate provided")
+                            .own_crate
                             .inner
                             .index
                     }
@@ -61,6 +66,60 @@ pub(super) fn resolve_crate_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
                 Box::new(std::iter::once(origin.make_item_vertex(module)))
             })
         }
+        "feature" => {
+            let current_crate = adapter.current_crate;
+            let previous_crate = adapter.previous_crate;
+
+            resolve_neighbors_with(contexts, move |vertex| {
+                let origin = vertex.origin;
+
+                let features_lookup = match origin {
+                    Origin::CurrentCrate => &current_crate.features,
+                    Origin::PreviousCrate => {
+                        &previous_crate.expect("no previous crate provided").features
+                    }
+                }
+                .as_ref()
+                .expect("no feature data was loaded");
+
+                Box::new(
+                    features_lookup
+                        .features
+                        .values()
+                        .map(move |feat| origin.make_feature_vertex(feat)),
+                )
+            })
+        }
+        "default_feature" => {
+            let current_crate = adapter.current_crate;
+            let previous_crate = adapter.previous_crate;
+
+            resolve_neighbors_with(contexts, move |vertex| {
+                let origin = vertex.origin;
+
+                let features_lookup = match origin {
+                    Origin::CurrentCrate => &current_crate.features,
+                    Origin::PreviousCrate => {
+                        &previous_crate.expect("no previous crate provided").features
+                    }
+                }
+                .as_ref()
+                .expect("no feature data was loaded");
+
+                // If there's no `default` feature, then no features are enabled by default.
+                let Some(default_feature) = features_lookup.features.get("default") else {
+                    return Box::new(std::iter::empty());
+                };
+                let (default_enabled, _) =
+                    default_feature.enables_recursive(&features_lookup.features);
+
+                Box::new(
+                    default_enabled
+                        .into_values()
+                        .map(move |feat| origin.make_feature_vertex(feat)),
+                )
+            })
+        }
         _ => unreachable!("resolve_crate_edge {edge_name}"),
     }
 }
@@ -68,8 +127,8 @@ pub(super) fn resolve_crate_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 pub(super) fn resolve_importable_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     edge_name: &str,
-    current_crate: &'a IndexedCrate<'a>,
-    previous_crate: Option<&'a IndexedCrate<'a>>,
+    current_crate: &'a PackageIndex<'a>,
+    previous_crate: Option<&'a PackageIndex<'a>>,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
     match edge_name {
         "canonical_path" => resolve_neighbors_with(contexts, move |vertex| {
@@ -78,9 +137,15 @@ pub(super) fn resolve_importable_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
             let item_id = &item.id;
 
             if let Some(path) = match origin {
-                Origin::CurrentCrate => current_crate.inner.paths.get(item_id).map(|x| &x.path),
+                Origin::CurrentCrate => current_crate
+                    .own_crate
+                    .inner
+                    .paths
+                    .get(item_id)
+                    .map(|x| &x.path),
                 Origin::PreviousCrate => previous_crate
                     .expect("no baseline provided")
+                    .own_crate
                     .inner
                     .paths
                     .get(item_id)
@@ -103,6 +168,7 @@ pub(super) fn resolve_importable_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 
             Box::new(
                 parent_crate
+                    .own_crate
                     .publicly_importable_names(item_id)
                     .into_iter()
                     .map(move |x| origin.make_importable_path_vertex(x)),
@@ -140,7 +206,7 @@ pub(super) fn resolve_item_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 }
 
 pub(super) fn resolve_impl_owner_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
-    adapter: &RustdocAdapter<'a>,
+    adapter: &'a RustdocAdapter<'a>,
     contexts: ContextIterator<'a, V>,
     edge_name: &str,
     resolve_info: &ResolveEdgeInfo,
@@ -215,8 +281,8 @@ pub(super) fn resolve_generic_parameter_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 pub(super) fn resolve_module_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     edge_name: &str,
-    current_crate: &'a IndexedCrate<'a>,
-    previous_crate: Option<&'a IndexedCrate<'a>>,
+    current_crate: &'a PackageIndex<'a>,
+    previous_crate: Option<&'a PackageIndex<'a>>,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
     match edge_name {
         "item" => resolve_neighbors_with(contexts, move |vertex| {
@@ -224,10 +290,11 @@ pub(super) fn resolve_module_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
             let module_item = vertex.as_module().expect("vertex was not a Module");
 
             let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.inner.index,
+                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
                 Origin::PreviousCrate => {
                     &previous_crate
                         .expect("no previous crate provided")
+                        .own_crate
                         .inner
                         .index
                 }
@@ -247,8 +314,8 @@ pub(super) fn resolve_module_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 pub(super) fn resolve_struct_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     edge_name: &str,
-    current_crate: &'a IndexedCrate<'a>,
-    previous_crate: Option<&'a IndexedCrate<'a>>,
+    current_crate: &'a PackageIndex<'a>,
+    previous_crate: Option<&'a PackageIndex<'a>>,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
     match edge_name {
         "field" => resolve_neighbors_with(contexts, move |vertex| {
@@ -256,10 +323,11 @@ pub(super) fn resolve_struct_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
             let struct_item = vertex.as_struct().expect("vertex was not a Struct");
 
             let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.inner.index,
+                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
                 Origin::PreviousCrate => {
                     &previous_crate
                         .expect("no previous crate provided")
+                        .own_crate
                         .inner
                         .index
                 }
@@ -284,8 +352,8 @@ pub(super) fn resolve_struct_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 pub(super) fn resolve_variant_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     edge_name: &str,
-    current_crate: &'a IndexedCrate<'a>,
-    previous_crate: Option<&'a IndexedCrate<'a>>,
+    current_crate: &'a PackageIndex<'a>,
+    previous_crate: Option<&'a PackageIndex<'a>>,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
     match edge_name {
         "field" => resolve_neighbors_with(contexts, move |vertex| {
@@ -295,10 +363,11 @@ pub(super) fn resolve_variant_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
                 .expect("vertex was not a Variant")
                 .variant();
             let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.inner.index,
+                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
                 Origin::PreviousCrate => {
                     &previous_crate
                         .expect("no previous crate provided")
+                        .own_crate
                         .inner
                         .index
                 }
@@ -341,8 +410,8 @@ pub(super) fn resolve_variant_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 pub(super) fn resolve_enum_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     edge_name: &str,
-    current_crate: &'a IndexedCrate<'a>,
-    previous_crate: Option<&'a IndexedCrate<'a>>,
+    current_crate: &'a PackageIndex<'a>,
+    previous_crate: Option<&'a PackageIndex<'a>>,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
     match edge_name {
         "variant" => resolve_neighbors_with(contexts, move |vertex| {
@@ -351,10 +420,11 @@ pub(super) fn resolve_enum_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
             let outer_item = vertex.as_item().expect("enum was not a vertex");
 
             let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.inner.index,
+                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
                 Origin::PreviousCrate => {
                     &previous_crate
                         .expect("no previous crate provided")
+                        .own_crate
                         .inner
                         .index
                 }
@@ -437,8 +507,8 @@ pub(super) fn resolve_enum_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 pub(super) fn resolve_union_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     edge_name: &str,
-    current_crate: &'a IndexedCrate<'a>,
-    previous_crate: Option<&'a IndexedCrate<'a>>,
+    current_crate: &'a PackageIndex<'a>,
+    previous_crate: Option<&'a PackageIndex<'a>>,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
     match edge_name {
         "field" => resolve_neighbors_with(contexts, move |vertex| {
@@ -446,10 +516,11 @@ pub(super) fn resolve_union_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
             let union_item = vertex.as_union().expect("vertex was not an Union");
 
             let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.inner.index,
+                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
                 Origin::PreviousCrate => {
                     &previous_crate
                         .expect("no previous crate provided")
+                        .own_crate
                         .inner
                         .index
                 }
@@ -478,7 +549,7 @@ pub(super) fn resolve_struct_field_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 }
 
 pub(super) fn resolve_impl_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
-    adapter: &RustdocAdapter<'a>,
+    adapter: &'a RustdocAdapter<'a>,
     contexts: ContextIterator<'a, V>,
     edge_name: &str,
     resolve_info: &ResolveEdgeInfo,
@@ -492,10 +563,11 @@ pub(super) fn resolve_impl_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
         "implemented_trait" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
             let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.inner.index,
+                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
                 Origin::PreviousCrate => {
                     &previous_crate
                         .expect("no previous crate provided")
+                        .own_crate
                         .inner
                         .index
                 }
@@ -514,10 +586,13 @@ pub(super) fn resolve_impl_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
                 // with items stored in `manually_inlined_builtin_traits`.
                 let found_item = item_index.get(&path.id).or_else(|| {
                     let manually_inlined_builtin_traits = match origin {
-                        Origin::CurrentCrate => &current_crate.manually_inlined_builtin_traits,
+                        Origin::CurrentCrate => {
+                            &current_crate.own_crate.manually_inlined_builtin_traits
+                        }
                         Origin::PreviousCrate => {
                             &previous_crate
                                 .expect("no previous crate provided")
+                                .own_crate
                                 .manually_inlined_builtin_traits
                         }
                     };
@@ -534,10 +609,11 @@ pub(super) fn resolve_impl_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
         "associated_constant" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
             let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.inner.index,
+                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
                 Origin::PreviousCrate => {
                     &previous_crate
                         .expect("no previous crate provided")
+                        .own_crate
                         .inner
                         .index
                 }
@@ -560,17 +636,18 @@ pub(super) fn resolve_impl_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 pub(super) fn resolve_trait_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     edge_name: &str,
-    current_crate: &'a IndexedCrate<'a>,
-    previous_crate: Option<&'a IndexedCrate<'a>>,
+    current_crate: &'a PackageIndex<'a>,
+    previous_crate: Option<&'a PackageIndex<'a>>,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
     match edge_name {
         "supertrait" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
             let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.inner.index,
+                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
                 Origin::PreviousCrate => {
                     &previous_crate
                         .expect("no previous crate provided")
+                        .own_crate
                         .inner
                         .index
                 }
@@ -589,10 +666,13 @@ pub(super) fn resolve_trait_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
                     // with items stored in `manually_inlined_builtin_traits`.
                     let found_item = item_index.get(&trait_.id).or_else(|| {
                         let manually_inlined_builtin_traits = match origin {
-                            Origin::CurrentCrate => &current_crate.manually_inlined_builtin_traits,
+                            Origin::CurrentCrate => {
+                                &current_crate.own_crate.manually_inlined_builtin_traits
+                            }
                             Origin::PreviousCrate => {
                                 &previous_crate
                                     .expect("no previous crate provided")
+                                    .own_crate
                                     .manually_inlined_builtin_traits
                             }
                         };
@@ -614,10 +694,11 @@ pub(super) fn resolve_trait_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
         "method" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
             let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.inner.index,
+                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
                 Origin::PreviousCrate => {
                     &previous_crate
                         .expect("no previous crate provided")
+                        .own_crate
                         .inner
                         .index
                 }
@@ -641,10 +722,11 @@ pub(super) fn resolve_trait_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
         "associated_type" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
             let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.inner.index,
+                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
                 Origin::PreviousCrate => {
                     &previous_crate
                         .expect("no previous crate provided")
+                        .own_crate
                         .inner
                         .index
                 }
@@ -668,10 +750,11 @@ pub(super) fn resolve_trait_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
         "associated_constant" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
             let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.inner.index,
+                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
                 Origin::PreviousCrate => {
                     &previous_crate
                         .expect("no previous crate provided")
+                        .own_crate
                         .inner
                         .index
                 }
@@ -781,17 +864,18 @@ pub(super) fn resolve_derive_proc_macro_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 pub(super) fn resolve_generic_type_parameter_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     edge_name: &str,
-    current_crate: &'a IndexedCrate<'a>,
-    previous_crate: Option<&'a IndexedCrate<'a>>,
+    current_crate: &'a PackageIndex<'a>,
+    previous_crate: Option<&'a PackageIndex<'a>>,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
     match edge_name {
         "type_bound" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
             let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.inner.index,
+                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
                 Origin::PreviousCrate => {
                     &previous_crate
                         .expect("no previous crate provided")
+                        .own_crate
                         .inner
                         .index
                 }
@@ -857,11 +941,12 @@ pub(super) fn resolve_generic_type_parameter_edge<'a, V: AsVertex<Vertex<'a>> + 
                             let found_item = item_index.get(&trait_.id).or_else(|| {
                                 let manually_inlined_builtin_traits = match origin {
                                     Origin::CurrentCrate => {
-                                        &current_crate.manually_inlined_builtin_traits
+                                        &current_crate.own_crate.manually_inlined_builtin_traits
                                     }
                                     Origin::PreviousCrate => {
                                         &previous_crate
                                             .expect("no previous crate provided")
+                                            .own_crate
                                             .manually_inlined_builtin_traits
                                     }
                                 };
@@ -880,5 +965,43 @@ pub(super) fn resolve_generic_type_parameter_edge<'a, V: AsVertex<Vertex<'a>> + 
             )
         }),
         _ => unreachable!("resolve_generic_type_parameter_edge {edge_name}"),
+    }
+}
+
+pub(super) fn resolve_feature_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
+    contexts: ContextIterator<'a, V>,
+    edge_name: &str,
+    current_crate: &'a PackageIndex<'a>,
+    previous_crate: Option<&'a PackageIndex<'a>>,
+) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
+    match edge_name {
+        "directly_enables" => resolve_neighbors_with(contexts, move |vertex| {
+            let origin = vertex.origin;
+            let feature: &Feature<'_> = vertex.as_feature().expect("vertex was not a Feature");
+
+            let features_lookup = match origin {
+                Origin::CurrentCrate => &current_crate.features,
+                Origin::PreviousCrate => {
+                    &previous_crate.expect("no previous crate provided").features
+                }
+            }
+            .as_ref()
+            .expect("no feature data was loaded");
+
+            Box::new(
+                feature
+                    .inner
+                    .enables_features
+                    .iter()
+                    .copied()
+                    .filter_map(move |key| {
+                        features_lookup
+                            .features
+                            .get(key)
+                            .map(|f| origin.make_feature_vertex(f))
+                    }),
+            )
+        }),
+        _ => unreachable!("resolve_feature_edge {edge_name}"),
     }
 }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -9,7 +9,7 @@ use trustfall::{
     FieldValue, Schema,
 };
 
-use crate::indexed_crate::IndexedCrate;
+use crate::PackageIndex;
 
 use self::{
     origin::Origin,
@@ -29,14 +29,14 @@ mod tests;
 
 #[non_exhaustive]
 pub struct RustdocAdapter<'a> {
-    current_crate: &'a IndexedCrate<'a>,
-    previous_crate: Option<&'a IndexedCrate<'a>>,
+    current_crate: &'a PackageIndex<'a>,
+    previous_crate: Option<&'a PackageIndex<'a>>,
 }
 
 impl<'a> RustdocAdapter<'a> {
     pub fn new(
-        current_crate: &'a IndexedCrate<'a>,
-        previous_crate: Option<&'a IndexedCrate<'a>>,
+        current_crate: &'a PackageIndex<'a>,
+        previous_crate: Option<&'a PackageIndex<'a>>,
     ) -> Self {
         Self {
             current_crate,
@@ -49,7 +49,11 @@ impl<'a> RustdocAdapter<'a> {
     }
 }
 
-impl<'a> Adapter<'a> for RustdocAdapter<'a> {
+impl Drop for RustdocAdapter<'_> {
+    fn drop(&mut self) {}
+}
+
+impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
     type Vertex = Vertex<'a>;
 
     fn resolve_starting_vertices(
@@ -188,6 +192,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                 "Discriminant" => {
                     properties::resolve_discriminant_property(contexts, property_name)
                 }
+                "Feature" => properties::resolve_feature_property(contexts, property_name),
                 "DeriveMacroHelperAttribute" => {
                     properties::resolve_derive_macro_helper_attribute_property(
                         contexts,
@@ -324,6 +329,12 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
             "ImplementedTrait" => edges::resolve_implemented_trait_edge(contexts, edge_name),
             "Attribute" => edges::resolve_attribute_edge(contexts, edge_name),
             "AttributeMetaItem" => edges::resolve_attribute_meta_item_edge(contexts, edge_name),
+            "Feature" => edges::resolve_feature_edge(
+                contexts,
+                edge_name,
+                self.current_crate,
+                self.previous_crate,
+            ),
             "DeriveProcMacro" => edges::resolve_derive_proc_macro_edge(contexts, edge_name),
             "GenericTypeParameter" => edges::resolve_generic_type_parameter_edge(
                 contexts,

--- a/src/adapter/optimizations/impl_lookup.rs
+++ b/src/adapter/optimizations/impl_lookup.rs
@@ -9,13 +9,13 @@ use trustfall::{
     FieldValue,
 };
 
-use crate::{indexed_crate::ImplEntry, IndexedCrate};
+use crate::{adapter::PackageIndex, indexed_crate::ImplEntry};
 
 use super::super::{origin::Origin, vertex::Vertex, RustdocAdapter};
 
 /// Resolve the `ImplOwner.impl` and `ImplOwner.inherent_impl` edges.
 pub(crate) fn resolve_owner_impl<'a, V: AsVertex<Vertex<'a>> + 'a>(
-    adapter: &RustdocAdapter<'a>,
+    adapter: &'a RustdocAdapter<'a>,
     contexts: ContextIterator<'a, V>,
     edge_name: &str,
     resolve_info: &ResolveEdgeInfo,
@@ -53,10 +53,10 @@ pub(crate) fn resolve_owner_impl<'a, V: AsVertex<Vertex<'a>> + 'a>(
 }
 
 fn resolve_owner_impl_based_on_method_info<'a, V: AsVertex<Vertex<'a>> + 'a>(
-    adapter: &RustdocAdapter<'a>,
+    adapter: &'a RustdocAdapter<'a>,
     contexts: ContextIterator<'a, V>,
-    current_crate: &'a IndexedCrate<'a>,
-    previous_crate: Option<&'a IndexedCrate<'a>>,
+    current_crate: &'a PackageIndex<'a>,
+    previous_crate: Option<&'a PackageIndex<'a>>,
     inherent_impls_only: bool,
     method_vertex_info: &impl VertexInfo,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
@@ -67,7 +67,7 @@ fn resolve_owner_impl_based_on_method_info<'a, V: AsVertex<Vertex<'a>> + 'a>(
     // statically vs dynamically, so we check the dynamic case first since
     // it might be more specific.
     if let Some(resolver) = method_vertex_info.dynamically_required_property("name") {
-        resolver.resolve_with(adapter, contexts, move |vertex, candidate| {
+        resolver.resolve_with(&adapter, contexts, move |vertex, candidate| {
             resolve_impl_based_on_method_name_candidate(
                 vertex,
                 current_crate,
@@ -96,19 +96,21 @@ fn resolve_owner_impl_based_on_method_info<'a, V: AsVertex<Vertex<'a>> + 'a>(
 
 fn resolve_impl_based_on_method_name_candidate<'a>(
     vertex: &Vertex<'a>,
-    current_crate: &'a IndexedCrate<'a>,
-    previous_crate: Option<&'a IndexedCrate<'a>>,
+    current_crate: &'a PackageIndex<'a>,
+    previous_crate: Option<&'a PackageIndex<'a>>,
     inherent_impls_only: bool,
     method_name: CandidateValue<FieldValue>,
 ) -> VertexIterator<'a, Vertex<'a>> {
     let origin = vertex.origin;
     let impl_index = match origin {
         Origin::CurrentCrate => current_crate
+            .own_crate
             .impl_index
             .as_ref()
             .expect("no impl index present"),
         Origin::PreviousCrate => previous_crate
             .expect("no previous crate provided")
+            .own_crate
             .impl_index
             .as_ref()
             .expect("no impl index provided"),
@@ -173,16 +175,17 @@ the `impl_index` returned a value where the `impl_item` was not an impl: {impl_i
 
 fn resolve_owner_impl_slow_path<'a>(
     vertex: &Vertex<'a>,
-    current_crate: &'a IndexedCrate<'a>,
-    previous_crate: Option<&'a IndexedCrate<'a>>,
+    current_crate: &'a PackageIndex<'a>,
+    previous_crate: Option<&'a PackageIndex<'a>>,
     inherent_impls_only: bool,
 ) -> VertexIterator<'a, Vertex<'a>> {
     let origin = vertex.origin;
     let item_index = match origin {
-        Origin::CurrentCrate => &current_crate.inner.index,
+        Origin::CurrentCrate => &current_crate.own_crate.inner.index,
         Origin::PreviousCrate => {
             &previous_crate
                 .expect("no previous crate provided")
+                .own_crate
                 .inner
                 .index
         }

--- a/src/adapter/optimizations/item_lookup.rs
+++ b/src/adapter/optimizations/item_lookup.rs
@@ -12,7 +12,7 @@ use super::super::{origin::Origin, vertex::Vertex, RustdocAdapter};
 use crate::IndexedCrate;
 
 pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
-    adapter: &RustdocAdapter<'a>,
+    adapter: &'a RustdocAdapter<'a>,
     contexts: ContextIterator<'a, V>,
     resolve_info: &ResolveEdgeInfo,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
@@ -31,7 +31,7 @@ pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
         // statically vs dynamically, so we check the dynamic case first since
         // it might be more specific.
         if let Some(dynamic_value) = neighbor_info.dynamically_required_property("path") {
-            return dynamic_value.resolve_with(adapter, contexts, |vertex, candidate| {
+            return dynamic_value.resolve_with(&adapter, contexts, |vertex, candidate| {
                 let crate_vertex = vertex.as_indexed_crate().expect("vertex was not a Crate");
                 let origin = vertex.origin;
                 resolve_items_by_importable_path(crate_vertex, origin, candidate)
@@ -57,7 +57,7 @@ pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
             });
         } else if let Some(dynamic_value) = destination.dynamically_required_property("export_name")
         {
-            return dynamic_value.resolve_with(adapter, contexts, |vertex, candidate| {
+            return dynamic_value.resolve_with(&adapter, contexts, |vertex, candidate| {
                 let crate_vertex = vertex.as_indexed_crate().expect("vertex was not a Crate");
                 let origin = vertex.origin;
                 resolve_function_by_export_name(crate_vertex, origin, candidate)

--- a/src/adapter/optimizations/method_lookup.rs
+++ b/src/adapter/optimizations/method_lookup.rs
@@ -10,13 +10,13 @@ use trustfall::{
 };
 
 use crate::{
-    adapter::{Origin, Vertex},
+    adapter::{Origin, PackageIndex, Vertex},
     indexed_crate::ImplEntry,
-    IndexedCrate, RustdocAdapter,
+    RustdocAdapter,
 };
 
 pub(crate) fn resolve_impl_methods<'a, V: AsVertex<Vertex<'a>> + 'a>(
-    adapter: &RustdocAdapter<'a>,
+    adapter: &'a RustdocAdapter<'a>,
     contexts: ContextIterator<'a, V>,
     resolve_info: &ResolveEdgeInfo,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
@@ -32,7 +32,7 @@ pub(crate) fn resolve_impl_methods<'a, V: AsVertex<Vertex<'a>> + 'a>(
     // statically vs dynamically, so we check the dynamic case first since
     // it might be more specific.
     if let Some(resolver) = neighbor_info.dynamically_required_property("name") {
-        resolver.resolve_with(adapter, contexts, move |vertex, candidate| {
+        resolver.resolve_with(&adapter, contexts, move |vertex, candidate| {
             resolve_method_from_candidate_value(current_crate, previous_crate, vertex, candidate)
         })
     } else if let Some(candidate) = neighbor_info.statically_required_property("name") {
@@ -48,10 +48,11 @@ pub(crate) fn resolve_impl_methods<'a, V: AsVertex<Vertex<'a>> + 'a>(
         resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
             let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.inner.index,
+                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
                 Origin::PreviousCrate => {
                     &previous_crate
                         .expect("no previous crate provided")
+                        .own_crate
                         .inner
                         .index
                 }
@@ -89,16 +90,17 @@ fn find_impl_owner_id(impl_vertex: &Impl) -> Option<&Id> {
 }
 
 fn resolve_method_from_candidate_value<'a>(
-    current_crate: &'a IndexedCrate<'a>,
-    previous_crate: Option<&'a IndexedCrate<'a>>,
+    current_crate: &'a PackageIndex<'a>,
+    previous_crate: Option<&'a PackageIndex<'a>>,
     vertex: &Vertex<'a>,
     method_name: CandidateValue<FieldValue>,
 ) -> VertexIterator<'a, Vertex<'a>> {
     let origin = vertex.origin;
     let (item_index, impl_index) = match origin {
         Origin::CurrentCrate => (
-            &current_crate.inner.index,
+            &current_crate.own_crate.inner.index,
             current_crate
+                .own_crate
                 .impl_index
                 .as_ref()
                 .expect("no impl index present"),
@@ -106,8 +108,9 @@ fn resolve_method_from_candidate_value<'a>(
         Origin::PreviousCrate => {
             let previous_crate = previous_crate.expect("no previous crate provided");
             (
-                &previous_crate.inner.index,
+                &previous_crate.own_crate.inner.index,
                 previous_crate
+                    .own_crate
                     .impl_index
                     .as_ref()
                     .expect("no impl index provided"),

--- a/src/adapter/origin.rs
+++ b/src/adapter/origin.rs
@@ -124,6 +124,16 @@ impl Origin {
         }
     }
 
+    pub(super) fn make_feature_vertex<'a>(
+        &self,
+        feature: &'a cargo_toml::features::Feature<'a>,
+    ) -> Vertex<'a> {
+        Vertex {
+            origin: *self,
+            kind: VertexKind::Feature(super::vertex::Feature { inner: feature }),
+        }
+    }
+
     pub(super) fn make_derive_helper_attr_vertex<'a>(&self, helper: &'a str) -> Vertex<'a> {
         Vertex {
             origin: *self,

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -7,7 +7,7 @@ use trustfall::{
     FieldValue,
 };
 
-use crate::{attributes::Attribute, IndexedCrate};
+use crate::{attributes::Attribute, PackageIndex};
 
 use super::{origin::Origin, rust_type_name, vertex::Vertex};
 
@@ -441,8 +441,8 @@ pub(super) fn resolve_raw_type_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
 pub(super) fn resolve_trait_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     property_name: &str,
-    current_crate: &'a IndexedCrate<'a>,
-    previous_crate: Option<&'a IndexedCrate<'a>>,
+    current_crate: &'a PackageIndex<'a>,
+    previous_crate: Option<&'a PackageIndex<'a>>,
 ) -> ContextOutcomeIterator<'a, V, FieldValue> {
     match property_name {
         "unsafe" => resolve_property_with(contexts, field_property!(as_trait, is_unsafe)),
@@ -451,12 +451,12 @@ pub(super) fn resolve_trait_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
             let trait_item = vertex.as_item().expect("not an Item");
             let origin = vertex.origin;
 
-            let indexed_crate = match origin {
+            let handler = match origin {
                 Origin::CurrentCrate => current_crate,
                 Origin::PreviousCrate => previous_crate.expect("no previous crate provided"),
             };
 
-            indexed_crate.is_trait_sealed(&trait_item.id).into()
+            handler.own_crate.is_trait_sealed(&trait_item.id).into()
         }),
         _ => unreachable!("Trait property {property_name}"),
     }
@@ -465,8 +465,8 @@ pub(super) fn resolve_trait_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
 pub(super) fn resolve_implemented_trait_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     property_name: &str,
-    current_crate: &'a IndexedCrate<'a>,
-    previous_crate: Option<&'a IndexedCrate<'a>>,
+    current_crate: &'a PackageIndex<'a>,
+    previous_crate: Option<&'a PackageIndex<'a>>,
 ) -> ContextOutcomeIterator<'a, V, FieldValue> {
     match property_name {
         "name" | "bare_name" => resolve_property_with(contexts, move |vertex| {
@@ -483,7 +483,7 @@ pub(super) fn resolve_implemented_trait_property<'a, V: AsVertex<Vertex<'a>> + '
             if let Some(item) = impld.resolved_item {
                 // We have the full item already. Use the original declaration name.
                 item.name.clone().into()
-            } else if let Some(summary) = origin_crate.inner.paths.get(&impld.path.id) {
+            } else if let Some(summary) = origin_crate.own_crate.inner.paths.get(&impld.path.id) {
                 // The item is from a foreign crate.
                 // The last component of the canonical path should match its declaration name,
                 // so use that.
@@ -622,6 +622,23 @@ pub(crate) fn resolve_discriminant_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
                 .into()
         }),
         _ => unreachable!("Discriminant property {property_name}"),
+    }
+}
+
+pub(crate) fn resolve_feature_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
+    contexts: ContextIterator<'a, V>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, V, FieldValue> {
+    match property_name {
+        "name" => resolve_property_with(contexts, |vertex| {
+            vertex
+                .as_feature()
+                .expect("vertex was not a Feature")
+                .inner
+                .key
+                .into()
+        }),
+        _ => unreachable!("Feature property {property_name}"),
     }
 }
 

--- a/src/adapter/rust_type_name.rs
+++ b/src/adapter/rust_type_name.rs
@@ -599,24 +599,44 @@ display_wrapper!(Function, fmt_function, &'a str);
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use anyhow::Context as _;
     use maplit::btreemap;
     use rustdoc_types::{Item, ItemEnum, StructKind};
     use trustfall::{Schema, TryIntoStruct as _};
 
-    use crate::{IndexedCrate, RustdocAdapter};
+    use crate::RustdocAdapter;
 
     use super::rust_type_name;
 
     #[test]
     fn typename() {
-        let path = "./localdata/test_data/rust_type_name/rustdoc.json";
-        let content = std::fs::read_to_string(path)
-            .with_context(|| format!("could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
+        let test_case = "rust_type_name";
+
+        let rustdoc_path = format!("./localdata/test_data/{}/rustdoc.json", test_case);
+        let content = std::fs::read_to_string(&rustdoc_path)
+            .with_context(|| format!("Could not load {rustdoc_path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
             .expect("failed to load rustdoc");
         let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-        let indexed_crate = IndexedCrate::new(&crate_);
-        let adapter = RustdocAdapter::new(&indexed_crate, None);
+
+        let manifest_path = format!("./test_crates/{}/Cargo.toml", test_case);
+
+        let mut metadata = cargo_metadata::MetadataCommand::new()
+            .manifest_path(&manifest_path)
+            .no_deps()
+            .exec()
+            .expect("failed to run cargo metadata");
+        assert_eq!(metadata.packages.len(), 1, "{metadata:?}");
+        let package = metadata
+            .packages
+            .pop()
+            .expect("failed to pop only item in vec");
+
+        let storage = crate::PackageStorage::from_rustdoc_and_package(crate_, package);
+
+        let data = crate::PackageIndex::from_storage(&storage);
+        let adapter = RustdocAdapter::new(&data, None);
 
         let query = r#"
             {
@@ -651,7 +671,7 @@ mod tests {
         }
 
         let mut results: Vec<Output> =
-            trustfall::execute_query(&schema, adapter.into(), query, variables.clone())
+            trustfall::execute_query(&schema, Arc::new(&adapter), query, variables.clone())
                 .expect("failed to run query")
                 .map(|row| row.try_into_struct().expect("shape mismatch"))
                 .collect();

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -10,20 +10,49 @@ use anyhow::Context;
 use maplit::btreemap;
 use trustfall::{FieldValue, Schema, TryIntoStruct};
 
-use crate::{IndexedCrate, RustdocAdapter};
+use crate::RustdocAdapter;
 
 #[allow(dead_code)]
 mod type_level_invariants {
-    use crate::{IndexedCrate, RustdocAdapter};
+    use crate::{IndexedCrate, PackageIndex, RustdocAdapter};
 
     fn ensure_send_and_sync<T: Send + Sync>(_value: &T) {}
 
-    fn ensure_indexed_crate_is_sync(value: &IndexedCrate<'_>) {
+    fn ensure_indexed_crate_is_send_and_sync(value: &IndexedCrate<'_>) {
         ensure_send_and_sync(value);
     }
 
-    fn ensure_adapter_is_sync(value: &RustdocAdapter<'_>) {
+    fn ensure_crate_handler_is_send_and_sync(value: &PackageIndex<'_>) {
         ensure_send_and_sync(value);
+    }
+
+    fn ensure_adapter_is_send_and_sync(value: &RustdocAdapter<'_>) {
+        ensure_send_and_sync(value);
+    }
+}
+
+// This has to be a macro due to borrows. It can't be a function call
+// unless we get a "super let" feature in Rust.
+macro_rules! get_test_data {
+    ($data:ident, $case:ident) => {
+        let rustdoc_path = format!("./localdata/test_data/{}/rustdoc.json", stringify!($case));
+        let content = std::fs::read_to_string(&rustdoc_path)
+            .with_context(|| format!("Could not load {rustdoc_path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
+            .expect("failed to load rustdoc");
+        let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
+
+        let manifest_path = format!("./test_crates/{}/Cargo.toml", stringify!($case));
+
+        let mut metadata = cargo_metadata::MetadataCommand::new().manifest_path(&manifest_path).no_deps().exec().expect("failed to run cargo metadata");
+        assert_eq!(metadata.packages.len(), 1, "{metadata:?}");
+        let package = metadata.packages.pop().expect("failed to pop only item in vec");
+
+        let storage = crate::PackageStorage::from_rustdoc_and_package(
+            crate_,
+            package,
+        );
+
+        let $data = crate::PackageIndex::from_storage(&storage);
     }
 }
 
@@ -48,31 +77,19 @@ fn rustdoc_json_format_version() {
 fn adapter_invariants() {
     // Which rustdoc file we use doesn't really matter,
     // we just need it to create the `RustdocAdapter` struct.
-    let path = "./localdata/test_data/impl_for_ref/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = RustdocAdapter::new(&indexed_crate, None);
+    get_test_data!(data, impl_for_ref);
+    let adapter = RustdocAdapter::new(&data, None);
     let schema =
         Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
 
-    trustfall::provider::check_adapter_invariants(&schema, adapter)
+    trustfall::provider::check_adapter_invariants(&schema, &adapter)
 }
 
 /// Ensure that methods implemented on references (like `&Foo`) show up in queries.
 #[test]
 fn impl_for_ref() {
-    let path = "./localdata/test_data/impl_for_ref/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = RustdocAdapter::new(&indexed_crate, None);
+    get_test_data!(data, impl_for_ref);
+    let adapter = RustdocAdapter::new(&data, None);
 
     let query = r#"
 {
@@ -105,7 +122,7 @@ fn impl_for_ref() {
     }
 
     let mut results: Vec<_> =
-        trustfall::execute_query(&schema, adapter.into(), query, variables.clone())
+        trustfall::execute_query(&schema, Arc::new(&adapter), query, variables.clone())
             .expect("failed to run query")
             .map(|row| row.try_into_struct().expect("shape mismatch"))
             .collect();
@@ -121,14 +138,8 @@ fn impl_for_ref() {
 
 #[test]
 fn rustdoc_finds_supertrait() {
-    let path = "./localdata/test_data/supertrait/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = RustdocAdapter::new(&indexed_crate, None);
+    get_test_data!(data, supertrait);
+    let adapter = RustdocAdapter::new(&data, None);
 
     let query = r#"
 {
@@ -158,7 +169,7 @@ fn rustdoc_finds_supertrait() {
     }
 
     let mut results: Vec<_> =
-        trustfall::execute_query(&schema, adapter.into(), query, variables.clone())
+        trustfall::execute_query(&schema, Arc::new(&adapter), query, variables.clone())
             .expect("failed to run query")
             .map(|row| row.try_into_struct().expect("shape mismatch"))
             .collect();
@@ -192,14 +203,8 @@ fn rustdoc_finds_supertrait() {
 
 #[test]
 fn rustdoc_sealed_traits() {
-    let path = "./localdata/test_data/sealed_traits/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = RustdocAdapter::new(&indexed_crate, None);
+    get_test_data!(data, sealed_traits);
+    let adapter = RustdocAdapter::new(&data, None);
 
     let query = r#"
 {
@@ -226,7 +231,7 @@ fn rustdoc_sealed_traits() {
     }
 
     let mut results: Vec<_> =
-        trustfall::execute_query(&schema, adapter.into(), query, variables.clone())
+        trustfall::execute_query(&schema, Arc::new(&adapter), query, variables.clone())
             .expect("failed to run query")
             .map(|row| row.try_into_struct().expect("shape mismatch"))
             .collect();
@@ -441,14 +446,9 @@ fn rustdoc_sealed_traits() {
 
 #[test]
 fn rustdoc_finds_consts() {
-    let path = "./localdata/test_data/consts/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+    get_test_data!(data, consts);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
 
     let query = r#"
 {
@@ -555,14 +555,9 @@ fn rustdoc_finds_consts() {
 
 #[test]
 fn rustdoc_trait_has_associated_types() {
-    let path = "./localdata/test_data/traits_with_associated_types/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+    get_test_data!(data, traits_with_associated_types);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
 
     let query = r#"
 {
@@ -614,14 +609,9 @@ fn rustdoc_trait_has_associated_types() {
 
 #[test]
 fn rustdoc_finds_statics() {
-    let path = "./localdata/test_data/statics/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+    get_test_data!(data, statics);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
 
     let query = r#"
 {
@@ -717,15 +707,9 @@ fn rustdoc_finds_statics() {
 
 #[test]
 fn rustdoc_modules() {
-    let path = "./localdata/test_data/modules/rustdoc.json";
-
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+    get_test_data!(data, modules);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
 
     let mod_query = r#"
 {
@@ -857,14 +841,9 @@ fn rustdoc_modules() {
 
 #[test]
 fn rustdoc_associated_consts() {
-    let path = "./localdata/test_data/associated_consts/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+    get_test_data!(data, associated_consts);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
 
     let impl_owner_query = r#"
 {
@@ -963,14 +942,9 @@ fn rustdoc_associated_consts() {
 
 #[test]
 fn function_abi() {
-    let path = "./localdata/test_data/function_abi/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+    get_test_data!(data, function_abi);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
 
     let query = r#"
 {
@@ -1037,14 +1011,9 @@ fn function_abi() {
 
 #[test]
 fn function_export_name() {
-    let path = "./localdata/test_data/function_export_name/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+    get_test_data!(data, function_export_name);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
 
     let query = r#"
 {
@@ -1146,14 +1115,9 @@ fn function_export_name() {
 
 #[test]
 fn importable_paths() {
-    let path = "./localdata/test_data/importable_paths/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+    get_test_data!(data, importable_paths);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
 
     let query = r#"
 {
@@ -1363,14 +1327,9 @@ fn importable_paths() {
 
 #[test]
 fn item_own_public_api_properties() {
-    let path = "./localdata/test_data/importable_paths/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+    get_test_data!(data, importable_paths);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
 
     let query = r#"
 {
@@ -1492,14 +1451,9 @@ fn item_own_public_api_properties() {
 /// Enum variants have as-if-public visibility by default -- they are public if the enum is public.
 #[test]
 fn enum_variant_public_api_eligible() {
-    let path = "./localdata/test_data/importable_paths/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+    get_test_data!(data, importable_paths);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
 
     let query = r#"
 {
@@ -1578,14 +1532,9 @@ fn enum_variant_public_api_eligible() {
 /// Trait associated items have as-if-public visibility by default.
 #[test]
 fn trait_associated_items_public_api_eligible() {
-    let path = "./localdata/test_data/importable_paths/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+    get_test_data!(data, importable_paths);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
 
     let query = r#"
 {
@@ -1713,14 +1662,9 @@ fn trait_associated_items_public_api_eligible() {
 
 #[test]
 fn unions() {
-    let path = "./localdata/test_data/unions/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+    get_test_data!(data, unions);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
 
     // Part 1: make sure unions have correct visibility (similart to importable_paths
     // test case)
@@ -1978,14 +1922,9 @@ fn unions() {
 
 #[test]
 fn function_has_body() {
-    let path = "./localdata/test_data/function_has_body/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+    get_test_data!(data, function_has_body);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
 
     let schema =
         Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
@@ -2127,14 +2066,8 @@ fn function_has_body() {
 
 #[test]
 fn enum_discriminants() {
-    let path = "./localdata/test_data/enum_discriminants/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = RustdocAdapter::new(&indexed_crate, None);
+    get_test_data!(data, enum_discriminants);
+    let adapter = RustdocAdapter::new(&data, None);
 
     let query = r#"
 {
@@ -2166,7 +2099,7 @@ fn enum_discriminants() {
     }
 
     let mut results: Vec<Output> =
-        trustfall::execute_query(&schema, adapter.into(), query, variables.clone())
+        trustfall::execute_query(&schema, Arc::new(&adapter), query, variables.clone())
             .expect("failed to run query")
             .map(|row| row.try_into_struct().expect("shape mismatch"))
             .collect();
@@ -2291,14 +2224,8 @@ fn enum_discriminants() {
 
 #[test]
 fn declarative_macros() {
-    let path = "./localdata/test_data/declarative_macros/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+    get_test_data!(data, declarative_macros);
+    let adapter = RustdocAdapter::new(&data, None);
 
     let query = r#"
 {
@@ -2332,7 +2259,7 @@ fn declarative_macros() {
     }
 
     let mut results: Vec<_> =
-        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+        trustfall::execute_query(&schema, Arc::new(&adapter), query, variables.clone())
             .expect("failed to run query")
             .map(|row| row.try_into_struct().expect("shape mismatch"))
             .collect();
@@ -2393,14 +2320,9 @@ fn declarative_macros() {
 
 #[test]
 fn proc_macros() {
-    let path = "./localdata/test_data/proc_macros/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+    get_test_data!(data, proc_macros);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
 
     let query = r#"
 {
@@ -2528,14 +2450,9 @@ fn proc_macros() {
 
 #[test]
 fn generic_parameters() {
-    let path = "./localdata/test_data/generic_parameters/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+    get_test_data!(data, generic_parameters);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
 
     let top_level_query = r#"
 {
@@ -2809,14 +2726,9 @@ fn generic_parameters() {
 
 #[test]
 fn generic_type_parameters() {
-    let path = "./localdata/test_data/generic_parameters/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+    get_test_data!(data, generic_parameters);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
 
     let top_level_query = r#"
 {
@@ -3104,14 +3016,9 @@ fn generic_type_parameters() {
 
 #[test]
 fn generic_const_parameters() {
-    let path = "./localdata/test_data/generic_parameters/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+    get_test_data!(data, generic_parameters);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
 
     let top_level_query = r#"
 {
@@ -3282,14 +3189,8 @@ fn generic_const_parameters() {
 
 #[test]
 fn implemented_trait_instantiated_name() {
-    let path = "./localdata/test_data/rust_type_name/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+    get_test_data!(data, rust_type_name);
+    let adapter = RustdocAdapter::new(&data, None);
 
     let query = r#"
 {
@@ -3343,7 +3244,7 @@ fn implemented_trait_instantiated_name() {
     }
 
     let mut results: Vec<_> =
-        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+        trustfall::execute_query(&schema, Arc::new(&adapter), query, variables.clone())
             .expect("failed to run query")
             .map(|row| row.try_into_struct().expect("shape mismatch"))
             .collect();
@@ -3418,14 +3319,9 @@ fn implemented_trait_instantiated_name() {
 
 #[test]
 fn parenthesized_type_bounds_on_type_and_impl() {
-    let path = "./localdata/test_data/rust_type_name/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+    get_test_data!(data, rust_type_name);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
 
     let query = r#"
 {
@@ -3544,15 +3440,136 @@ fn parenthesized_type_bounds_on_type_and_impl() {
 }
 
 #[test]
-fn type_generic_bounds() {
-    let path = "./localdata/test_data/type_generic_bounds/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
+fn features() {
+    get_test_data!(data, features);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
 
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+    let query = r#"
+{
+    Crate {
+        feature {
+            name @output
+
+            directly_enables @optional {
+                enables: name @output
+            }
+        }
+    }
+}
+"#;
+
+    let variables: BTreeMap<&str, &str> = BTreeMap::default();
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        enables: Option<String>,
+    }
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    // We write the results in the order the items appear in the test file,
+    // and sort them afterward in order to compare with the (sorted) query results.
+    // This makes it easier to verify that the expected data here is correct
+    // by reading it side-by-side with the file.
+    let mut expected_results = vec![
+        Output {
+            name: "default".into(),
+            enables: Some("foo".into()),
+        },
+        Output {
+            name: "default".into(),
+            enables: Some("bar".into()),
+        },
+        Output {
+            name: "foo".into(),
+            enables: Some("baz".into()),
+        },
+        Output {
+            name: "bar".into(),
+            enables: None,
+        },
+        Output {
+            name: "baz".into(),
+            enables: None,
+        },
+        Output {
+            name: "opt_in".into(),
+            enables: None,
+        },
+        Output {
+            name: "serde".into(),
+            enables: None,
+        },
+        Output {
+            name: "serde_json".into(),
+            enables: None,
+        },
+        Output {
+            name: "nightly".into(),
+            enables: None,
+        },
+    ];
+    expected_results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+
+    //
+    // Check default features as well.
+    //
+
+    let query = r#"
+{
+    Crate {
+        default_feature {
+            name @output
+        }
+    }
+}
+"#;
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct DefaultsOutput {
+        name: String,
+    }
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    // We write the results in the order the items appear in the test file,
+    // and sort them afterward in order to compare with the (sorted) query results.
+    // This makes it easier to verify that the expected data here is correct
+    // by reading it side-by-side with the file.
+    let mut expected_results = vec![
+        DefaultsOutput {
+            name: "default".into(),
+        },
+        DefaultsOutput { name: "foo".into() },
+        DefaultsOutput { name: "bar".into() },
+        DefaultsOutput { name: "baz".into() },
+    ];
+    expected_results.sort_unstable();
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
+#[test]
+fn type_generic_bounds() {
+    get_test_data!(data, type_generic_bounds);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
 
     let query = r#"
 {
@@ -3672,14 +3689,9 @@ fn type_generic_bounds() {
 
 #[test]
 fn function_signatures() {
-    let path = "./localdata/test_data/raw_type_json/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+    get_test_data!(data, raw_type_json);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
 
     let query = r#"
 {
@@ -3724,14 +3736,9 @@ fn function_signatures() {
 
 #[test]
 fn method_signature() {
-    let path = "./localdata/test_data/raw_type_json/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+    get_test_data!(data, raw_type_json);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
 
     let query = r#"
 {
@@ -3788,14 +3795,9 @@ fn method_signature() {
 
 #[test]
 fn trait_method_nested_generics() {
-    let path = "./localdata/test_data/raw_type_json/rustdoc.json";
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Could not load {path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
-        .expect("failed to load rustdoc");
-
-    let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
-    let indexed_crate = IndexedCrate::new(&crate_);
-    let adapter = Arc::new(RustdocAdapter::new(&indexed_crate, None));
+    get_test_data!(data, raw_type_json);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
 
     let query = r#"
 {

--- a/src/adapter/vertex.rs
+++ b/src/adapter/vertex.rs
@@ -8,8 +8,7 @@ use trustfall::provider::Typename;
 
 use crate::{
     attributes::{Attribute, AttributeMetaItem},
-    indexed_crate::ImportablePath,
-    IndexedCrate,
+    ImportablePath, IndexedCrate, PackageIndex,
 };
 
 use super::{enum_variant::EnumVariant, origin::Origin};
@@ -24,8 +23,8 @@ pub struct Vertex<'a> {
 #[non_exhaustive]
 #[derive(Debug, Clone)]
 pub enum VertexKind<'a> {
-    CrateDiff((&'a IndexedCrate<'a>, &'a IndexedCrate<'a>)),
-    Crate(&'a IndexedCrate<'a>),
+    CrateDiff((&'a PackageIndex<'a>, &'a PackageIndex<'a>)),
+    Crate(&'a PackageIndex<'a>),
     Item(&'a Item),
     Span(&'a Span),
     Path(&'a [String]),
@@ -40,6 +39,7 @@ pub enum VertexKind<'a> {
     Variant(EnumVariant<'a>),
     DeriveHelperAttr(&'a str),
     GenericParameter(&'a rustdoc_types::Generics, &'a GenericParamDef),
+    Feature(Feature<'a>),
 }
 
 impl Typename for Vertex<'_> {
@@ -99,20 +99,21 @@ impl Typename for Vertex<'_> {
                 rustdoc_types::GenericParamDefKind::Type { .. } => "GenericTypeParameter",
                 rustdoc_types::GenericParamDefKind::Const { .. } => "GenericConstParameter",
             },
+            VertexKind::Feature(..) => "Feature",
         }
     }
 }
 
 #[allow(dead_code)]
 impl<'a> Vertex<'a> {
-    pub(super) fn new_crate(origin: Origin, crate_: &'a IndexedCrate<'a>) -> Self {
+    pub(super) fn new_crate(origin: Origin, crate_: &'a PackageIndex<'a>) -> Self {
         Self {
             origin,
             kind: VertexKind::Crate(crate_),
         }
     }
 
-    pub(super) fn as_crate_diff(&self) -> Option<(&'a IndexedCrate<'a>, &'a IndexedCrate<'a>)> {
+    pub(super) fn as_crate_diff(&self) -> Option<(&'a PackageIndex<'a>, &'a PackageIndex<'a>)> {
         match &self.kind {
             VertexKind::CrateDiff(tuple) => Some(*tuple),
             _ => None,
@@ -121,7 +122,15 @@ impl<'a> Vertex<'a> {
 
     pub(super) fn as_indexed_crate(&self) -> Option<&'a IndexedCrate<'a>> {
         match self.kind {
-            VertexKind::Crate(c) => Some(c),
+            VertexKind::Crate(c) => Some(&c.own_crate),
+            _ => None,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(super) fn as_crate_handler(&self) -> Option<&'a PackageIndex<'a>> {
+        match self.kind {
+            VertexKind::Crate(h) => Some(h),
             _ => None,
         }
     }
@@ -292,6 +301,13 @@ impl<'a> Vertex<'a> {
         }
     }
 
+    pub(super) fn as_feature(&self) -> Option<&Feature<'a>> {
+        match &self.kind {
+            VertexKind::Feature(f) => Some(f),
+            _ => None,
+        }
+    }
+
     pub(super) fn as_derive_helper_attr(&self) -> Option<&'a str> {
         match &self.kind {
             VertexKind::DeriveHelperAttr(value) => Some(value),
@@ -327,8 +343,8 @@ impl<'a> From<&'a Item> for VertexKind<'a> {
     }
 }
 
-impl<'a> From<&'a IndexedCrate<'a>> for VertexKind<'a> {
-    fn from(c: &'a IndexedCrate<'a>) -> Self {
+impl<'a> From<&'a PackageIndex<'a>> for VertexKind<'a> {
+    fn from(c: &'a PackageIndex<'a>) -> Self {
         Self::Crate(c)
     }
 }
@@ -343,6 +359,11 @@ impl<'a> From<&'a Abi> for VertexKind<'a> {
     fn from(a: &'a Abi) -> Self {
         Self::FunctionAbi(a)
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct Feature<'a> {
+    pub(super) inner: &'a cargo_toml::features::Feature<'a>,
 }
 
 #[non_exhaustive]

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -1,6 +1,7 @@
 use std::{
     borrow::Borrow,
     collections::{hash_map::Entry, HashMap, HashSet},
+    sync::Arc,
 };
 
 #[cfg(feature = "rayon")]
@@ -8,6 +9,168 @@ use rayon::prelude::*;
 use rustdoc_types::{Crate, Id, Item};
 
 use crate::{adapter::supported_item_kind, sealed_trait, visibility_tracker::VisibilityTracker};
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct DependencyKey(Arc<str>);
+
+impl Borrow<str> for DependencyKey {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Borrow<Arc<str>> for DependencyKey {
+    fn borrow(&self) -> &Arc<str> {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PackageData {
+    pub(crate) package: cargo_metadata::Package,
+
+    features: HashMap<String, Vec<String>>,
+
+    // (dependency, target selector), parallel to `package.dependencies`
+    dependency_info: Vec<(cargo_toml::Dependency, Option<String>)>,
+}
+
+impl From<cargo_metadata::Package> for PackageData {
+    fn from(value: cargo_metadata::Package) -> Self {
+        let features = value
+            .features
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        let dependency_info: Vec<_> = value
+            .dependencies
+            .iter()
+            .map(|dep| {
+                let dependency = if dep.features.is_empty() {
+                    cargo_toml::Dependency::Simple(dep.req.to_string())
+                } else {
+                    cargo_toml::Dependency::Detailed(Box::new(cargo_toml::DependencyDetail {
+                        package: dep.rename.is_none().then(|| dep.name.clone()),
+                        version: (dep.req != cargo_metadata::semver::VersionReq::STAR)
+                            .then(|| dep.req.to_string()),
+                        features: dep.features.clone(),
+                        default_features: dep.uses_default_features,
+                        optional: dep.optional,
+                        path: dep.path.as_ref().map(|p| p.to_string()),
+                        ..Default::default()
+                    }))
+                };
+
+                (dependency, dep.target.as_ref().map(|p| p.to_string()))
+            })
+            .collect();
+
+        Self {
+            package: value,
+            features,
+            dependency_info,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PackageStorage {
+    pub(crate) own_crate: Crate,
+    pub(crate) package_data: Option<PackageData>,
+    pub(crate) dependencies: HashMap<DependencyKey, Crate>,
+}
+
+impl PackageStorage {
+    pub fn crate_version(&self) -> Option<&str> {
+        self.own_crate.crate_version.as_deref()
+    }
+
+    pub fn from_rustdoc(own_crate: Crate) -> Self {
+        Self {
+            own_crate,
+            package_data: None,
+            dependencies: Default::default(),
+        }
+    }
+
+    pub fn from_rustdoc_and_package(own_crate: Crate, package: cargo_metadata::Package) -> Self {
+        Self {
+            own_crate,
+            package_data: Some(package.into()),
+            dependencies: Default::default(),
+        }
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct PackageIndex<'a> {
+    pub(crate) own_crate: IndexedCrate<'a>,
+    pub(crate) features: Option<cargo_toml::features::Features<'a, 'a>>,
+    #[allow(dead_code)]
+    pub(crate) dependencies: HashMap<DependencyKey, IndexedCrate<'a>>,
+}
+
+impl<'a> PackageIndex<'a> {
+    /// Create a new [`PackageIndex`] for a given crate, in order to query it with Trustfall.
+    ///
+    /// Prefer the [`PackageIndex::from_storage`] function when possible, since it makes features
+    /// information available as well. Values constructed with the [`PackageIndex::from_crate`]
+    /// function will appear to have no information on features or other manifest data.
+    pub fn from_crate(crate_: &'a Crate) -> Self {
+        Self {
+            own_crate: IndexedCrate::new(crate_),
+            features: None,
+            dependencies: Default::default(),
+        }
+    }
+
+    /// Create a new [`PackageIndex`] for a given crate, in order to query it with Trustfall.
+    pub fn from_storage(storage: &'a PackageStorage) -> Self {
+        #[cfg(not(feature = "rayon"))]
+        let dependencies_iter = storage.dependencies.iter();
+        #[cfg(feature = "rayon")]
+        let dependencies_iter = storage.dependencies.par_iter();
+
+        Self {
+            own_crate: IndexedCrate::new(&storage.own_crate),
+            features: storage.package_data.as_ref().map(|data| {
+                let resolver = cargo_toml::features::Resolver::new();
+
+                let dependencies = data
+                    .package
+                    .dependencies
+                    .iter()
+                    .zip(data.dependency_info.iter())
+                    .filter_map(|(dep, (dep_data, platform))| {
+                        Some(cargo_toml::features::ParseDependency {
+                            key: dep.rename.as_deref().unwrap_or(dep.name.as_ref()),
+                            kind: match dep.kind {
+                                cargo_metadata::DependencyKind::Normal => {
+                                    cargo_toml::features::Kind::Normal
+                                }
+                                cargo_metadata::DependencyKind::Development => {
+                                    cargo_toml::features::Kind::Dev
+                                }
+                                cargo_metadata::DependencyKind::Build => {
+                                    cargo_toml::features::Kind::Build
+                                }
+                                _ => return None,
+                            },
+                            target: platform.as_deref(),
+                            dep: dep_data,
+                        })
+                    });
+
+                resolver.parse_custom(&data.features, dependencies)
+            }),
+
+            dependencies: dependencies_iter
+                .map(|(k, v)| (k.clone(), IndexedCrate::new(v)))
+                .collect(),
+        }
+    }
+}
 
 /// The rustdoc for a crate, together with associated indexed data to speed up common operations.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,10 @@ pub(crate) mod test_util;
 // Re-export the Crate type so we can deserialize it.
 pub use rustdoc_types::Crate;
 
+// Re-export `cargo_metadata` since its types are in our public API.
+pub use cargo_metadata;
+
 pub use {
     adapter::RustdocAdapter,
-    indexed_crate::{ImportablePath, IndexedCrate},
+    indexed_crate::{ImportablePath, IndexedCrate, PackageIndex, PackageStorage},
 };

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -33,6 +33,27 @@ type Crate {
   root_module: Module!
 
   item: [Item!]
+
+  """
+  User-facing features that are present in the crate.
+
+  We heuristically disregard features prefixed with `_`, and features introduced by
+  optional dependencies that are never referenced by any other feature.
+  We deem those features to be non-user-facing, and do not show them here.
+  """
+  feature: [Feature!]
+
+  """
+  User-facing features that are enabled by default, either directly or transitively.
+
+  Directly enabled features are explicitly enabled by the `default` feature. Such features
+  may in turn enable other features, and so on — those are transitively enabled default features.
+
+  We heuristically disregard features prefixed with `_`, and features introduced by
+  optional dependencies that are never referenced by any other feature.
+  We deem those features to be non-user-facing, and do not show them here.
+  """
+  default_feature: [Feature!]
 }
 
 """
@@ -2390,4 +2411,18 @@ type ResolvedPathType implements RawType {
   For example: "core::marker::PhantomData" or "std::marker::PhantomData"
   """
   name: String!
+}
+
+type Feature {
+  """
+  The feature's name.
+  """
+  name: String!
+
+  """
+  Other features that are directly (non-transitively) enabled by this feature.
+
+  Enabling those features may in turn enable other features not listed here.
+  """
+  directly_enables: [Feature!]
 }

--- a/test_crates/features/Cargo.toml
+++ b/test_crates/features/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "features"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+default = ["foo", "bar"]
+
+# these are (transitively) enabled by default
+foo = ["baz"]
+bar = []
+baz = []
+
+# this feature is considered internal
+_internal = []
+
+# this feature is opt-in only, not default
+opt_in = []
+
+# this feature enables a dependency
+serde = ["dep:serde"]
+
+# this feature is nightly-only and not considered stable
+nightly = []
+
+# there's also an implicit `serde_json` dependency that's opt-in
+# due to the optional dependency that isn't referenced in a `dep:` or `/` or `?` operator
+
+[dependencies]
+serde = { version = "1.0", optional = true }
+serde_json = { version = "1.0", optional = true }


### PR DESCRIPTION
- **Add schema for features.**
- **Implement feature schema in the Trustfall adapter.**
- **Move `Adapter` impl to `&RustdocAdapter` and add `Drop` impl.**
- **Add support for querying manifest information.**
