### PR TITLE
Allow feature data to not be loaded. (#651)

### DIFF
--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -73,14 +73,16 @@ pub(super) fn resolve_crate_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
             resolve_neighbors_with(contexts, move |vertex| {
                 let origin = vertex.origin;
 
-                let features_lookup = match origin {
+                let Some(features_lookup) = match origin {
                     Origin::CurrentCrate => &current_crate.features,
                     Origin::PreviousCrate => {
                         &previous_crate.expect("no previous crate provided").features
                     }
                 }
-                .as_ref()
-                .expect("no feature data was loaded");
+                .as_ref() else {
+                    // No feature data was loaded.
+                    return Box::new(std::iter::empty());
+                };
 
                 Box::new(
                     features_lookup
@@ -97,14 +99,16 @@ pub(super) fn resolve_crate_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
             resolve_neighbors_with(contexts, move |vertex| {
                 let origin = vertex.origin;
 
-                let features_lookup = match origin {
+                let Some(features_lookup) = match origin {
                     Origin::CurrentCrate => &current_crate.features,
                     Origin::PreviousCrate => {
                         &previous_crate.expect("no previous crate provided").features
                     }
                 }
-                .as_ref()
-                .expect("no feature data was loaded");
+                .as_ref() else {
+                    // No feature data was loaded.
+                    return Box::new(std::iter::empty());
+                };
 
                 // If there's no `default` feature, then no features are enabled by default.
                 let Some(default_feature) = features_lookup.features.get("default") else {

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -40,6 +40,8 @@ type Crate {
   We heuristically disregard features prefixed with `_`, and features introduced by
   optional dependencies that are never referenced by any other feature.
   We deem those features to be non-user-facing, and do not show them here.
+
+  If feature data is not loaded into the adapter, this edge will not have any instances.
   """
   feature: [Feature!]
 
@@ -52,6 +54,8 @@ type Crate {
   We heuristically disregard features prefixed with `_`, and features introduced by
   optional dependencies that are never referenced by any other feature.
   We deem those features to be non-user-facing, and do not show them here.
+
+  If feature data is not loaded into the adapter, this edge will not have any instances.
   """
   default_feature: [Feature!]
 }


### PR DESCRIPTION
Don't crash if no features data has been loaded. Instead, return no data
in those cases.
