### PR TITLE
Add a per-item-kind index of public items in the crate.

### DIFF
--- a/src/adapter/optimizations/item_lookup.rs
+++ b/src/adapter/optimizations/item_lookup.rs
@@ -65,6 +65,195 @@ pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
         }
     }
 
+    // Is the `importable_path` edge being resolved in a subsequent step in a *mandatory* fashion?
+    // If so, we could only match on public items, so check which kinds of public items
+    // we're looking for and only return those from the index.
+    if destination
+        .first_mandatory_edge("importable_path")
+        .is_some()
+    {
+        if let Some(item_type) = destination.coerced_to_type().map(|x| x.as_ref()) {
+            match item_type {
+                "Function" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .free_functions
+                                .iter()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    })
+                }
+                "Struct" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .structs
+                                .iter()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    })
+                }
+                "Enum" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .enums
+                                .iter()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    })
+                }
+                "Union" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .unions
+                                .iter()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    })
+                }
+                "Trait" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .traits
+                                .iter()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    })
+                }
+                "ImplOwner" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .structs
+                                .iter()
+                                .chain(crate_vertex.pub_item_kind_index.enums.iter())
+                                .chain(crate_vertex.pub_item_kind_index.unions.iter())
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    })
+                }
+                "Constant" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .free_consts
+                                .iter()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    })
+                }
+                "Static" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .statics
+                                .iter()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    })
+                }
+                "GlobalValue" => {
+                    // const or static
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .free_consts
+                                .iter()
+                                .chain(crate_vertex.pub_item_kind_index.statics.iter())
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    });
+                }
+                "Macro" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .decl_macros
+                                .iter()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    })
+                }
+                "ProcMacro"
+                | "FunctionLikeProcMacro"
+                | "AttributeProcMacro"
+                | "DeriveProcMacro" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .proc_macros
+                                .iter()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    })
+                }
+                "Module" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .modules
+                                .iter()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    })
+                }
+                _ => {}
+            }
+        }
+    }
+
     resolve_neighbors_with(contexts, |vertex| {
         let crate_vertex = vertex.as_indexed_crate().expect("vertex was not a Crate");
         let origin = vertex.origin;

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -198,6 +198,9 @@ pub struct IndexedCrate<'a> {
     /// -> function item with that export name; exported symbol names must be unique.
     pub(crate) export_name_index: Option<HashMap<&'a str, &'a Item>>,
 
+    /// index: kind of public top-level item -> `Vec<&'a Item>` of that kind
+    pub(crate) pub_item_kind_index: PubItemKindIndex<'a>,
+
     /// Trait items defined in external crates are not present in the `inner: &Crate` field,
     /// even if they are implemented by a type in that crate. This also includes
     /// Rust's built-in traits like `Debug, Send, Eq` etc.
@@ -212,6 +215,159 @@ pub struct IndexedCrate<'a> {
     /// A more complete future solution may generate multiple crates' rustdoc JSON
     /// and link to the external crate's trait items as necessary.
     pub(crate) manually_inlined_builtin_traits: HashMap<Id, Item>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PubItemKindIndex<'a> {
+    pub(crate) free_functions: Vec<&'a Item>,
+    pub(crate) structs: Vec<&'a Item>,
+    pub(crate) enums: Vec<&'a Item>,
+    pub(crate) unions: Vec<&'a Item>,
+    pub(crate) traits: Vec<&'a Item>,
+    pub(crate) modules: Vec<&'a Item>,
+    pub(crate) statics: Vec<&'a Item>,
+    pub(crate) free_consts: Vec<&'a Item>,
+    pub(crate) decl_macros: Vec<&'a Item>,
+    pub(crate) proc_macros: Vec<&'a Item>,
+}
+
+impl<'a> PubItemKindIndex<'a> {
+    fn with_capacity_hint(hint: usize) -> Self {
+        let capacity = if hint < 128 * 128 { 128 } else { hint / 128 };
+        Self {
+            // Most top-level items in a crate are functions, structs, enums, or traits.
+            // We want indexing to be fast, and it's okay if we waste a bit of memory.
+            free_functions: Vec::with_capacity(capacity),
+            structs: Vec::with_capacity(capacity),
+            enums: Vec::with_capacity(capacity),
+            traits: Vec::with_capacity(capacity),
+            unions: Vec::new(),
+            modules: Vec::with_capacity(64),
+            statics: Vec::new(),
+            free_consts: Vec::new(),
+            decl_macros: Vec::new(),
+            proc_macros: Vec::new(),
+        }
+    }
+
+    fn from_crate(crate_: &'a Crate, fn_owner_index: &HashMap<Id, &'a Item>) -> Self {
+        #[cfg(feature = "rayon")]
+        let iter = crate_.index.par_iter().map(|(_, value)| value);
+        #[cfg(not(feature = "rayon"))]
+        let iter = crate_.index.values();
+
+        #[cfg(feature = "rayon")]
+        let init = || Self::with_capacity_hint(crate_.index.len());
+        #[cfg(not(feature = "rayon"))]
+        let init = Self::with_capacity_hint(crate_.index.len());
+
+        let folded = iter.fold(init, |mut acc, item| {
+            if item.visibility == rustdoc_types::Visibility::Public {
+                match &item.inner {
+                    rustdoc_types::ItemEnum::Module { .. } => {
+                        acc.modules.push(item);
+                    }
+                    rustdoc_types::ItemEnum::Union { .. } => {
+                        acc.unions.push(item);
+                    }
+                    rustdoc_types::ItemEnum::Struct { .. } => {
+                        acc.structs.push(item);
+                    }
+                    rustdoc_types::ItemEnum::Enum { .. } => {
+                        acc.enums.push(item);
+                    }
+                    rustdoc_types::ItemEnum::Function { .. } => {
+                        if !fn_owner_index.contains_key(&item.id) {
+                            // This is a free function.
+                            acc.free_functions.push(item);
+                        }
+                    }
+                    rustdoc_types::ItemEnum::Trait { .. } => {
+                        acc.traits.push(item);
+                    }
+                    rustdoc_types::ItemEnum::Constant { .. } => {
+                        acc.free_consts.push(item);
+                    }
+                    rustdoc_types::ItemEnum::Static { .. } => {
+                        acc.statics.push(item);
+                    }
+                    rustdoc_types::ItemEnum::Macro { .. } => {
+                        acc.decl_macros.push(item);
+                    }
+                    rustdoc_types::ItemEnum::ProcMacro { .. } => {
+                        acc.proc_macros.push(item);
+                    }
+                    _ => {}
+                }
+            }
+
+            acc
+        });
+
+        #[cfg(feature = "rayon")]
+        let folded = {
+            let collected = folded
+                .map(|index| vec![index])
+                .reduce(Vec::new, |mut left, right| {
+                    left.extend(right);
+                    left
+                });
+
+            let mut fns_len = 0;
+            let mut structs_len = 0;
+            let mut enums_len = 0;
+            let mut unions_len = 0;
+            let mut traits_len = 0;
+            let mut modules_len = 0;
+            let mut statics_len = 0;
+            let mut consts_len = 0;
+            let mut decl_macros_len = 0;
+            let mut proc_macros_len = 0;
+
+            for c in &collected {
+                fns_len += c.free_functions.len();
+                structs_len += c.structs.len();
+                enums_len += c.enums.len();
+                unions_len += c.unions.len();
+                traits_len += c.traits.len();
+                modules_len += c.modules.len();
+                statics_len += c.statics.len();
+                consts_len += c.free_consts.len();
+                decl_macros_len += c.decl_macros.len();
+                proc_macros_len += c.proc_macros.len();
+            }
+
+            let mut value = Self {
+                free_functions: Vec::with_capacity(fns_len),
+                structs: Vec::with_capacity(structs_len),
+                enums: Vec::with_capacity(enums_len),
+                unions: Vec::with_capacity(unions_len),
+                traits: Vec::with_capacity(traits_len),
+                modules: Vec::with_capacity(modules_len),
+                statics: Vec::with_capacity(statics_len),
+                free_consts: Vec::with_capacity(consts_len),
+                decl_macros: Vec::with_capacity(decl_macros_len),
+                proc_macros: Vec::with_capacity(proc_macros_len),
+            };
+
+            for c in collected {
+                value.free_functions.extend(c.free_functions);
+                value.structs.extend(c.structs);
+                value.enums.extend(c.enums);
+                value.unions.extend(c.unions);
+                value.traits.extend(c.traits);
+                value.modules.extend(c.modules);
+                value.statics.extend(c.statics);
+                value.free_consts.extend(c.free_consts);
+                value.decl_macros.extend(c.decl_macros);
+                value.proc_macros.extend(c.proc_macros);
+            }
+
+            value
+        };
+
+        folded
+    }
 }
 
 /// Map a Key to a List (Vec) of values
@@ -403,14 +559,17 @@ fn build_impl_index(index: &HashMap<Id, Item>) -> MapList<ImplEntry<'_>, (&Item,
 
 impl<'a> IndexedCrate<'a> {
     pub fn new(crate_: &'a Crate) -> Self {
+        let fn_owner_index = build_fn_owner_index(&crate_.index);
+        let pub_item_kind_index = PubItemKindIndex::from_crate(crate_, &fn_owner_index);
         let mut value = Self {
             inner: crate_,
             visibility_tracker: VisibilityTracker::from_crate(crate_),
             manually_inlined_builtin_traits: create_manually_inlined_builtin_traits(crate_),
             imports_index: None,
-            impl_index: None,
-            fn_owner_index: None,
-            export_name_index: None,
+            impl_index: Some(build_impl_index(&crate_.index).into_inner()),
+            fn_owner_index: Some(fn_owner_index),
+            export_name_index: Some(build_export_name_index(&crate_.index)),
+            pub_item_kind_index,
         };
 
         debug_assert!(
@@ -447,10 +606,6 @@ impl<'a> IndexedCrate<'a> {
             .collect::<MapList<_, _>>()
             .into_inner(),
         );
-
-        value.impl_index = Some(build_impl_index(&crate_.index).into_inner());
-        value.fn_owner_index = Some(build_fn_owner_index(&crate_.index));
-        value.export_name_index = Some(build_export_name_index(&crate_.index));
 
         value
     }


### PR DESCRIPTION
Most items we'll see in the crate either aren't public, or aren't top-level items that would be returned by the `Crate -[item]-> Item` edge. For example, many of those items are methods, impls, trait associated types, associated constants, etc.

In this PR, we ensure we don't bother iterating over such items in queries where they can't possibly match. Queries that look at public structs should only iterate over structs, ones that look at enums should only iterate over enums, etc.

This has a substantial performance effect: it speeds up the median `cargo-semver-checks` lint by ~100x, and makes it so that a tiny handful (~5) of lints dominate all linting runtime — the combined runtime of all other lints becomes negligible. In end-to-end terms, `cargo-semver-checks` becomes about ~35% faster on our largest workload, but this number is misleadingly small w.r.t. the impact of this optimization: the new runtime is now equal to ~101% of the slowest lint, whereas that number was ~140% previously. If we can now optimize that slow lint in particular, we'll get tens of percent of additional speedup from the optimization in this PR.
