### PR TITLE
Include ordinal positions of generic parameters in the schema. (#688)

### DIFF
--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -1,5 +1,7 @@
-use rustdoc_types::{GenericBound::TraitBound, Id, ItemEnum, VariantKind, WherePredicate};
-use std::rc::Rc;
+use rustdoc_types::{
+    GenericBound::TraitBound, GenericParamDefKind, Id, ItemEnum, VariantKind, WherePredicate,
+};
+use std::{num::NonZeroUsize, rc::Rc};
 use trustfall::provider::{
     resolve_neighbors_with, AsVertex, ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo,
     VertexIterator,
@@ -262,17 +264,52 @@ pub(super) fn resolve_generic_parameter_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     edge_name: &str,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
+    struct GenericParamCounter {
+        lifetimes: NonZeroUsize,
+        types: NonZeroUsize,
+        consts: NonZeroUsize,
+    }
+
     match edge_name {
         "generic_parameter" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
+            let mut counter = GenericParamCounter {
+                lifetimes: NonZeroUsize::new(1).unwrap(),
+                types: NonZeroUsize::new(1).unwrap(),
+                consts: NonZeroUsize::new(1).unwrap(),
+            };
             Box::new(
                 vertex
                     .as_generics()
                     .map(move |generics| {
-                        generics
-                            .params
-                            .iter()
-                            .map(move |param| origin.make_generic_parameter_vertex(generics, param))
+                        generics.params.iter().map(move |param| {
+                            let position = match param.kind {
+                                GenericParamDefKind::Lifetime { .. } => {
+                                    let position = counter.lifetimes;
+                                    counter.lifetimes =
+                                        position.checked_add(1).expect("param position overflow");
+                                    Some(position)
+                                }
+                                GenericParamDefKind::Type { is_synthetic, .. } => {
+                                    if is_synthetic {
+                                        None
+                                    } else {
+                                        let position = counter.types;
+                                        counter.types = position
+                                            .checked_add(1)
+                                            .expect("param position overflow");
+                                        Some(position)
+                                    }
+                                }
+                                GenericParamDefKind::Const { .. } => {
+                                    let position = counter.consts;
+                                    counter.consts =
+                                        position.checked_add(1).expect("param position overflow");
+                                    Some(position)
+                                }
+                            };
+                            origin.make_generic_parameter_vertex(generics, param, position)
+                        })
                     })
                     .into_iter()
                     .flatten(),

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -203,7 +203,7 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
                 | "GenericTypeParameter"
                 | "GenericLifetimeParameter"
                 | "GenericConstParameter"
-                    if matches!(property_name.as_ref(), "name") =>
+                    if matches!(property_name.as_ref(), "name" | "position") =>
                 {
                     properties::resolve_generic_parameter_property(contexts, property_name)
                 }

--- a/src/adapter/origin.rs
+++ b/src/adapter/origin.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, rc::Rc};
+use std::{borrow::Cow, num::NonZeroUsize, rc::Rc};
 
 use rustdoc_types::{Abi, Item, Span};
 
@@ -145,10 +145,11 @@ impl Origin {
         &self,
         generics: &'a rustdoc_types::Generics,
         param: &'a rustdoc_types::GenericParamDef,
+        position: Option<NonZeroUsize>,
     ) -> Vertex<'a> {
         Vertex {
             origin: *self,
-            kind: VertexKind::GenericParameter(generics, param),
+            kind: VertexKind::GenericParameter(generics, param, position),
         }
     }
 }

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -672,6 +672,16 @@ pub(crate) fn resolve_generic_parameter_property<'a, V: AsVertex<Vertex<'a>> + '
 
             generic.name.clone().into()
         }),
+        "position" => resolve_property_with(contexts, |vertex| {
+            let position = vertex
+                .as_generic_parameter_position()
+                .expect("vertex was not a GenericParameter");
+
+            match position {
+                None => FieldValue::NULL,
+                Some(x) => FieldValue::Uint64(x.get() as u64),
+            }
+        }),
         _ => unreachable!("GenericParameter property {property_name}"),
     }
 }

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -4060,3 +4060,347 @@ fn impl_lookup_by_method_name_optimization() {
     expected_results.sort_unstable();
     similar_asserts::assert_eq!(expected_results, results);
 }
+
+#[test]
+fn generic_param_positions() {
+    get_test_data!(data, generic_param_positions);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on GenericItem {
+                item: name @output
+                item_kind: __typename @output
+
+                generic_parameter {
+                    name @output
+                    kind: __typename @output
+                    position @output
+                }
+            }
+        }
+    }
+}
+    "#;
+
+    let variables: BTreeMap<&str, &str> = BTreeMap::new();
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        item_kind: String,
+        item: String,
+        name: String,
+        kind: String,
+        position: Option<i64>,
+    }
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    let mut expected_results = vec![
+        Output {
+            item_kind: "Function".into(),
+            item: "function".into(),
+            name: "'a".into(),
+            kind: "GenericLifetimeParameter".into(),
+            position: Some(1),
+        },
+        Output {
+            item_kind: "Function".into(),
+            item: "function".into(),
+            name: "'b".into(),
+            kind: "GenericLifetimeParameter".into(),
+            position: Some(2),
+        },
+        Output {
+            item_kind: "Function".into(),
+            item: "function".into(),
+            name: "T".into(),
+            kind: "GenericTypeParameter".into(),
+            position: Some(1),
+        },
+        Output {
+            item_kind: "Function".into(),
+            item: "function".into(),
+            name: "U".into(),
+            kind: "GenericTypeParameter".into(),
+            position: Some(2),
+        },
+        Output {
+            item_kind: "Function".into(),
+            item: "function".into(),
+            name: "N".into(),
+            kind: "GenericConstParameter".into(),
+            position: Some(1),
+        },
+        Output {
+            item_kind: "Function".into(),
+            item: "function".into(),
+            name: "M".into(),
+            kind: "GenericConstParameter".into(),
+            position: Some(2),
+        },
+        Output {
+            item_kind: "Trait".into(),
+            item: "Trait".into(),
+            name: "'a".into(),
+            kind: "GenericLifetimeParameter".into(),
+            position: Some(1),
+        },
+        Output {
+            item_kind: "Trait".into(),
+            item: "Trait".into(),
+            name: "T".into(),
+            kind: "GenericTypeParameter".into(),
+            position: Some(1),
+        },
+        Output {
+            item_kind: "Trait".into(),
+            item: "Trait".into(),
+            name: "N".into(),
+            kind: "GenericConstParameter".into(),
+            position: Some(1),
+        },
+        Output {
+            item_kind: "Function".into(),
+            item: "impl_trait".into(),
+            name: "T".into(),
+            kind: "GenericTypeParameter".into(),
+            position: Some(1),
+        },
+        Output {
+            item_kind: "Function".into(),
+            item: "impl_trait".into(),
+            name: "U".into(),
+            kind: "GenericTypeParameter".into(),
+            position: Some(2),
+        },
+        Output {
+            item_kind: "Function".into(),
+            item: "impl_trait".into(),
+            name: "impl Into<U>".into(),
+            kind: "GenericTypeParameter".into(),
+            position: None,
+        },
+        Output {
+            item_kind: "Struct".into(),
+            item: "Example".into(),
+            name: "'a".into(),
+            kind: "GenericLifetimeParameter".into(),
+            position: Some(1),
+        },
+        Output {
+            item_kind: "Struct".into(),
+            item: "Example".into(),
+            name: "'b".into(),
+            kind: "GenericLifetimeParameter".into(),
+            position: Some(2),
+        },
+        Output {
+            item_kind: "Struct".into(),
+            item: "SingleLifetimeElided".into(),
+            name: "'a".into(),
+            kind: "GenericLifetimeParameter".into(),
+            position: Some(1),
+        },
+    ];
+    expected_results.sort_unstable();
+    similar_asserts::assert_eq!(expected_results, results);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on ImplOwner {
+                item: name @output
+                item_kind: __typename @output
+
+                inherent_impl {
+                    generic_parameter {
+                        name @output
+                        kind: __typename @output
+                        position @output
+                    }
+                }
+            }
+        }
+    }
+}
+    "#;
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    let mut expected_results = vec![
+        Output {
+            item_kind: "Struct".into(),
+            item: "Example".into(),
+            name: "'a".into(),
+            kind: "GenericLifetimeParameter".into(),
+            position: Some(1),
+        },
+        Output {
+            item_kind: "Struct".into(),
+            item: "Example".into(),
+            name: "'b".into(),
+            kind: "GenericLifetimeParameter".into(),
+            position: Some(2),
+        },
+        // `impl SingleLifetimeElided<'_>` doesn't have a generic parameter,
+        // since neither implicit nor elided parameters get an entry.
+    ];
+    expected_results.sort_unstable();
+    similar_asserts::assert_eq!(expected_results, results);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on ImplOwner {
+                item: name @output
+                item_kind: __typename @output
+
+                inherent_impl {
+                    method {
+                        method: name @output
+
+                        generic_parameter {
+                            name @output
+                            kind: __typename @output
+                            position @output
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+    "#;
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output2 {
+        item_kind: String,
+        item: String,
+        method: String,
+        name: String,
+        kind: String,
+        position: Option<i64>,
+    }
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    let mut expected_results = vec![
+        Output2 {
+            item_kind: "Struct".into(),
+            item: "Example".into(),
+            method: "elided_lifetimes".into(),
+            name: "'c".into(),
+            kind: "GenericLifetimeParameter".into(),
+            position: Some(1),
+        },
+        Output2 {
+            item_kind: "Struct".into(),
+            item: "SingleLifetimeElided".into(),
+            method: "explicit_self_lifetime".into(),
+            name: "'a".into(),
+            kind: "GenericLifetimeParameter".into(),
+            position: Some(1),
+        },
+        Output2 {
+            item_kind: "Struct".into(),
+            item: "SingleLifetimeElided".into(),
+            method: "explicit_self_lifetime".into(),
+            name: "impl Into<&'a i64>".into(),
+            kind: "GenericTypeParameter".into(),
+            position: None,
+        },
+    ];
+    expected_results.sort_unstable();
+    similar_asserts::assert_eq!(expected_results, results);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Trait {
+                item: name @output
+                item_kind: __typename @output
+
+                method {
+                    method: name @output
+
+                    generic_parameter {
+                        name @output
+                        kind: __typename @output
+                        position @output
+                    }
+                }
+            }
+        }
+    }
+}
+    "#;
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    let mut expected_results = vec![
+        Output2 {
+            item_kind: "Trait".into(),
+            item: "Trait".into(),
+            method: "method".into(),
+            name: "'b".into(),
+            kind: "GenericLifetimeParameter".into(),
+            position: Some(1),
+        },
+        Output2 {
+            item_kind: "Trait".into(),
+            item: "Trait".into(),
+            method: "method".into(),
+            name: "U".into(),
+            kind: "GenericTypeParameter".into(),
+            position: Some(1),
+        },
+        Output2 {
+            item_kind: "Trait".into(),
+            item: "Trait".into(),
+            method: "method".into(),
+            name: "V".into(),
+            kind: "GenericTypeParameter".into(),
+            position: Some(2),
+        },
+        Output2 {
+            item_kind: "Trait".into(),
+            item: "Trait".into(),
+            method: "method".into(),
+            name: "M".into(),
+            kind: "GenericConstParameter".into(),
+            position: Some(1),
+        },
+    ];
+    expected_results.sort_unstable();
+    similar_asserts::assert_eq!(expected_results, results);
+}

--- a/src/adapter/vertex.rs
+++ b/src/adapter/vertex.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, rc::Rc};
+use std::{borrow::Cow, num::NonZeroUsize, rc::Rc};
 
 use rustdoc_types::{
     Abi, Constant, Crate, Enum, Function, GenericBound, GenericParamDef, Impl, Item, Module, Path,
@@ -38,7 +38,11 @@ pub enum VertexKind<'a> {
     Discriminant(Cow<'a, str>),
     Variant(EnumVariant<'a>),
     DeriveHelperAttr(&'a str),
-    GenericParameter(&'a rustdoc_types::Generics, &'a GenericParamDef),
+    GenericParameter(
+        &'a rustdoc_types::Generics,
+        &'a GenericParamDef,
+        Option<NonZeroUsize>,
+    ),
     Feature(Feature<'a>),
 }
 
@@ -94,7 +98,7 @@ impl Typename for Vertex<'_> {
                 VariantKind::Struct { .. } => "StructVariant",
             },
             VertexKind::DeriveHelperAttr(..) => "DeriveMacroHelperAttribute",
-            VertexKind::GenericParameter(_, param) => match &param.kind {
+            VertexKind::GenericParameter(_, param, _) => match &param.kind {
                 rustdoc_types::GenericParamDefKind::Lifetime { .. } => "GenericLifetimeParameter",
                 rustdoc_types::GenericParamDefKind::Type { .. } => "GenericTypeParameter",
                 rustdoc_types::GenericParamDefKind::Const { .. } => "GenericConstParameter",
@@ -319,7 +323,14 @@ impl<'a> Vertex<'a> {
         &self,
     ) -> Option<(&'a rustdoc_types::Generics, &'a GenericParamDef)> {
         match &self.kind {
-            VertexKind::GenericParameter(generics, param) => Some((generics, param)),
+            VertexKind::GenericParameter(generics, param, _) => Some((generics, param)),
+            _ => None,
+        }
+    }
+
+    pub(super) fn as_generic_parameter_position(&self) -> Option<Option<NonZeroUsize>> {
+        match &self.kind {
+            VertexKind::GenericParameter(_, _, position) => Some(*position),
             _ => None,
         }
     }

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -172,6 +172,15 @@ interface GenericItem implements Item {
 
   """
   Generic type, lifetime, or const parameters by which this item is parameterized.
+
+  Lifetime parameters that are elided or unnamed (such as in `&self` or `Example<'_>`)
+  do not have a `generic_parameter` entry.
+
+  `impl Trait` in parameter position is considered a synthetic generic type parameter,
+  since that functionality is merely syntax sugar for such a generic type.
+
+  `impl Trait` in return position is not considered a generic type parameter,
+  since its desugaring is different: it's more like an associated type than a generic.
   """
   generic_parameter: [GenericParameter]
 }
@@ -1033,6 +1042,9 @@ type Impl implements Item & GenericItem {
   # edges from GenericItem
   """
   Generic type, lifetime, or const parameters by which this impl is parameterized.
+
+  Lifetime parameters that are elided or unnamed (such as in `impl Example<'_>`)
+  do not have a `generic_parameter` entry.
   """
   generic_parameter: [GenericParameter]
 
@@ -1390,6 +1402,15 @@ type Function implements Item & FunctionLike & Importable & GenericItem {
   # edges from GenericItem
   """
   Generic type, lifetime, or const parameters by which this function is parameterized.
+
+  Lifetime parameters that are elided or unnamed (such as in `&i64` or `&'_ i64`)
+  do not have a `generic_parameter` entry.
+
+  `impl Trait` in parameter position is considered a synthetic generic type parameter,
+  since that functionality is merely syntax sugar for such a generic type.
+
+  `impl Trait` in return position is not considered a generic type parameter,
+  since its desugaring is different: it's more like an associated type than a generic.
   """
   generic_parameter: [GenericParameter]
 }
@@ -1467,6 +1488,15 @@ type Method implements Item & FunctionLike & GenericItem {
 
   This only includes the *method's own* generic parameters. It does not include
   any generic parameters that may be part of the definition of the type that owns the method.
+
+  Lifetime parameters that are elided or unnamed (such as in `&self` or `Example<'_>`)
+  do not have a `generic_parameter` entry.
+
+  `impl Trait` in parameter position is considered a synthetic generic type parameter,
+  since that functionality is merely syntax sugar for such a generic type.
+
+  `impl Trait` in return position is not considered a generic type parameter,
+  since its desugaring is different: it's more like an associated type than a generic.
   """
   generic_parameter: [GenericParameter]
 }
@@ -2317,6 +2347,29 @@ interface GenericParameter {
   - `"N"` as a generic constant
   """
   name: String!
+
+  """
+  The 1-based position of this generic parameter in the item's type signature.
+
+  For example, in `struct Generic<'a, 'b>`,
+  parameter `'a` has position `1` while `'b` has position `2`.
+
+  The position considers parameters of each kind (lifetime, type, and const) separately.
+  For example: in `struct Generic<'a, T, U>`, both the `'a` lifetime parameter and
+  the `T` type parameter have position `1`, while the `U` generic parameter has position `2`.
+
+  The position only considers generic parameters belonging *directly* to
+  the item in question. It ignores generic parameters originally declared by a parent item.
+  For example, in `fn method<'b>(&self, a: &'a i64, b: &'b i64);` found inside `trait Example<'a>`,
+  the `'b` lifetime parameter has position `1` as the `'a` lifetime parameter belongs to `Example`,
+  not `method`.
+
+  Synthetic (`impl Trait`) generic type parameters do not have a positional index. This property
+  has value `null` for them. For example,
+  in `fn method<T>(&self, value: T, iter: impl Into<String>) { ... }`, the `T` type parameter
+  has position `1` whereas the `impl Into<String>` synthetic generic type has position `null`.
+  """
+  position: Int
 }
 
 type GenericTypeParameter implements GenericParameter {
@@ -2351,6 +2404,28 @@ type GenericTypeParameter implements GenericParameter {
   """
   synthetic: Boolean!
 
+  """
+  The 1-based position of this generic type parameter in the item's type signature.
+
+  For example, in `struct Generic<A, B>`, parameter `A` has position `1` while `B` has position `2`.
+
+  The position only considers type parameters. For example: in `struct Generic<'a, 'b, T>`,
+  the `T` type parameter has position `1`. The other generic parameters are ignored
+  when computing `T`'s position.
+
+  The position only considers generic type parameters belonging *directly* to
+  the item in question. It ignores generic parameters originally declared by a parent item.
+  For example, in `fn method<B>(&self, a: A, b: B);` found inside `trait Example<A>`,
+  the `B` type parameter has position `1` as the `A` type parameter belongs to `Example`,
+  not `method`.
+
+  Synthetic (`impl Trait`) generic type parameters do not have a positional index. This property
+  has value `null` for them. For example,
+  in `fn method<T>(&self, value: T, iter: impl Into<String>) { ... }`, the `T` type parameter
+  has position `1` whereas the `impl Into<String>` synthetic generic type has position `null`.
+  """
+  position: Int
+
   # own edges
   """
   Type bounds applied specifically to this generic type parameter.
@@ -2381,6 +2456,24 @@ type GenericLifetimeParameter implements GenericParameter {
   """
   name: String!
 
+  """
+  The 1-based position of this generic lifetime parameter in the item's type signature.
+
+  For example, in `struct Generic<'a, 'b>`,
+  parameter `'a` has position `1` while `'b` has position `2`.
+
+  The position only considers lifetime parameters. For example: in `struct Generic<'a, T, U>`,
+  the `'a` lifetime parameter has position `1`. The other generic parameters are ignored
+  when computing `'a`'s position.
+
+  The position only considers generic lifetime parameters belonging *directly* to
+  the item in question. It ignores generic parameters originally declared by a parent item.
+  For example, in `fn method<'b>(&self, a: &'a i64, b: &'b i64);` found inside `trait Example<'a>`,
+  the `'b` lifetime parameter has position `1` as the `'a` lifetime parameter belongs to `Example`,
+  not `method`.
+  """
+  position: Int!
+
   # own edges
   # TODO: needs lifetime bounds
   # lifetime_bound: ?
@@ -2402,6 +2495,25 @@ type GenericConstParameter implements GenericParameter {
   Whether the generic const parameter has a default value.
   """
   has_default: Boolean!
+
+  """
+  The 1-based position of this generic const parameter in the item's type signature.
+
+  For example, in `struct Generic<const N: usize, const M: usize>`,
+  parameter `N` has position `1` while `M` has position `2`.
+
+  The position only considers const parameters.
+  For example: in `struct Generic<'a, T, const N: usize>`,
+  the `N` const parameter has position `1`. The other generic parameters are ignored
+  when computing `N`'s position.
+
+  The position only considers const generics belonging *directly* to
+  the item in question. It ignores generic parameters originally declared by a parent item.
+  For example, in `fn method<const M: usize>(&self, a: &'a [i64; N], b: &'b [i64; M]);`
+  found inside `trait Example<const N: usize>`, the `M` lifetime parameter has position `1` as
+  the `N` lifetime parameter belongs to `Example`, not `method`.
+  """
+  position: Int!
 
   # own edges
   # TODO: needs type and value

--- a/test_crates/generic_param_positions/Cargo.toml
+++ b/test_crates/generic_param_positions/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "generic_param_positions"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/generic_param_positions/src/lib.rs
+++ b/test_crates/generic_param_positions/src/lib.rs
@@ -1,0 +1,27 @@
+#![allow(unused_variables)]
+
+pub fn function<'a, 'b, T, U, const N: usize, const M: usize>(left: &'a [T; N], right: &'b [U; M]) {}
+
+pub trait Trait<'a, T, const N: usize> {
+    fn method<'b, U, V, const M: usize>(&self, value: &'b U) -> [V; M];
+}
+
+pub fn impl_trait<T, U>(first: T, impld: impl Into<U>) -> impl Iterator<Item = T> {}
+
+pub struct Example<'a, 'b> {
+    _marker: std::marker::PhantomData<&'a &'b ()>,
+}
+
+impl<'a, 'b> Example<'a, 'b> {
+    pub fn elided_lifetimes<'c>(&self, arg: &'a i64, elided: &i64, explicit: &'c i64) -> &'_ i64 {
+        todo!()
+    }
+}
+
+pub struct SingleLifetimeElided<'a> {
+    _marker: std::marker::PhantomData<&'a ()>,
+}
+
+impl SingleLifetimeElided<'_> {
+    pub fn explicit_self_lifetime<'a>(&'a self, value: impl Into<&'a i64>) {}
+}


### PR DESCRIPTION
Contains a breaking change to the `VertexKind::GenericParameter` enum
variant.
