### PR TITLE
Use `rustc-hash` everywhere when enabled.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,12 @@ jobs:
       - name: test with rayon
         run: cargo test --features rayon
 
+      - name: compile with rayon and rustc-hash
+        run: cargo test --no-run --features rayon,rustc-hash
+
+      - name: test with rayon and rustc-hash
+        run: cargo test --features rayon,rustc-hash
+
   publish:
     name: Publish to crates.io
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,10 +530,11 @@ checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustdoc-types"
-version = "0.32.0"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0958527c2f4e8ff8b64e067bda402306946efc96f9b69f9f691b146f4b17f930"
+checksum = "7fd5cb7a0c0a5a4f6bc429274fc1073d395237c83ef13d0ac728e0f95f5499ca"
 dependencies = [
+ "rustc-hash",
  "serde",
 ]
 
@@ -740,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "36.4.0"
+version = "37.2.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustfall-rustdoc-adapter"
-version = "36.4.0"
+version = "37.2.0"
 edition = "2021"
 authors = ["Predrag Gruevski <obi1kenobi82@gmail.com>"]
 license = "Apache-2.0 OR MIT"
@@ -25,7 +25,7 @@ cargo_metadata = "0.19.1"
 # Keep this dependency last, its own block, since we change it often via automated means
 # and we'd like to avoid merge conflicts.
 #
-rustdoc-types = "0.32.0"
+rustdoc-types = "0.32.1"
 #
 # No dependencies after this point. Put all dependencies above this section.
 #
@@ -37,7 +37,7 @@ default = []
 # definitely increases the memory usage
 rayon = ["dep:rayon"]
 # Use rustc-hash::{FxHashMap, FxHashSet} internally for improved performance
-rustc-hash = ["dep:rustc-hash"]
+rustc-hash = ["dep:rustc-hash", "rustdoc-types/rustc-hash"]
 
 [[bench]]
 name = "indexed_crate"

--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -1,7 +1,8 @@
+use std::{num::NonZeroUsize, rc::Rc};
+
 use rustdoc_types::{
     GenericBound::TraitBound, GenericParamDefKind, Id, ItemEnum, VariantKind, WherePredicate,
 };
-use std::{num::NonZeroUsize, rc::Rc};
 use trustfall::provider::{
     resolve_neighbors_with, AsVertex, ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo,
     VertexIterator,

--- a/src/adapter/enum_variant.rs
+++ b/src/adapter/enum_variant.rs
@@ -1,10 +1,11 @@
-use rustdoc_types::{Item, ItemEnum, Variant};
 use std::borrow::Cow;
 use std::cell::OnceCell;
 use std::fmt::{self, Debug};
 use std::num::ParseIntError;
 use std::rc::Rc;
 use std::str::FromStr;
+
+use rustdoc_types::{Item, ItemEnum, Variant};
 
 #[non_exhaustive]
 #[derive(Debug, Clone)]

--- a/src/adapter/optimizations/impl_lookup.rs
+++ b/src/adapter/optimizations/impl_lookup.rs
@@ -1,4 +1,8 @@
+#[cfg(not(feature = "rustc-hash"))]
 use std::collections::HashMap;
+
+#[cfg(feature = "rustc-hash")]
+use rustc_hash::FxHashMap as HashMap;
 
 use rustdoc_types::{Id, Item};
 use trustfall::{

--- a/src/adapter/optimizations/method_lookup.rs
+++ b/src/adapter/optimizations/method_lookup.rs
@@ -1,4 +1,10 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
+
+#[cfg(not(feature = "rustc-hash"))]
+use std::collections::HashMap;
+
+#[cfg(feature = "rustc-hash")]
+use rustc_hash::FxHashMap as HashMap;
 
 use rustdoc_types::{Id, Impl, Item, ItemEnum, Type};
 use trustfall::{

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -1,8 +1,10 @@
-use std::{
-    borrow::Borrow,
-    collections::{hash_map::Entry, HashMap, HashSet},
-    sync::Arc,
-};
+use std::{borrow::Borrow, collections::hash_map::Entry, sync::Arc};
+
+#[cfg(not(feature = "rustc-hash"))]
+use std::collections::{HashMap, HashSet};
+
+#[cfg(feature = "rustc-hash")]
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
@@ -270,7 +272,7 @@ impl<K: std::cmp::Eq + std::hash::Hash, V> Extend<(K, V)> for MapList<K, V> {
 impl<K: std::cmp::Eq + std::hash::Hash, V> MapList<K, V> {
     #[inline]
     pub fn new() -> Self {
-        Self(HashMap::new())
+        Self(HashMap::default())
     }
 
     #[inline]
@@ -786,7 +788,7 @@ fn new_trait(manual_trait_item: &ManualTraitItem, id: Id, crate_id: u32) -> Item
         span: None,
         visibility: rustdoc_types::Visibility::Public,
         docs: None,
-        links: HashMap::new(),
+        links: HashMap::default(),
         attrs: Vec::new(),
         deprecation: None,
         inner: rustdoc_types::ItemEnum::Trait(rustdoc_types::Trait {

--- a/src/visibility_tracker.rs
+++ b/src/visibility_tracker.rs
@@ -1,7 +1,8 @@
-#[cfg(feature = "rustc-hash")]
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 #[cfg(not(feature = "rustc-hash"))]
 use std::collections::{HashMap, HashSet};
+
+#[cfg(feature = "rustc-hash")]
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use rustdoc_types::{Crate, GenericArgs, Id, Item, ItemEnum, TypeAlias, Visibility};
 


### PR DESCRIPTION
Use it internally for all hashmaps and hashsets, and explicitly enable it in `rustdoc-types` too.