### PR TITLE
Add export name to static (#737)

### DIFF
--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -274,7 +274,7 @@ pub(super) fn resolve_function_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
     match property_name {
         "export_name" => resolve_property_with(contexts, move |vertex| {
             let item = vertex.as_item().expect("not an Item vertex");
-            crate::exported_name::function_export_name(item).into()
+            crate::exported_name::item_export_name(item).into()
         }),
         _ => unreachable!("Function property {property_name}"),
     }
@@ -538,6 +538,10 @@ pub(crate) fn resolve_static_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
         "unsafe" => resolve_property_with(contexts, |_| {
             // This data is not available in this version of rustdoc JSON.
             FieldValue::Null
+        }),
+        "export_name" => resolve_property_with(contexts, |vertex| {
+            let item = vertex.as_item().expect("not an Item");
+            crate::exported_name::item_export_name(item).into()
         }),
         _ => unreachable!("Static property {property_name}"),
     }

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -723,6 +723,58 @@ fn rustdoc_finds_statics() {
 }
 
 #[test]
+fn static_export_name() {
+    get_test_data!(data, static_export_name);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Static {
+                name @output
+                export_name @output
+            }
+        }
+    }
+}
+"#;
+
+    let variables: BTreeMap<&str, &str> = BTreeMap::default();
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        export_name: Option<String>,
+    }
+
+    let mut results: Vec<Output> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    similar_asserts::assert_eq!(
+        vec![
+            Output {
+                name: "VAR1".into(),
+                export_name: Some("VAR1".into())
+            },
+            Output {
+                name: "VAR2".into(),
+                export_name: Some("EXTERNALLY_VISIBLE".into())
+            },
+        ],
+        results
+    );
+}
+
+#[test]
 fn rustdoc_modules() {
     get_test_data!(data, modules);
     let adapter = RustdocAdapter::new(&data, None);

--- a/src/exported_name.rs
+++ b/src/exported_name.rs
@@ -1,10 +1,12 @@
 use crate::attributes::Attribute;
 
-/// Get the externally-visible name of the specified function item, if any.
+/// Get the externally-visible name of the specified item, if any.
 ///
-/// Most Rust functions do not have an externally-visible name. Only functions intended
-/// to be called from "outside" the program via FFI have external names, which are set
-/// in one of the following ways:
+/// Most Rust items do not have an externally-visible name. Only items intended
+/// to be called or accessed from "outside" the program via FFI have external names,
+/// which are set in one of the following ways:
+///
+/// For functions:
 /// ```rust
 /// #[no_mangle]  // visible as `externally_visible`
 /// fn externally_visible() {}
@@ -13,9 +15,19 @@ use crate::attributes::Attribute;
 /// fn internal_name() {}
 /// ```
 ///
-/// For all other functions, this function returns `None`.
-/// If this function is called with a non-function item, the result is unspecified.
-pub(crate) fn function_export_name(item: &rustdoc_types::Item) -> Option<&str> {
+/// For statics:
+/// ```rust
+/// #[no_mangle]  // visible as `VAR1`
+/// static VAR1: i32 = 42;
+///
+/// #[export_name = "EXTERNALLY_VISIBLE"] // visible as `EXTERNALLY_VISIBLE`
+/// static VAR2: i32 = 42;
+/// ```
+///
+/// For all other functions/statics, this function returns `None`.
+/// If this function is called with an item that doesn't support external names,
+/// the result is unspecified.
+pub(crate) fn item_export_name(item: &rustdoc_types::Item) -> Option<&str> {
     if item.attrs.iter().any(|attr| attr == "#[no_mangle]") {
         // Items with `#[no_mangle]` attributes are exported under their item name.
         // Ref: https://doc.rust-lang.org/reference/abi.html#the-no_mangle-attribute

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -588,11 +588,14 @@ fn build_export_name_index(index: &HashMap<Id, Item>) -> HashMap<&str, &Item> {
     let iter = index.values();
 
     iter.filter_map(|item| {
-        if !matches!(item.inner, rustdoc_types::ItemEnum::Function(..)) {
+        if !matches!(
+            item.inner,
+            rustdoc_types::ItemEnum::Function(..) | rustdoc_types::ItemEnum::Static(..)
+        ) {
             return None;
         }
 
-        crate::exported_name::function_export_name(item).map(move |name| (name, item))
+        crate::exported_name::item_export_name(item).map(move |name| (name, item))
     })
     .collect()
 }

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -1722,6 +1722,28 @@ type Static implements Item & Importable & GlobalValue {
   # own properties
   mutable: Boolean!
   unsafe: Boolean!
+  """
+  The unmangled or explicitly-specified export name of this item, if any.
+
+  Export names are defined using the `#[export_name]` or `#[no_mangle]` attributes.
+
+  For example:
+  - The following static has `export_name = "VAR1"`:
+    ```rust
+    #[no_mangle]
+    static VAR1: i32 = 42;
+    ```
+  - The following static has `export_name = "EXTERNALLY_VISIBLE"`:
+    ```rust
+    #[export_name = "EXTERNALLY_VISIBLE"]
+    static VAR2: i32 = 42;
+    ```
+
+  More info:
+  https://doc.rust-lang.org/reference/abi.html#the-no_mangle-attribute
+  https://doc.rust-lang.org/reference/abi.html#the-export_name-attribute
+  """
+  export_name: String
 
   # edges from Item
   span: Span

--- a/test_crates/static_export_name/Cargo.toml
+++ b/test_crates/static_export_name/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "static_export_name"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/static_export_name/src/lib.rs
+++ b/test_crates/static_export_name/src/lib.rs
@@ -1,0 +1,5 @@
+#[no_mangle]
+pub static VAR1: i32 = 42;
+
+#[export_name = "EXTERNALLY_VISIBLE"]
+pub static VAR2: i32 = 42;


### PR DESCRIPTION
close #238.
But in Rust version 2024:
https://doc.rust-lang.org/reference/abi.html?highlight=no_mang#the-no_mangle-attribute,
we need to use `#[unsafe(no_mangle)]` and `#[unsafe(export_name =
"name")]`. Should we account for that?
