### PR TITLE
Reworked and improved trait sealing analysis

### DIFF
--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -460,6 +460,20 @@ pub(super) fn resolve_trait_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
 
             handler.own_crate.is_trait_sealed(&trait_item.id).into()
         }),
+        "public_api_sealed" => resolve_property_with(contexts, move |vertex| {
+            let trait_item = vertex.as_item().expect("not an Item");
+            let origin = vertex.origin;
+
+            let handler = match origin {
+                Origin::CurrentCrate => current_crate,
+                Origin::PreviousCrate => previous_crate.expect("no previous crate provided"),
+            };
+
+            handler
+                .own_crate
+                .is_trait_public_api_sealed(&trait_item.id)
+                .into()
+        }),
         _ => unreachable!("Trait property {property_name}"),
     }
 }

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -449,7 +449,7 @@ pub(super) fn resolve_trait_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
         "object_safe" => {
             resolve_property_with(contexts, field_property!(as_trait, is_dyn_compatible))
         }
-        "sealed" => resolve_property_with(contexts, move |vertex| {
+        "unconditionally_sealed" | "sealed" => resolve_property_with(contexts, move |vertex| {
             let trait_item = vertex.as_item().expect("not an Item");
             let origin = vertex.origin;
 

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -438,6 +438,18 @@ fn rustdoc_sealed_traits() {
             name: "BlanketOverPointerSealed".into(),
             sealed: true,
         },
+        Output {
+            name: "SealedPlusSelfBlanket".into(),
+            sealed: true,
+        },
+        Output {
+            name: "RecursiveSealed".into(),
+            sealed: true,
+        },
+        Output {
+            name: "SealedPlusRecursiveBlanket".into(),
+            sealed: true,
+        },
     ];
     expected_results.sort_unstable();
 

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -342,6 +342,24 @@ fn rustdoc_sealed_traits() {
             public_api_sealed: false,
         },
         Output {
+            name: "ConstItemPubInPrivTypeSealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "ConstItemPubInPrivTypeSealed".into(),
+            ]],
+            sealed: true,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "NotSealedDueToConstDefaultValue".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "NotSealedDueToConstDefaultValue".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
             name: "NotTransitivelySealed".into(),
             path: vec![vec!["sealed_traits".into(), "NotTransitivelySealed".into()]],
             sealed: false,
@@ -767,6 +785,16 @@ fn rustdoc_sealed_traits() {
                 "sealed_traits".into(),
                 "doc_hidden".into(),
                 "HiddenSealedAssocConst".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "HiddenSealedAssocConstType".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "HiddenSealedAssocConstType".into(),
             ]],
             sealed: false,
             public_api_sealed: true,

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -213,6 +213,11 @@ fn rustdoc_sealed_traits() {
             ... on Trait {
                 name @output
                 sealed @output
+                public_api_sealed @output
+
+                importable_path @fold {
+                    path @output
+                }
             }
         }
     }
@@ -227,7 +232,9 @@ fn rustdoc_sealed_traits() {
     #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
     struct Output {
         name: String,
+        path: Vec<Vec<String>>,
         sealed: bool,
+        public_api_sealed: bool,
     }
 
     let mut results: Vec<_> =
@@ -240,215 +247,903 @@ fn rustdoc_sealed_traits() {
     let mut expected_results = vec![
         Output {
             name: "Sealed".into(),
+            path: vec![],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "InternalMarker".into(),
+            path: vec![],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "DirectlyTraitSealed".into(),
+            path: vec![vec!["sealed_traits".into(), "DirectlyTraitSealed".into()]],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "TransitivelyTraitSealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "TransitivelyTraitSealed".into(),
+            ]],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "SealedTraitWithStdSupertrait".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "SealedTraitWithStdSupertrait".into(),
+            ]],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "SealedWithWhereSelfBound".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "SealedWithWhereSelfBound".into(),
+            ]],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "PrivateSealed".into(),
+            path: vec![],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "SealedWithPrivateSupertrait".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "SealedWithPrivateSupertrait".into(),
+            ]],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "Unsealed".into(),
+            path: vec![vec!["sealed_traits".into(), "Unsealed".into()]],
             sealed: false,
+            public_api_sealed: false,
         },
         Output {
             name: "MethodSealed".into(),
+            path: vec![vec!["sealed_traits".into(), "MethodSealed".into()]],
             sealed: true,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "MethodReturnSealed".into(),
+            path: vec![vec!["sealed_traits".into(), "MethodReturnSealed".into()]],
+            sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "TransitivelyMethodSealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "TransitivelyMethodSealed".into(),
+            ]],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "NotMethodSealedBecauseOfDefaultImpl".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "NotMethodSealedBecauseOfDefaultImpl".into(),
+            ]],
             sealed: false,
+            public_api_sealed: false,
         },
         Output {
             name: "NotTransitivelySealed".into(),
+            path: vec![vec!["sealed_traits".into(), "NotTransitivelySealed".into()]],
             sealed: false,
+            public_api_sealed: false,
         },
         Output {
             name: "TraitUnsealedButMethodGenericSealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "TraitUnsealedButMethodGenericSealed".into(),
+            ]],
             sealed: false,
+            public_api_sealed: false,
         },
         Output {
             name: "NotGenericSealedBecauseOfDefaultImpl".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "NotGenericSealedBecauseOfDefaultImpl".into(),
+            ]],
             sealed: false,
+            public_api_sealed: false,
         },
         Output {
             name: "IteratorExt".into(),
+            path: vec![vec!["sealed_traits".into(), "IteratorExt".into()]],
             sealed: false,
+            public_api_sealed: false,
         },
         Output {
             name: "Iterator".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "shadow_builtins".into(),
+                "Iterator".into(),
+            ]],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "ShadowedSubIterator".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "shadow_builtins".into(),
+                "ShadowedSubIterator".into(),
+            ]],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "Super".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "generic_seal".into(),
+                "Super".into(),
+            ]],
             sealed: false,
+            public_api_sealed: false,
         },
         Output {
             name: "Marker".into(),
+            path: vec![],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "NotGenericSealedBecauseOfPubSupertrait".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "generic_seal".into(),
+                "NotGenericSealedBecauseOfPubSupertrait".into(),
+            ]],
             sealed: false,
+            public_api_sealed: false,
         },
         Output {
             name: "FullBlanket".into(),
+            path: vec![],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "PrivateBlanket".into(),
+            path: vec![],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "RefBlanket".into(),
+            path: vec![],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "ExternalSupertraitsBlanket".into(),
+            path: vec![],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "BlanketWithWhereClause".into(),
+            path: vec![],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "IteratorBlanket".into(),
+            path: vec![],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "BlanketOverLocalUnsealedTrait".into(),
+            path: vec![],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "BlanketOverSealedTrait".into(),
+            path: vec![],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "BlanketOverSealedAndUnsealedTrait".into(),
+            path: vec![],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "TransitiveBlanket".into(),
+            path: vec![],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "BlanketOverArc".into(),
+            path: vec![],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "BlanketOverTuple".into(),
+            path: vec![],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "BlanketOverSlice".into(),
+            path: vec![],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "BlanketOverArray".into(),
+            path: vec![],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "BlanketOverPointer".into(),
+            path: vec![],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "BlanketUnsealed".into(),
+            path: vec![vec!["sealed_traits".into(), "BlanketUnsealed".into()]],
             sealed: false,
+            public_api_sealed: false,
         },
         Output {
             name: "RefBlanketUnsealed".into(),
+            path: vec![vec!["sealed_traits".into(), "RefBlanketUnsealed".into()]],
             sealed: false,
+            public_api_sealed: false,
         },
         Output {
             name: "ExternalSupertraitsBlanketUnsealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "ExternalSupertraitsBlanketUnsealed".into(),
+            ]],
             sealed: false,
+            public_api_sealed: false,
         },
         Output {
             name: "BlanketWithWhereClauseUnsealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "BlanketWithWhereClauseUnsealed".into(),
+            ]],
             sealed: false,
+            public_api_sealed: false,
         },
         Output {
             name: "IteratorBlanketUnsealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "IteratorBlanketUnsealed".into(),
+            ]],
             sealed: false,
+            public_api_sealed: false,
         },
         Output {
             name: "BlanketOverLocalUnsealedTraitUnsealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "BlanketOverLocalUnsealedTraitUnsealed".into(),
+            ]],
             sealed: false,
+            public_api_sealed: false,
         },
         Output {
             name: "BlanketOverSealedTraitSealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "BlanketOverSealedTraitSealed".into(),
+            ]],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "BlanketSealedOverMultiple".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "BlanketSealedOverMultiple".into(),
+            ]],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "TransitiveBlanketUnsealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "TransitiveBlanketUnsealed".into(),
+            ]],
             sealed: false,
+            public_api_sealed: false,
         },
         Output {
             name: "BlanketOverArcSealed".into(),
+            path: vec![vec!["sealed_traits".into(), "BlanketOverArcSealed".into()]],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "BlanketOverTupleSealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "BlanketOverTupleSealed".into(),
+            ]],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "BlanketOverSliceSealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "BlanketOverSliceSealed".into(),
+            ]],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "BlanketOverArraySealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "BlanketOverArraySealed".into(),
+            ]],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "BlanketOverPointerSealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "BlanketOverPointerSealed".into(),
+            ]],
             sealed: true,
-        },
-        Output {
-            name: "SealedPlusSelfBlanket".into(),
-            sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "RecursiveSealed".into(),
+            path: vec![],
             sealed: true,
+            public_api_sealed: true,
         },
         Output {
             name: "SealedPlusRecursiveBlanket".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "cyclic_bounds".into(),
+                "SealedPlusRecursiveBlanket".into(),
+            ]],
             sealed: true,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "HiddenSealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "hidden_module".into(),
+                "HiddenSealed".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "Unsealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "Unsealed".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "DirectlyHiddenSealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "DirectlyHiddenSealed".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "HiddenSealedInherited".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "HiddenSealedInherited".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "TransitivelyHiddenSealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "TransitivelyHiddenSealed".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "HiddenSealedWithWhereSelfBound".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "HiddenSealedWithWhereSelfBound".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "MethodHiddenSealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "MethodHiddenSealed".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "MethodReturnHiddenSealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "MethodReturnHiddenSealed".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "HiddenMethodHiddenSealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "HiddenMethodHiddenSealed".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "TransitivelyMethodHiddenSealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "TransitivelyMethodHiddenSealed".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "NotMethodHiddenSealedBecauseOfDefaultImpl".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "NotMethodHiddenSealedBecauseOfDefaultImpl".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "HiddenSealedAssocType".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "HiddenSealedAssocType".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "HiddenSealedAssocConst".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "HiddenSealedAssocConst".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "UnsealedDefaultAssocConst".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "UnsealedDefaultAssocConst".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "MethodWithHiddenBound".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "MethodWithHiddenBound".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "FullBlanket".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "blanket_impls".into(),
+                "FullBlanket".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "RefBlanket".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "blanket_impls".into(),
+                "RefBlanket".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "ExternalSupertraitsBlanket".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "blanket_impls".into(),
+                "ExternalSupertraitsBlanket".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "BlanketWithWhereClause".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "blanket_impls".into(),
+                "BlanketWithWhereClause".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "IteratorBlanket".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "blanket_impls".into(),
+                "IteratorBlanket".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "BlanketOverLocalUnsealedTrait".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "blanket_impls".into(),
+                "BlanketOverLocalUnsealedTrait".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "BlanketOverSealedTrait".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "blanket_impls".into(),
+                "BlanketOverSealedTrait".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "BlanketOverSealedAndUnsealedTrait".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "blanket_impls".into(),
+                "BlanketOverSealedAndUnsealedTrait".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "TransitiveBlanket".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "blanket_impls".into(),
+                "TransitiveBlanket".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "BlanketOverArc".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "blanket_impls".into(),
+                "BlanketOverArc".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "BlanketOverTuple".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "blanket_impls".into(),
+                "BlanketOverTuple".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "BlanketOverSlice".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "blanket_impls".into(),
+                "BlanketOverSlice".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "BlanketOverArray".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "blanket_impls".into(),
+                "BlanketOverArray".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "BlanketOverPointer".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "blanket_impls".into(),
+                "BlanketOverPointer".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "BlanketUnsealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "BlanketUnsealed".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "RefBlanketUnsealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "RefBlanketUnsealed".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "ExternalSupertraitsBlanketUnsealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "ExternalSupertraitsBlanketUnsealed".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "BlanketWithWhereClauseUnsealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "BlanketWithWhereClauseUnsealed".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "IteratorBlanketUnsealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "IteratorBlanketUnsealed".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "BlanketOverLocalUnsealedTraitUnsealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "BlanketOverLocalUnsealedTraitUnsealed".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "BlanketOverSealedTraitSealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "BlanketOverSealedTraitSealed".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "BlanketSealedOverMultiple".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "BlanketSealedOverMultiple".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "TransitiveBlanketUnsealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "TransitiveBlanketUnsealed".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "BlanketOverArcSealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "BlanketOverArcSealed".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "BlanketOverTupleSealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "BlanketOverTupleSealed".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "BlanketOverSliceSealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "BlanketOverSliceSealed".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "BlanketOverArraySealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "BlanketOverArraySealed".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "BlanketOverPointerSealed".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "BlanketOverPointerSealed".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "DeprecatedHidden".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "DeprecatedHidden".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "UnsealedDueToDeprecatedSuper".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "UnsealedDueToDeprecatedSuper".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "DeprecatedAssocType".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "DeprecatedAssocType".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "DeprecatedAssocConst".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "DeprecatedAssocConst".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "DeprecatedMethod".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "DeprecatedMethod".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "MethodDeprecatedArgType".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "doc_hidden".into(),
+                "MethodDeprecatedArgType".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
         },
     ];
     expected_results.sort_unstable();

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -501,7 +501,7 @@ impl<'a> IndexedCrate<'a> {
         self.flags
             .as_ref()
             .expect("flags index was never constructed")[id]
-            .is_sealed()
+            .is_unconditionally_sealed()
     }
 
     /// Report whether our analysis indicates the trait can be implemented within public API.

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -505,7 +505,7 @@ impl<'a> IndexedCrate<'a> {
     }
 
     /// Report whether our analysis indicates the trait can be implemented within public API.
-    ///(
+    ///
     /// A trait can be implemented within public API if the trait is not sealed, and implementing it
     /// does not require using any non-public-API items in the `impl`. A non-public-API item is
     /// one that is `#[doc(hidden)]` but not `#[deprecated]`.

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -10,7 +10,11 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use rayon::prelude::*;
 use rustdoc_types::{Crate, Id, Item};
 
-use crate::{adapter::supported_item_kind, sealed_trait, visibility_tracker::VisibilityTracker};
+use crate::{
+    adapter::supported_item_kind,
+    item_flags::{build_flags_index, ItemFlag},
+    visibility_tracker::VisibilityTracker,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct DependencyKey(Arc<str>);
@@ -188,6 +192,9 @@ pub struct IndexedCrate<'a> {
 
     /// index: importable name (in any namespace) -> list of items under that name
     pub(crate) imports_index: Option<HashMap<Path<'a>, Vec<(&'a Item, Modifiers)>>>,
+
+    /// index: item ID -> bit flags recording yes-no indicators for various item states
+    pub(crate) flags: Option<HashMap<Id, ItemFlag>>,
 
     /// index: impl owner + impl'd item name -> list of (impl itself, the named item))
     pub(crate) impl_index: Option<HashMap<ImplEntry<'a>, Vec<(&'a Item, &'a Item)>>>,
@@ -409,6 +416,7 @@ impl<'a> IndexedCrate<'a> {
             inner: crate_,
             visibility_tracker: VisibilityTracker::from_crate(crate_),
             manually_inlined_builtin_traits: create_manually_inlined_builtin_traits(crate_),
+            flags: None,
             imports_index: None,
             impl_index: None,
             fn_owner_index: None,
@@ -429,8 +437,8 @@ impl<'a> IndexedCrate<'a> {
         #[cfg(not(feature = "rayon"))]
         let iter = crate_.index.iter();
 
-        value.imports_index = Some(
-            iter.filter_map(|(_id, item)| {
+        let imports_index = iter
+            .filter_map(|(_id, item)| {
                 if !supported_item_kind(item) {
                     return None;
                 }
@@ -447,8 +455,9 @@ impl<'a> IndexedCrate<'a> {
             })
             .flatten()
             .collect::<MapList<_, _>>()
-            .into_inner(),
-        );
+            .into_inner();
+        value.flags = Some(build_flags_index(&crate_.index, &imports_index));
+        value.imports_index = Some(imports_index);
 
         value.impl_index = Some(build_impl_index(&crate_.index).into_inner());
         value.fn_owner_index = Some(build_fn_owner_index(&crate_.index));
@@ -484,26 +493,43 @@ impl<'a> IndexedCrate<'a> {
     ///
     /// ## Panics
     ///
-    /// This method will panic if the provided `id` is not an item in this crate,
-    /// or does not correspond to a trait in this crate.
+    /// This method will panic if the provided `Id` is not an item in this crate.
     ///
-    /// ## Re-entrancy
-    ///
-    /// This method is re-entrant: calling it may cause additional calls to itself, inquiring about
-    /// the sealed-ness of a trait's supertraits.
-    ///
-    /// We rely on rustc to reject supertrait cycles in order to prevent infinite loops.
-    /// Here's a supertrait cycle that must be rejected by rustc:
-    /// ```compile_fail
-    /// pub trait First: Third {}
-    ///
-    /// pub trait Second: First {}
-    ///
-    /// pub trait Third: Second {}
-    /// ```
+    /// If the provided `Id` is not a trait, the result is sound but not specified.
+    /// It could be any return value or a panic, but not undefined behavior.
     pub fn is_trait_sealed(&self, id: &'a Id) -> bool {
-        let trait_item = &self.inner.index[id];
-        sealed_trait::is_trait_sealed(self, trait_item)
+        self.flags
+            .as_ref()
+            .expect("flags index was never constructed")[id]
+            .is_sealed()
+    }
+
+    /// Report whether our analysis indicates the trait can be implemented within public API.
+    ///(
+    /// A trait can be implemented within public API if the trait is not sealed, and implementing it
+    /// does not require using any non-public-API items in the `impl`. A non-public-API item is
+    /// one that is `#[doc(hidden)]` but not `#[deprecated]`.
+    ///
+    /// Our analysis is conservative: it has false-negatives but no false-positives.
+    /// If this method returns `true`, the trait is *definitely* not implementable within public API
+    /// or else you've found a bug. It may be possible to construct traits that *technically*
+    /// are not implementable within public API for which our analysis returns `false`.
+    ///
+    /// Our analysis does not inspect function bodies or do interprocedural analysis.
+    /// The same caveats apply as for the [`Self::is_trait_sealed`] function above.
+    ///
+    /// ## Panics
+    ///
+    /// This method will panic if the provided `Id` is not an item in this crate.
+    ///
+    /// If the provided `Id` is not a trait, the result is sound but not specified.
+    /// It could be any return value or a panic, but not undefined behavior.
+    pub fn is_trait_public_api_sealed(&self, id: &'a Id) -> bool {
+        !self
+            .flags
+            .as_ref()
+            .expect("flags index was never constructed")[id]
+            .is_pub_api_implementable()
     }
 }
 

--- a/src/item_flags.rs
+++ b/src/item_flags.rs
@@ -84,7 +84,7 @@ impl ItemFlag {
     /// #[doc(hidden)]
     /// pub mod hidden {
     ///     // The item path `this_crate::hidden::Example` is accessible, but not public API.
-    ///     struct Example;
+    ///     pub struct Example;
     /// }
     ///
     /// // The item path `this_crate::Example` is public API, and not hidden.
@@ -115,7 +115,7 @@ impl ItemFlag {
     ///
     /// Attempting to implement the trait in a downstream crate is guaranteed to be a compile error.
     #[inline]
-    pub(crate) fn is_sealed(&self) -> bool {
+    pub(crate) fn is_unconditionally_sealed(&self) -> bool {
         (self.0 & Self::TRAIT_SEALED.0) != 0
     }
 
@@ -125,7 +125,8 @@ impl ItemFlag {
     /// meaning they are not covered by SemVer stability guarantees and may suffer breakage.
     ///
     /// If the trait is unconditionally sealed, this method returns `false`. In other words,
-    /// at most one of [`Self::is_only_pub_api_sealed()`] and [`Self::is_sealed()`] returns `true`.
+    /// at most one of [`Self::is_only_pub_api_sealed()`] and
+    /// [`Self::is_unconditionally_sealed()`] returns `true`.
     #[inline]
     pub(crate) fn is_only_pub_api_sealed(&self) -> bool {
         (self.0 & Self::TRAIT_DOC_HIDDEN_SEALED.0) != 0
@@ -145,15 +146,15 @@ impl ItemFlag {
     }
 
     #[inline]
-    pub(crate) fn set_sealed(&mut self) {
-        // Turn off the "doc-hidden-sealed" bit, since sealed dominates.
+    pub(crate) fn set_unconditionally_sealed(&mut self) {
+        // Turn off the "public-API-sealed" bit, since sealed dominates.
         self.0 &= !Self::TRAIT_DOC_HIDDEN_SEALED.0;
         self.0 |= Self::TRAIT_SEALED.0;
     }
 
     #[inline]
-    pub(crate) fn set_doc_hidden_sealed(&mut self) {
-        if !self.is_sealed() {
+    pub(crate) fn set_pub_api_sealed(&mut self) {
+        if !self.is_unconditionally_sealed() {
             self.0 |= Self::TRAIT_DOC_HIDDEN_SEALED.0;
         }
     }

--- a/src/item_flags.rs
+++ b/src/item_flags.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 
 #[cfg(feature = "rustc-hash")]
 use rustc_hash::FxHashMap as HashMap;
+
 use rustdoc_types::{Id, Item};
 
 use crate::{
@@ -50,19 +51,47 @@ impl ItemFlag {
         Self(0)
     }
 
+    /// Whether the item is reachable from another crate, ignoring public API considerations.
+    ///
+    /// Items that aren't reachable simply cannot be used in a downstream crate.
+    /// Their visibility does not allow them to be accessed, and doing so is a hard compiler error.
     #[inline]
     pub(crate) fn is_reachable(&self) -> bool {
         (self.0 & (Self::PUB_REACHABLE.0 | Self::DOC_HIDDEN_REACHABLE.0)) != 0
     }
 
+    /// Whether the item is reachable from another crate via the public API of this crate.
+    ///
+    /// This means the item is importable, or is a public API component of an importable item.
+    /// For example: a `pub trait` at the root `lib.rs` file, and a `pub fn` within the trait,
+    /// are both items where [`Self::is_pub_reachable()`] returns `true`.
+    ///
+    /// An example where [`Self::is_pub_reachable()`] returns `false` but [`Self::is_reachable()`]
+    /// would return `true` is a `#[doc(hidden)]` non-deprecated item. Such an item is not part of
+    /// the public API, even though it is possible to access from outside its crate.
     #[inline]
     pub(crate) fn is_pub_reachable(&self) -> bool {
         (self.0 & Self::PUB_REACHABLE.0) != 0
     }
 
-    // TODO: rename this, it should be "non-pub-API reachable"
+    /// Whether the item is reachable via non-public API in this crate.
+    ///
+    /// This is not mutually-exclusive with [`Self::is_pub_reachable()`]!
+    /// For example, it's possible for an item to be both public API and non-public API
+    /// simultaneously at different paths, and have both [`Self::is_non_pub_api_reachable()`] and
+    /// [`Self::is_pub_reachable()`] return `true`:
+    /// ```no_run
+    /// #[doc(hidden)]
+    /// pub mod hidden {
+    ///     // The item path `this_crate::hidden::Example` is accessible, but not public API.
+    ///     struct Example;
+    /// }
+    ///
+    /// // The item path `this_crate::Example` is public API, and not hidden.
+    /// pub use hidden::Example;
+    /// ```
     #[inline]
-    pub(crate) fn is_doc_hidden_reachable(&self) -> bool {
+    pub(crate) fn is_non_pub_api_reachable(&self) -> bool {
         (self.0 & Self::DOC_HIDDEN_REACHABLE.0) != 0
     }
 
@@ -76,21 +105,35 @@ impl ItemFlag {
         self.0 |= Self::DOC_HIDDEN_REACHABLE.0;
     }
 
+    /// Whether the trait has impls like `impl<T> TheTrait for T`, with optional bounds on `T`.
     #[inline]
     pub(crate) fn trait_has_blanket_impls(&self) -> bool {
         (self.0 & Self::TRAIT_BLANKET_IMPLS.0) != 0
     }
 
+    /// Whether the trait is unconditionally sealed: a downstream crate cannot provide its own impl.
+    ///
+    /// Attempting to implement the trait in a downstream crate is guaranteed to be a compile error.
     #[inline]
     pub(crate) fn is_sealed(&self) -> bool {
         (self.0 & Self::TRAIT_SEALED.0) != 0
     }
 
+    /// Whether the trait is sealed only in public API: impls of the trait rely on non-public API.
+    ///
+    /// Implementations of the trait in a downstream crate are forced to rely on non-public API,
+    /// meaning they are not covered by SemVer stability guarantees and may suffer breakage.
+    ///
+    /// If the trait is unconditionally sealed, this method returns `false`. In other words,
+    /// at most one of [`Self::is_only_pub_api_sealed()`] and [`Self::is_sealed()`] returns `true`.
     #[inline]
-    pub(crate) fn is_doc_hidden_sealed(&self) -> bool {
+    pub(crate) fn is_only_pub_api_sealed(&self) -> bool {
         (self.0 & Self::TRAIT_DOC_HIDDEN_SEALED.0) != 0
     }
 
+    /// Whether downstream crates can provide impls for this trait within public API.
+    ///
+    /// Such impls are then covered by SemVer stability guarantees.
     #[inline]
     pub(crate) fn is_pub_api_implementable(&self) -> bool {
         (self.0 & (Self::TRAIT_DOC_HIDDEN_SEALED.0 | Self::TRAIT_SEALED.0)) == 0
@@ -214,44 +257,34 @@ pub(crate) fn build_flags_index(
                     parent_reachability,
                 );
             }
-            rustdoc_types::ItemEnum::Struct(inner) => match &inner.kind {
-                rustdoc_types::StructKind::Unit => {
-                    set_impl_flags_index(
-                        index,
-                        inner.impls.iter().filter_map(|id| index.get(id)),
-                        &mut flags,
-                        parent_reachability,
-                    );
+            rustdoc_types::ItemEnum::Struct(inner) => {
+                match &inner.kind {
+                    rustdoc_types::StructKind::Unit => {}
+                    rustdoc_types::StructKind::Tuple(ids) => {
+                        set_field_flags_index(
+                            ids.iter()
+                                .filter_map(|x| x.as_ref())
+                                .filter_map(|id| index.get(id)),
+                            &mut flags,
+                            parent_reachability,
+                        );
+                    }
+                    rustdoc_types::StructKind::Plain { fields, .. } => {
+                        set_field_flags_index(
+                            fields.iter().filter_map(|id| index.get(id)),
+                            &mut flags,
+                            parent_reachability,
+                        );
+                    }
                 }
-                rustdoc_types::StructKind::Tuple(ids) => {
-                    set_field_flags_index(
-                        ids.iter()
-                            .filter_map(|x| x.as_ref())
-                            .filter_map(|id| index.get(id)),
-                        &mut flags,
-                        parent_reachability,
-                    );
-                    set_impl_flags_index(
-                        index,
-                        inner.impls.iter().filter_map(|id| index.get(id)),
-                        &mut flags,
-                        parent_reachability,
-                    );
-                }
-                rustdoc_types::StructKind::Plain { fields, .. } => {
-                    set_field_flags_index(
-                        fields.iter().filter_map(|id| index.get(id)),
-                        &mut flags,
-                        parent_reachability,
-                    );
-                    set_impl_flags_index(
-                        index,
-                        inner.impls.iter().filter_map(|id| index.get(id)),
-                        &mut flags,
-                        parent_reachability,
-                    );
-                }
-            },
+
+                set_impl_flags_index(
+                    index,
+                    inner.impls.iter().filter_map(|id| index.get(id)),
+                    &mut flags,
+                    parent_reachability,
+                );
+            }
             rustdoc_types::ItemEnum::Enum(inner) => {
                 set_variant_flags_index(
                     index,

--- a/src/item_flags.rs
+++ b/src/item_flags.rs
@@ -1,0 +1,367 @@
+#[cfg(not(feature = "rustc-hash"))]
+use std::collections::HashMap;
+
+#[cfg(feature = "rustc-hash")]
+use rustc_hash::FxHashMap as HashMap;
+use rustdoc_types::{Id, Item};
+
+use crate::{
+    attributes::Attribute,
+    indexed_crate::{Modifiers, Path},
+    sealed_trait,
+};
+
+#[derive(Debug, Clone, Copy)]
+#[repr(transparent)]
+pub(crate) struct ItemFlag(u8);
+
+impl Default for ItemFlag {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Layout:
+/// +---+---+---+---+---+---+---+---+
+/// | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
+/// +---+---+---+---+---+---+---+---+
+/// | D | S | B | R | R | R | H | P |
+/// +---+---+---+---+---+---+---+---+
+///
+/// Key:
+/// P = pub reachable item: an item with a publicly importable name,
+///     or a public API associated item of such an item
+/// H = item publicly importable via a `doc(hidden)` path or an associated item of such an item,
+///     or a `doc(hidden)` associated item of a pub reachable item
+/// R = reserved for future use
+/// B = trait with blanket impls (`impl<T> Trait for T`, possibly with some bounds on `T`)
+/// S = sealed trait, external crates cannot provide an impl for this trait
+/// D = `doc(hidden)`-sealed trait, providing an impl requires using `doc(hidden)` items
+impl ItemFlag {
+    const PUB_REACHABLE: Self = Self(1 << 0);
+    const DOC_HIDDEN_REACHABLE: Self = Self(1 << 1);
+    const TRAIT_BLANKET_IMPLS: Self = Self(1 << 5);
+    const TRAIT_SEALED: Self = Self(1 << 6);
+    const TRAIT_DOC_HIDDEN_SEALED: Self = Self(1 << 7);
+
+    #[inline]
+    pub(crate) fn new() -> Self {
+        Self(0)
+    }
+
+    #[inline]
+    pub(crate) fn is_reachable(&self) -> bool {
+        (self.0 & (Self::PUB_REACHABLE.0 | Self::DOC_HIDDEN_REACHABLE.0)) != 0
+    }
+
+    #[inline]
+    pub(crate) fn is_pub_reachable(&self) -> bool {
+        (self.0 & Self::PUB_REACHABLE.0) != 0
+    }
+
+    // TODO: rename this, it should be "non-pub-API reachable"
+    #[inline]
+    pub(crate) fn is_doc_hidden_reachable(&self) -> bool {
+        (self.0 & Self::DOC_HIDDEN_REACHABLE.0) != 0
+    }
+
+    #[inline]
+    pub(crate) fn set_pub_reachable(&mut self) {
+        self.0 |= Self::PUB_REACHABLE.0;
+    }
+
+    #[inline]
+    pub(crate) fn set_doc_hidden_reachable(&mut self) {
+        self.0 |= Self::DOC_HIDDEN_REACHABLE.0;
+    }
+
+    #[inline]
+    pub(crate) fn trait_has_blanket_impls(&self) -> bool {
+        (self.0 & Self::TRAIT_BLANKET_IMPLS.0) != 0
+    }
+
+    #[inline]
+    pub(crate) fn is_sealed(&self) -> bool {
+        (self.0 & Self::TRAIT_SEALED.0) != 0
+    }
+
+    #[inline]
+    pub(crate) fn is_doc_hidden_sealed(&self) -> bool {
+        (self.0 & Self::TRAIT_DOC_HIDDEN_SEALED.0) != 0
+    }
+
+    #[inline]
+    pub(crate) fn is_pub_api_implementable(&self) -> bool {
+        (self.0 & (Self::TRAIT_DOC_HIDDEN_SEALED.0 | Self::TRAIT_SEALED.0)) == 0
+    }
+
+    #[inline]
+    pub(crate) fn set_trait_has_blanket_impls(&mut self) {
+        self.0 |= Self::TRAIT_BLANKET_IMPLS.0;
+    }
+
+    #[inline]
+    pub(crate) fn set_sealed(&mut self) {
+        // Turn off the "doc-hidden-sealed" bit, since sealed dominates.
+        self.0 &= !Self::TRAIT_DOC_HIDDEN_SEALED.0;
+        self.0 |= Self::TRAIT_SEALED.0;
+    }
+
+    #[inline]
+    pub(crate) fn set_doc_hidden_sealed(&mut self) {
+        if !self.is_sealed() {
+            self.0 |= Self::TRAIT_DOC_HIDDEN_SEALED.0;
+        }
+    }
+
+    #[inline]
+    fn get_reachability(&self) -> Reachability {
+        let mask = self.0 & (Self::PUB_REACHABLE.0 | Self::DOC_HIDDEN_REACHABLE.0);
+        if mask == 0 {
+            Reachability::Unreachable
+        } else if mask == Self::DOC_HIDDEN_REACHABLE.0 {
+            Reachability::NonPublicAPI
+        } else {
+            Reachability::PublicAPI
+        }
+    }
+
+    #[inline]
+    fn apply_reachability(&mut self, reachability: Reachability) {
+        match reachability {
+            Reachability::Unreachable => {}
+            Reachability::NonPublicAPI => self.set_doc_hidden_reachable(),
+            Reachability::PublicAPI => self.set_pub_reachable(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Reachability {
+    Unreachable,
+    NonPublicAPI,
+    PublicAPI,
+}
+
+impl Reachability {
+    fn from_parent(parent_reachability: Self, item: &Item) -> Self {
+        match parent_reachability {
+            Reachability::Unreachable => parent_reachability,
+            Reachability::NonPublicAPI => match item.visibility {
+                rustdoc_types::Visibility::Public | rustdoc_types::Visibility::Default => {
+                    Reachability::NonPublicAPI
+                }
+                rustdoc_types::Visibility::Crate | rustdoc_types::Visibility::Restricted { .. } => {
+                    Reachability::Unreachable
+                }
+            },
+            Reachability::PublicAPI => match item.visibility {
+                rustdoc_types::Visibility::Public | rustdoc_types::Visibility::Default => {
+                    if item.deprecation.is_none()
+                        && item
+                            .attrs
+                            .iter()
+                            .any(|attr| Attribute::is_doc_hidden(attr.as_str()))
+                    {
+                        Reachability::NonPublicAPI
+                    } else {
+                        Reachability::PublicAPI
+                    }
+                }
+                rustdoc_types::Visibility::Crate | rustdoc_types::Visibility::Restricted { .. } => {
+                    Reachability::Unreachable
+                }
+            },
+        }
+    }
+}
+
+pub(crate) fn build_flags_index(
+    index: &HashMap<Id, Item>,
+    imports_index: &HashMap<Path<'_>, Vec<(&Item, Modifiers)>>,
+) -> HashMap<Id, ItemFlag> {
+    let mut flags: HashMap<Id, ItemFlag> =
+        index.keys().map(|id| (*id, Default::default())).collect();
+
+    // First, initialize the flags of all top-level importable items.
+    imports_index
+        .values()
+        .flatten()
+        .for_each(|(item, modifiers)| {
+            let flag = flags.entry(item.id).or_default();
+            if !modifiers.deprecated && modifiers.doc_hidden {
+                flag.set_doc_hidden_reachable();
+            } else {
+                flag.set_pub_reachable();
+            }
+        });
+
+    // Then, traverse the children of all top-level items to set the flags of those child items.
+    index.values().for_each(|item| {
+        let parent_reachability = flags[&item.id].get_reachability();
+        match &item.inner {
+            rustdoc_types::ItemEnum::Union(inner) => {
+                set_field_flags_index(
+                    inner.fields.iter().filter_map(|id| index.get(id)),
+                    &mut flags,
+                    parent_reachability,
+                );
+                set_impl_flags_index(
+                    index,
+                    inner.impls.iter().filter_map(|id| index.get(id)),
+                    &mut flags,
+                    parent_reachability,
+                );
+            }
+            rustdoc_types::ItemEnum::Struct(inner) => match &inner.kind {
+                rustdoc_types::StructKind::Unit => {
+                    set_impl_flags_index(
+                        index,
+                        inner.impls.iter().filter_map(|id| index.get(id)),
+                        &mut flags,
+                        parent_reachability,
+                    );
+                }
+                rustdoc_types::StructKind::Tuple(ids) => {
+                    set_field_flags_index(
+                        ids.iter()
+                            .filter_map(|x| x.as_ref())
+                            .filter_map(|id| index.get(id)),
+                        &mut flags,
+                        parent_reachability,
+                    );
+                    set_impl_flags_index(
+                        index,
+                        inner.impls.iter().filter_map(|id| index.get(id)),
+                        &mut flags,
+                        parent_reachability,
+                    );
+                }
+                rustdoc_types::StructKind::Plain { fields, .. } => {
+                    set_field_flags_index(
+                        fields.iter().filter_map(|id| index.get(id)),
+                        &mut flags,
+                        parent_reachability,
+                    );
+                    set_impl_flags_index(
+                        index,
+                        inner.impls.iter().filter_map(|id| index.get(id)),
+                        &mut flags,
+                        parent_reachability,
+                    );
+                }
+            },
+            rustdoc_types::ItemEnum::Enum(inner) => {
+                set_variant_flags_index(
+                    index,
+                    inner.variants.iter().filter_map(|id| index.get(id)),
+                    &mut flags,
+                    parent_reachability,
+                );
+                set_impl_flags_index(
+                    index,
+                    inner.impls.iter().filter_map(|id| index.get(id)),
+                    &mut flags,
+                    parent_reachability,
+                );
+            }
+            rustdoc_types::ItemEnum::Trait(inner) => {
+                set_assoc_item_flags_index(
+                    inner.items.iter().filter_map(|id| index.get(id)),
+                    &mut flags,
+                    parent_reachability,
+                );
+            }
+            _ => {}
+        }
+    });
+
+    sealed_trait::compute_trait_flags(index, &mut flags);
+
+    flags
+}
+
+fn set_field_flags_index<'a>(
+    fields: impl Iterator<Item = &'a Item>,
+    flags: &mut HashMap<Id, ItemFlag>,
+    parent_reachability: Reachability,
+) {
+    fields.for_each(|item| {
+        let reachability = Reachability::from_parent(parent_reachability, item);
+        let flag = flags.get_mut(&item.id).expect("missing flag for item");
+        flag.apply_reachability(reachability);
+    })
+}
+
+fn set_variant_flags_index<'a>(
+    index: &HashMap<Id, Item>,
+    variants: impl Iterator<Item = &'a Item>,
+    flags: &mut HashMap<Id, ItemFlag>,
+    parent_reachability: Reachability,
+) {
+    variants.for_each(|item| {
+        let reachability = Reachability::from_parent(parent_reachability, item);
+        let flag = flags.get_mut(&item.id).expect("missing flag for item");
+        flag.apply_reachability(reachability);
+
+        match &item.inner {
+            rustdoc_types::ItemEnum::Variant(variant) => match &variant.kind {
+                rustdoc_types::VariantKind::Plain => {}
+                rustdoc_types::VariantKind::Tuple(ids) => {
+                    set_field_flags_index(
+                        ids.iter()
+                            .filter_map(|x| x.as_ref())
+                            .filter_map(|id| index.get(id)),
+                        flags,
+                        reachability,
+                    );
+                }
+                rustdoc_types::VariantKind::Struct { fields, .. } => {
+                    set_field_flags_index(
+                        fields.iter().filter_map(|id| index.get(id)),
+                        flags,
+                        reachability,
+                    );
+                }
+            },
+            _ => unreachable!("not a variant item: {item:?}"),
+        }
+    })
+}
+
+fn set_impl_flags_index<'a>(
+    index: &HashMap<Id, Item>,
+    impls: impl Iterator<Item = &'a Item>,
+    flags: &mut HashMap<Id, ItemFlag>,
+    parent_reachability: Reachability,
+) {
+    impls.for_each(|item| {
+        let reachability = Reachability::from_parent(parent_reachability, item);
+        let flag = flags.get_mut(&item.id).expect("missing flag for item");
+        flag.apply_reachability(reachability);
+
+        match &item.inner {
+            rustdoc_types::ItemEnum::Impl(impl_inner) => {
+                set_assoc_item_flags_index(
+                    impl_inner.items.iter().filter_map(|id| index.get(id)),
+                    flags,
+                    reachability,
+                );
+            }
+            _ => unreachable!("not an impl item: {item:?}"),
+        }
+    })
+}
+
+fn set_assoc_item_flags_index<'a>(
+    assoc_items: impl Iterator<Item = &'a Item>,
+    flags: &mut HashMap<Id, ItemFlag>,
+    parent_reachability: Reachability,
+) {
+    assoc_items.for_each(|item| {
+        let reachability = Reachability::from_parent(parent_reachability, item);
+        let flag = flags.get_mut(&item.id).expect("missing flag for item");
+        flag.apply_reachability(reachability);
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,11 @@
 mod adapter;
 mod attributes;
+mod exported_name;
 mod indexed_crate;
+mod item_flags;
 mod sealed_trait;
 mod visibility_tracker;
 
-mod exported_name;
 #[cfg(test)]
 pub(crate) mod test_util;
 

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -1138,7 +1138,18 @@ type Trait implements Item & Importable & GenericItem {
   This is a stronger property than `public_api_sealed`, which shows whether the trait
   is prevented from being implemented with *only public API items*.
   """
-  sealed: Boolean!
+  unconditionally_sealed: Boolean!
+
+  """
+  Whether downstream crates are unconditionally prevented from implementing this trait themselves.
+
+  Required implementation items can be added to sealed traits without causing a breaking change,
+  since no implementations of that trait may exist in other crates.
+
+  This is a stronger property than `public_api_sealed`, which shows whether the trait
+  is prevented from being implemented with *only public API items*.
+  """
+  sealed: Boolean! @deprecated(reason: "Renamed to `unconditionally_sealed`, please use that instead.")
 
   """
   Whether downstream crates cannot add implementations of this trait by using only public API.

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -1130,12 +1130,27 @@ type Trait implements Item & Importable & GenericItem {
   object_safe: Boolean!
 
   """
-  Whether downstream crates are prevented from implementing this trait themselves.
+  Whether downstream crates are unconditionally prevented from implementing this trait themselves.
 
   Required implementation items can be added to sealed traits without causing a breaking change,
   since no implementations of that trait may exist in other crates.
+
+  This is a stronger property than `public_api_sealed`, which shows whether the trait
+  is prevented from being implemented with *only public API items*.
   """
   sealed: Boolean!
+
+  """
+  Whether downstream crates cannot add implementations of this trait by using only public API.
+
+  Required implementation items can be added to public-API-sealed traits without causing
+  a major change in the public API of those traits. Any breaking changes thus caused are
+  explicitly in non-public-API, and shouldn't affect users that adhere to using only public API.
+
+  This is a weaker property than `sealed`, which shows whether the trait is unconditionally
+  prevented from being implemented — any implementation attempt will result in compile errors.
+  """
+  public_api_sealed: Boolean!
 
   # edges from Item
   span: Span

--- a/src/sealed_trait.rs
+++ b/src/sealed_trait.rs
@@ -65,7 +65,7 @@ pub(crate) fn compute_trait_flags(index: &HashMap<Id, Item>, flags: &mut HashMap
             // So it's trivially sealed. Nothing further to check here.
             item_flags.set_sealed();
             continue;
-        } else if item_flags.is_doc_hidden_reachable() {
+        } else if item_flags.is_non_pub_api_reachable() {
             // The trait is reachable only via `doc(hidden)` paths.
             // Downstream crates can only `impl` it by naming such a non-public-API path,
             // so the trait is doc-hidden-sealed.
@@ -150,7 +150,7 @@ pub(crate) fn compute_trait_flags(index: &HashMap<Id, Item>, flags: &mut HashMap
                     bound_on_undecided_trait = true;
                 }
 
-                if supertrait_flags.is_doc_hidden_sealed() {
+                if supertrait_flags.is_only_pub_api_sealed() {
                     // Doc-hidden-sealed supertrait with no blanket impls. This means our trait
                     // is *at least* doc-hidden-sealed. But it might still be sealed!
                     flags
@@ -252,7 +252,8 @@ fn determine_if_trait_is_supertrait_sealed_avoiding_cycles(
     consider_doc_hidden_sealed: bool,
 ) -> bool {
     let trait_flag = flags[&trait_item.id];
-    if trait_flag.is_sealed() || (consider_doc_hidden_sealed && trait_flag.is_doc_hidden_sealed()) {
+    if trait_flag.is_sealed() || (consider_doc_hidden_sealed && trait_flag.is_only_pub_api_sealed())
+    {
         return true;
     }
 
@@ -292,7 +293,7 @@ fn determine_if_trait_is_supertrait_sealed_avoiding_cycles(
     }
 
     let trait_flag = flags[&trait_item.id];
-    trait_flag.is_sealed() || (consider_doc_hidden_sealed && trait_flag.is_doc_hidden_sealed())
+    trait_flag.is_sealed() || (consider_doc_hidden_sealed && trait_flag.is_only_pub_api_sealed())
 }
 
 fn has_no_externally_satifiable_blanket_impls(
@@ -427,7 +428,7 @@ fn is_method_or_item_sealed<'a>(
                     continue;
                 }
 
-                if !assoc_item_flag.is_pub_reachable() && assoc_item_flag.is_doc_hidden_reachable()
+                if !assoc_item_flag.is_pub_reachable() && assoc_item_flag.is_non_pub_api_reachable()
                 {
                     // This associated item is `doc(hidden)` and required to implement the trait.
                     // That makes the trait doc-hidden-sealed.
@@ -448,7 +449,7 @@ fn is_method_or_item_sealed<'a>(
                                     .expect("no flags entry for trait item ID")
                                     .set_sealed();
                                 return true;
-                            } else if item_flag.is_doc_hidden_reachable() {
+                            } else if item_flag.is_non_pub_api_reachable() {
                                 flags
                                     .get_mut(trait_id)
                                     .expect("no flags entry for trait item ID")
@@ -468,7 +469,7 @@ fn is_method_or_item_sealed<'a>(
                                 .expect("no flags entry for trait item ID")
                                 .set_sealed();
                             return true;
-                        } else if item_flag.is_doc_hidden_reachable() {
+                        } else if item_flag.is_non_pub_api_reachable() {
                             flags
                                 .get_mut(trait_id)
                                 .expect("no flags entry for trait item ID")
@@ -480,7 +481,7 @@ fn is_method_or_item_sealed<'a>(
             rustdoc_types::ItemEnum::AssocType { type_, .. } if type_.is_none() => {
                 // Associated types without a default can cause a trait to be doc-hidden-sealed.
 
-                if !assoc_item_flag.is_pub_reachable() && assoc_item_flag.is_doc_hidden_reachable()
+                if !assoc_item_flag.is_pub_reachable() && assoc_item_flag.is_non_pub_api_reachable()
                 {
                     // This associated item is `doc(hidden)` and required to implement the trait.
                     // That makes the trait doc-hidden-sealed.
@@ -493,7 +494,7 @@ fn is_method_or_item_sealed<'a>(
             rustdoc_types::ItemEnum::AssocConst { type_, value } if value.is_none() => {
                 // Associated constants without a default can cause a trait to be doc-hidden-sealed.
 
-                if !assoc_item_flag.is_pub_reachable() && assoc_item_flag.is_doc_hidden_reachable()
+                if !assoc_item_flag.is_pub_reachable() && assoc_item_flag.is_non_pub_api_reachable()
                 {
                     // This associated item is `doc(hidden)` and required to implement the trait.
                     // That makes the trait doc-hidden-sealed.
@@ -512,7 +513,7 @@ fn is_method_or_item_sealed<'a>(
                                 .expect("no flags entry for trait item ID")
                                 .set_sealed();
                             return true;
-                        } else if type_flag.is_doc_hidden_reachable() {
+                        } else if type_flag.is_non_pub_api_reachable() {
                             flags
                                 .get_mut(trait_id)
                                 .expect("no flags entry for trait item ID")

--- a/src/sealed_trait.rs
+++ b/src/sealed_trait.rs
@@ -85,7 +85,7 @@ fn has_sealed_supertrait<'a>(indexed_crate: &IndexedCrate<'a>, inner: &'a Trait)
                         // any implementer of `Example` would still have to implement it too.
                         // This makes it equivalent to a supertrait bound for purposes
                         // of trait sealing. Apply the equivalent logic here.
-                        if is_sealed_supertrait_bound(indexed_crate, bound) {
+                        if does_supertrait_bound_cause_sealing(indexed_crate, bound) {
                             return true;
                         }
                     }
@@ -96,7 +96,7 @@ fn has_sealed_supertrait<'a>(indexed_crate: &IndexedCrate<'a>, inner: &'a Trait)
     }
 
     for bound in &inner.bounds {
-        if is_sealed_supertrait_bound(indexed_crate, bound) {
+        if does_supertrait_bound_cause_sealing(indexed_crate, bound) {
             return true;
         }
     }
@@ -104,7 +104,7 @@ fn has_sealed_supertrait<'a>(indexed_crate: &IndexedCrate<'a>, inner: &'a Trait)
     false
 }
 
-fn is_sealed_supertrait_bound<'a>(
+fn does_supertrait_bound_cause_sealing<'a>(
     indexed_crate: &IndexedCrate<'a>,
     bound: &'a GenericBound,
 ) -> bool {

--- a/src/sealed_trait.rs
+++ b/src/sealed_trait.rs
@@ -1,158 +1,242 @@
-use rustdoc_types::{GenericBound, Item, Trait};
+#[cfg(not(feature = "rustc-hash"))]
+use std::collections::{HashMap, HashSet};
 
-use crate::IndexedCrate;
+#[cfg(feature = "rustc-hash")]
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
-pub(crate) fn is_trait_sealed<'a>(indexed_crate: &IndexedCrate<'a>, item: &'a Item) -> bool {
-    let trait_item = unwrap_trait(item);
+use rustdoc_types::{GenericBound, Id, Item, Trait};
 
-    // If the trait is pub-in-priv, trivially sealed.
-    if is_pub_in_priv_item(indexed_crate, &item.id) {
-        return true;
-    }
+use crate::item_flags::ItemFlag;
 
-    // Does the trait have a method that:
-    // - does not have a default impl, and
-    // - takes at least one non-`self` argument that is pub-in-priv
-    //
-    // If so, the trait is method-sealed, per:
-    // https://predr.ag/blog/definitive-guide-to-sealed-traits-in-rust/#sealing-traits-via-method-signatures
-    if is_method_sealed(indexed_crate, trait_item) {
-        return true;
-    }
+// TODO: update terminology: `doc-hidden-sealed` is inappropriate because
+//       deprecated doc-hidden items are considered public API.
+//       we want something like "sealed in public API"
 
-    // Does the trait have a supertrait that is all of the below:
-    // - defined in this crate
-    // - pub-in-priv, or otherwise sealed
-    // - lacking a blanket impl whose bounds can be satisfied outside this crate
-    if has_sealed_supertrait(indexed_crate, trait_item) {
-        return true;
-    }
-
-    false
-}
-
-fn is_pub_in_priv_item<'a>(indexed_crate: &IndexedCrate<'a>, id: &'a rustdoc_types::Id) -> bool {
-    // TODO: We don't need all names here, one is plenty. See if this is worth optimizing.
-    indexed_crate.publicly_importable_names(id).is_empty()
-}
-
-fn unwrap_trait(item: &Item) -> &'_ Trait {
-    match &item.inner {
-        rustdoc_types::ItemEnum::Trait(t) => t,
-        _ => unreachable!(),
-    }
-}
-
-fn is_method_sealed<'a>(indexed_crate: &IndexedCrate<'a>, trait_inner: &'a Trait) -> bool {
-    for inner_item_id in &trait_inner.items {
-        let inner_item = &indexed_crate.inner.index[inner_item_id];
-        if let rustdoc_types::ItemEnum::Function(func) = &inner_item.inner {
-            if func.has_body {
-                // This trait function has a default implementation.
-                // An implementation is not required in order to implement this trait on a type.
-                // Therefore, it cannot on its own cause the trait to be sealed.
-                continue;
-            }
-
-            // Check for pub-in-priv function parameters.
-            for (_, param) in &func.sig.inputs {
-                if let rustdoc_types::Type::ResolvedPath(path) = param {
-                    if is_local_pub_in_priv_path(indexed_crate, path) {
-                        return true;
-                    }
-                }
-            }
-        }
-    }
-
-    false
-}
-
-fn has_sealed_supertrait<'a>(indexed_crate: &IndexedCrate<'a>, inner: &'a Trait) -> bool {
-    for predicate in &inner.generics.where_predicates {
-        match predicate {
-            // Only `where Self: SomeTrait` predicates are relevant for sealed trait analysis.
-            // Ignore all other predicate types.
-            rustdoc_types::WherePredicate::BoundPredicate { type_, bounds, .. } => {
-                // If the predicate isn't over `Self`, it isn't relevant.
-                if matches!(type_, rustdoc_types::Type::Generic(generic) if generic.as_str() == "Self")
-                {
-                    for bound in bounds {
-                        // We found a trait similar to:
-                        // `pub trait Example where Self: SealedTrait { ... }`
-                        //
-                        // Even though `SealedTrait` isn't *explicitly* a supertrait,
-                        // any implementer of `Example` would still have to implement it too.
-                        // This makes it equivalent to a supertrait bound for purposes
-                        // of trait sealing. Apply the equivalent logic here.
-                        if does_supertrait_bound_cause_sealing(indexed_crate, bound) {
-                            return true;
-                        }
-                    }
-                }
-            }
+/// Update the `flags` with trait sealing and blanket impls information.
+///
+/// # Preconditions
+/// - `flags` must contain complete reachability information,
+///   including info on `doc(hidden)` importable paths.
+pub(crate) fn compute_trait_flags(index: &HashMap<Id, Item>, flags: &mut HashMap<Id, ItemFlag>) {
+    let mut possibly_sealed = Vec::with_capacity(128);
+    let mut definitely_not_fully_sealed: HashSet<Id> = HashSet::default();
+    for (id, item) in index.iter() {
+        let trait_inner = match &item.inner {
+            rustdoc_types::ItemEnum::Trait(t) => t,
             _ => continue,
+        };
+        let item_flags = flags.get_mut(id).expect("item flags weren't initialized");
+
+        // First, check for blanket impls.
+        for impl_id in &trait_inner.implementations {
+            let Some(impl_item) = index.get(impl_id) else {
+                // Probably a rustdoc bug -- the impl isn't part of the crate's index.
+                continue;
+            };
+            let impl_inner = match &impl_item.inner {
+                rustdoc_types::ItemEnum::Impl(impl_inner) => impl_inner,
+                _ => {
+                    // Probably a rustdoc bug -- we referenced an item as an impl but it isn't one.
+                    continue;
+                }
+            };
+
+            // Ensure our opinion on whether downstream types can gain impls via a blanket
+            // matches rustdoc's opinion on what counts as a blanket impl.
+            //
+            // N.B.: The `blanket_impl` field in rustdoc JSON is *not* trustworthy!
+            //
+            // The following `impl` has `blanket_impl = None`,
+            // seven though it seems to clearly be a blanket impl.
+            // ```rust
+            // mod private {
+            //     pub trait FullBlanket {}
+            //     impl<T> FullBlanket for T {}
+            // }
+            // ```
+            if can_blanket_impl_target_include_downstream_types(impl_inner) {
+                item_flags.set_trait_has_blanket_impls();
+            }
+        }
+
+        if !item_flags.is_reachable() {
+            // The trait isn't importable at all.
+            // Either it's pub-in-priv or just not pub at all.
+            // So it's trivially sealed. Nothing further to check here.
+            item_flags.set_sealed();
+            continue;
+        } else if item_flags.is_doc_hidden_reachable() {
+            // The trait is reachable only via `doc(hidden)` paths.
+            // Downstream crates can only `impl` it by naming such a non-public-API path,
+            // so the trait is doc-hidden-sealed.
+            item_flags.set_doc_hidden_sealed();
+
+            // The trait might be completely sealed though, so we'll keep looking.
+        }
+
+        // Does the trait have a method that:
+        // - does not have a default impl, and
+        // - takes at least one non-`self` argument that is not importable
+        //   (is non-pub, or is pub-in-priv)
+        //
+        // If so, the trait is method-sealed, per:
+        // https://predr.ag/blog/definitive-guide-to-sealed-traits-in-rust/#sealing-traits-via-method-signatures
+        //
+        // Instead, if the argument is only `doc(hidden)`-reachable,
+        // then the trait is doc-hidden-sealed. Similarly, if a non-defaulted associated item
+        // is `doc(hidden)` and not deprecated, the trait is doc-hidden-sealed.
+        //
+        // This method applies the flags internally, and returns `true` only if
+        // the trait is sealed, meaning that we can skip further analysis for it.
+        if is_method_or_item_sealed(index, id, trait_inner, flags) {
+            continue;
+        }
+
+        // The only remaining way a trait here could be sealed is if it has supertraits.
+        if effective_supertraits_iter(trait_inner).next().is_some() {
+            possibly_sealed.push(item);
+        } else {
+            definitely_not_fully_sealed.insert(*id);
         }
     }
 
-    for bound in &inner.bounds {
-        if does_supertrait_bound_cause_sealing(indexed_crate, bound) {
-            return true;
-        }
-    }
+    // At this point, we've figured out all traits that are sealed because of
+    // method-sealing or because they aren't publicly importable.
+    // We still need to look at supertraits.
+    //
+    // Supertrait sealing can lead to cycles when blanket impls are present.
+    // However, the vast majority of supertrait-sealed traits don't involve a blanket impl
+    // on the supertrait, so we don't want to pay the perf cost of cycle-busting in those cases.
+    // We use a two-step strategy:
+    // - First, evaluate traits that can be proven to be sealed by virtue of a sealed supertrait
+    //   with no blanket impls. No cycles are possible here -- this is a one-step analysis.
+    // - Then, evaluate traits with blanket impls on supertraits. Apply cycle-busting here.
+    let mut possible_cycles = Vec::with_capacity(possibly_sealed.len());
+    for trait_item in possibly_sealed {
+        let trait_inner = unwrap_trait(trait_item);
 
-    false
-}
+        let mut proven_sealed = false;
+        let mut blankets_found = false;
+        let mut bound_on_undecided_trait = false;
+        for bound in effective_supertraits_iter(trait_inner) {
+            let supertrait_item = match bound {
+                GenericBound::TraitBound { trait_, .. } => {
+                    if let Some(item) = index.get(&trait_.id) {
+                        item
+                    } else {
+                        // Not an item from this crate, so it can't cause sealing.
+                        //
+                        // TODO: Update this when we have cross-crate analysis,
+                        //       since this can cause doc-hidden-sealing.
+                        continue;
+                    }
+                }
+                _ => unreachable!("non-trait bound found: {bound:?}"),
+            };
 
-fn does_supertrait_bound_cause_sealing<'a>(
-    indexed_crate: &IndexedCrate<'a>,
-    bound: &'a GenericBound,
-) -> bool {
-    let supertrait = match bound {
-        rustdoc_types::GenericBound::TraitBound {
-            trait_: trait_path, ..
-        } => {
-            match indexed_crate.inner.index.get(&trait_path.id) {
-                Some(item) => item,
-                None => {
-                    // Item from another crate, so clearly not pub-in-priv.
-                    //
-                    // TODO: Once we have the ability to do cross-crate analysis, consider
-                    //       whether this external trait is sealed. That can have
-                    //       some interesting SemVer implications as well.
-                    return false;
+            let supertrait_flags = flags[&supertrait_item.id];
+            if supertrait_flags.trait_has_blanket_impls() {
+                blankets_found = true;
+            } else if supertrait_flags.is_sealed() {
+                // Sealed supertrait with no blanket impls! This seals our trait, and is final.
+                flags
+                    .get_mut(&trait_item.id)
+                    .expect("no flag for trait item")
+                    .set_sealed();
+                proven_sealed = true;
+                break;
+            } else {
+                if !definitely_not_fully_sealed.contains(&supertrait_item.id) {
+                    bound_on_undecided_trait = true;
+                }
+
+                if supertrait_flags.is_doc_hidden_sealed() {
+                    // Doc-hidden-sealed supertrait with no blanket impls. This means our trait
+                    // is *at least* doc-hidden-sealed. But it might still be sealed!
+                    flags
+                        .get_mut(&trait_item.id)
+                        .expect("no flag for trait item")
+                        .set_doc_hidden_sealed();
                 }
             }
         }
-        rustdoc_types::GenericBound::Outlives(_) | rustdoc_types::GenericBound::Use(_) => {
-            // Not a trait bound of any kind, nothing to check.
-            return false;
+        if !proven_sealed && (blankets_found || bound_on_undecided_trait) {
+            possible_cycles.push(trait_item);
         }
-    };
+    }
 
-    // Otherwise, check if the supertrait is itself sealed.
-    // This catches cases like:
-    // ```rust
-    // mod priv {
-    //     pub trait Sealed {}
-    // }
-    //
-    // pub trait First: Sealed {}
-    //
-    // pub trait Second: First {}
-    // ```
-    //
-    // Here, both `First` and `Second` are sealed.
-    //
-    // N.B.: This cannot infinite-loop, since rustc denies cyclic trait bounds.
-    if is_trait_sealed(indexed_crate, supertrait) {
-        // The supertrait is sealed, so a downstream crate cannot add a direct impl for it
-        // on any of its own types.
-        //
-        // However, this isn't the same thing as "downstream types cannot impl this trait"!
-        // We must check the supertrait for blanket impls that might result in
-        // a downstream type gaining an impl for that trait.
-        if has_no_externally_satisfiable_blanket_impls(indexed_crate, supertrait) {
+    // We've resolved all the easy cases. Time to deal with traits with possible cyclic bounds.
+    let mut visited_trait_ids: HashSet<Id> = HashSet::default();
+    for trait_item in &possible_cycles {
+        visited_trait_ids.insert(trait_item.id);
+        determine_if_trait_is_supertrait_sealed_avoiding_cycles(
+            index,
+            trait_item,
+            flags,
+            &mut visited_trait_ids,
+            false,
+        );
+        visited_trait_ids.clear();
+    }
+    for trait_item in &possible_cycles {
+        visited_trait_ids.insert(trait_item.id);
+        determine_if_trait_is_supertrait_sealed_avoiding_cycles(
+            index,
+            trait_item,
+            flags,
+            &mut visited_trait_ids,
+            true,
+        );
+        visited_trait_ids.clear();
+    }
+}
+
+fn determine_if_trait_is_sealed_with_no_external_blankets(
+    index: &HashMap<Id, Item>,
+    trait_item: &Item,
+    flags: &mut HashMap<Id, ItemFlag>,
+    visited_trait_ids: &mut HashSet<Id>,
+    consider_doc_hidden_sealed: bool,
+) -> bool {
+    if !visited_trait_ids.insert(trait_item.id) {
+        // Already visited this supertrait, we're in a cycle. Unwind the cycle,
+        // marking all traits in it as sealed.
+        if consider_doc_hidden_sealed {
+            visited_trait_ids.iter().for_each(|id| {
+                flags
+                    .get_mut(id)
+                    .expect("no flags for trait ID")
+                    .set_doc_hidden_sealed();
+            });
+        } else {
+            visited_trait_ids.iter().for_each(|id| {
+                flags
+                    .get_mut(id)
+                    .expect("no flags for trait ID")
+                    .set_sealed();
+            });
+        }
+        return true;
+    }
+
+    if determine_if_trait_is_supertrait_sealed_avoiding_cycles(
+        index,
+        trait_item,
+        flags,
+        visited_trait_ids,
+        consider_doc_hidden_sealed,
+    ) {
+        let trait_flags = flags[&trait_item.id];
+        let trait_inner = unwrap_trait(trait_item);
+        if !trait_flags.trait_has_blanket_impls()
+            || has_no_externally_satifiable_blanket_impls(
+                index,
+                trait_inner,
+                flags,
+                visited_trait_ids,
+                consider_doc_hidden_sealed,
+            )
+        {
             return true;
         }
     }
@@ -160,13 +244,66 @@ fn does_supertrait_bound_cause_sealing<'a>(
     false
 }
 
-fn has_no_externally_satisfiable_blanket_impls(
-    indexed_crate: &IndexedCrate<'_>,
-    trait_: &Item,
+fn determine_if_trait_is_supertrait_sealed_avoiding_cycles(
+    index: &HashMap<Id, Item>,
+    trait_item: &Item,
+    flags: &mut HashMap<Id, ItemFlag>,
+    visited_trait_ids: &mut HashSet<Id>,
+    consider_doc_hidden_sealed: bool,
 ) -> bool {
-    let trait_item = unwrap_trait(trait_);
-    for impl_id in &trait_item.implementations {
-        let impl_item = match indexed_crate.inner.index.get(impl_id).map(|item| {
+    let trait_flag = flags[&trait_item.id];
+    if trait_flag.is_sealed() || (consider_doc_hidden_sealed && trait_flag.is_doc_hidden_sealed()) {
+        return true;
+    }
+
+    let trait_inner = unwrap_trait(trait_item);
+    for bound in effective_supertraits_iter(trait_inner) {
+        let supertrait_item = match bound {
+            GenericBound::TraitBound { trait_, .. } => {
+                if let Some(item) = index.get(&trait_.id) {
+                    item
+                } else {
+                    // Not an item from this crate, so it can't cause sealing.
+                    //
+                    // TODO: Update this when we have cross-crate analysis,
+                    //       since this can cause doc-hidden-sealing.
+                    continue;
+                }
+            }
+            _ => unreachable!("non-trait bound found: {bound:?}"),
+        };
+        if determine_if_trait_is_sealed_with_no_external_blankets(
+            index,
+            supertrait_item,
+            flags,
+            visited_trait_ids,
+            consider_doc_hidden_sealed,
+        ) {
+            let trait_flags = flags
+                .get_mut(&trait_item.id)
+                .expect("no flags for trait ID");
+            if consider_doc_hidden_sealed {
+                trait_flags.set_doc_hidden_sealed();
+            } else {
+                trait_flags.set_sealed();
+                break;
+            }
+        }
+    }
+
+    let trait_flag = flags[&trait_item.id];
+    trait_flag.is_sealed() || (consider_doc_hidden_sealed && trait_flag.is_doc_hidden_sealed())
+}
+
+fn has_no_externally_satifiable_blanket_impls(
+    index: &HashMap<Id, Item>,
+    trait_inner: &Trait,
+    flags: &mut HashMap<Id, ItemFlag>,
+    visited_trait_ids: &mut HashSet<Id>,
+    consider_doc_hidden_sealed: bool,
+) -> bool {
+    for impl_id in &trait_inner.implementations {
+        let impl_item = match index.get(impl_id).map(|item| {
             let rustdoc_types::ItemEnum::Impl(impl_item) = &item.inner else {
                 panic!("impl Id {impl_id:?} did not refer to an impl item: {item:?}");
             };
@@ -179,7 +316,13 @@ fn has_no_externally_satisfiable_blanket_impls(
             }
         };
 
-        if is_externally_satisfiable_blanket_impl(indexed_crate, impl_item) {
+        if is_externally_satisfiable_blanket_impl(
+            index,
+            impl_item,
+            flags,
+            visited_trait_ids,
+            consider_doc_hidden_sealed,
+        ) {
             return false;
         }
     }
@@ -188,21 +331,16 @@ fn has_no_externally_satisfiable_blanket_impls(
 }
 
 fn is_externally_satisfiable_blanket_impl(
-    indexed_crate: &IndexedCrate<'_>,
+    index: &HashMap<Id, Item>,
     impl_item: &rustdoc_types::Impl,
+    flags: &mut HashMap<Id, ItemFlag>,
+    visited_trait_ids: &mut HashSet<Id>,
+    consider_doc_hidden_sealed: bool,
 ) -> bool {
-    let blanket_type = match get_impl_target_if_blanket_impl(impl_item) {
-        None => {
-            // Not a blanket impl, so not relevant here.
-            return false;
-        }
-        Some(blanket) => blanket,
-    };
-
-    // Can the blanket cover a type that a downstream crate might define?
+    // Is this a blanket impl, and can the blanket cover a type defined in a downstream crate?
     // For example, `T` and `&T` count, whereas `Vec<T>`, `[T]`, and `*const T` do not.
-    if !blanket_type_might_cover_types_in_downstream_crate(blanket_type) {
-        // This blanket impl doesn't cover types of a downstream crate. It isn't relevant here.
+    if !can_blanket_impl_target_include_downstream_types(impl_item) {
+        // This impl doesn't cover types of a downstream crate. It isn't relevant here.
         return false;
     }
 
@@ -222,11 +360,31 @@ fn is_externally_satisfiable_blanket_impl(
                 // The blanket impl is only not externally satisfiable if at least one trait bound
                 // references a trait where all of the following apply:
                 // - The trait is local to the crate we're analyzing.
-                // - The trait is sealed.
+                // - The trait is sealed / doc-hidden-sealed (depending on our bool input flag).
                 // - The trait has no blanket impls that are externally satisfiable.
                 //   (The same criterion we're in the middle of evaluating for another trait here.)
                 for bound in bounds {
-                    if is_bounded_on_local_sealed_trait_without_blankets(indexed_crate, bound) {
+                    let rustdoc_types::GenericBound::TraitBound { trait_, .. } = bound else {
+                        // Other kinds of generic bounds aren't relevant here.
+                        continue;
+                    };
+
+                    let bound_trait_id = &trait_.id;
+                    let Some(bound_item) = index.get(bound_trait_id) else {
+                        // Not a trait from this crate.
+                        //
+                        // TODO: Update this when we have cross-crate analysis,
+                        //       since this can cause doc-hidden-sealing.
+                        continue;
+                    };
+
+                    if determine_if_trait_is_sealed_with_no_external_blankets(
+                        index,
+                        bound_item,
+                        flags,
+                        visited_trait_ids,
+                        consider_doc_hidden_sealed,
+                    ) {
                         return false;
                     }
                 }
@@ -242,112 +400,206 @@ fn is_externally_satisfiable_blanket_impl(
     true
 }
 
-fn get_impl_target_if_blanket_impl(
-    impl_item: &rustdoc_types::Impl,
-) -> Option<&rustdoc_types::Type> {
+fn is_method_or_item_sealed<'a>(
+    index: &'a HashMap<Id, Item>,
+    trait_id: &Id,
+    trait_inner: &'a Trait,
+    flags: &mut HashMap<Id, ItemFlag>,
+) -> bool {
+    for inner_item_id in &trait_inner.items {
+        let inner_item = &index.get(inner_item_id);
+        let Some(inner_item) = inner_item else {
+            // This is almost certainly a bug in rustdoc JSON,
+            // since the trait's item isn't part of the trait's crate index.
+            continue;
+        };
+
+        let assoc_item_flag = flags
+            .get(inner_item_id)
+            .expect("no flags entry for trait associated item");
+
+        match &inner_item.inner {
+            rustdoc_types::ItemEnum::Function(func) => {
+                if func.has_body {
+                    // This trait function has a default implementation.
+                    // An implementation is not required in order to implement this trait on a type.
+                    // Therefore, it cannot on its own cause the trait to be sealed.
+                    continue;
+                }
+
+                if !assoc_item_flag.is_pub_reachable() && assoc_item_flag.is_doc_hidden_reachable()
+                {
+                    // This associated item is `doc(hidden)` and required to implement the trait.
+                    // That makes the trait doc-hidden-sealed.
+                    flags
+                        .get_mut(trait_id)
+                        .expect("no flags entry for trait item ID")
+                        .set_doc_hidden_sealed();
+                }
+
+                // Check for pub-in-priv function parameters.
+                for (_, param) in &func.sig.inputs {
+                    if let rustdoc_types::Type::ResolvedPath(path) = param {
+                        if let Some(item_flag) = flags.get(&path.id) {
+                            if !item_flag.is_reachable() {
+                                // Non-importable item, so this trait is method-sealed.
+                                flags
+                                    .get_mut(trait_id)
+                                    .expect("no flags entry for trait item ID")
+                                    .set_sealed();
+                                return true;
+                            } else if item_flag.is_doc_hidden_reachable() {
+                                flags
+                                    .get_mut(trait_id)
+                                    .expect("no flags entry for trait item ID")
+                                    .set_doc_hidden_sealed();
+                            }
+                        };
+                    }
+                }
+
+                // Check for pub-in-priv function return values.
+                if let Some(rustdoc_types::Type::ResolvedPath(path)) = &func.sig.output {
+                    if let Some(item_flag) = flags.get(&path.id) {
+                        if !item_flag.is_reachable() {
+                            // Non-importable item, so this trait is method-sealed.
+                            flags
+                                .get_mut(trait_id)
+                                .expect("no flags entry for trait item ID")
+                                .set_sealed();
+                            return true;
+                        } else if item_flag.is_doc_hidden_reachable() {
+                            flags
+                                .get_mut(trait_id)
+                                .expect("no flags entry for trait item ID")
+                                .set_doc_hidden_sealed();
+                        }
+                    };
+                }
+            }
+            rustdoc_types::ItemEnum::AssocType { type_, .. } if type_.is_none() => {
+                // Associated types without a default can cause a trait to be doc-hidden-sealed.
+
+                if !assoc_item_flag.is_pub_reachable() && assoc_item_flag.is_doc_hidden_reachable()
+                {
+                    // This associated item is `doc(hidden)` and required to implement the trait.
+                    // That makes the trait doc-hidden-sealed.
+                    flags
+                        .get_mut(trait_id)
+                        .expect("no flags entry for trait item ID")
+                        .set_doc_hidden_sealed();
+                }
+            }
+            rustdoc_types::ItemEnum::AssocConst { type_, value } if value.is_none() => {
+                // Associated constants without a default can cause a trait to be doc-hidden-sealed.
+
+                if !assoc_item_flag.is_pub_reachable() && assoc_item_flag.is_doc_hidden_reachable()
+                {
+                    // This associated item is `doc(hidden)` and required to implement the trait.
+                    // That makes the trait doc-hidden-sealed.
+                    flags
+                        .get_mut(trait_id)
+                        .expect("no flags entry for trait item ID")
+                        .set_doc_hidden_sealed();
+                }
+
+                if let rustdoc_types::Type::ResolvedPath(path) = type_ {
+                    if let Some(type_flag) = flags.get(&path.id) {
+                        if !type_flag.is_reachable() {
+                            // Non-importable item, so this trait is method-sealed.
+                            flags
+                                .get_mut(trait_id)
+                                .expect("no flags entry for trait item ID")
+                                .set_sealed();
+                            return true;
+                        } else if type_flag.is_doc_hidden_reachable() {
+                            flags
+                                .get_mut(trait_id)
+                                .expect("no flags entry for trait item ID")
+                                .set_doc_hidden_sealed();
+                        }
+                    };
+                }
+            }
+            _ => {}
+        }
+    }
+
+    false
+}
+
+fn effective_supertraits_iter(trait_inner: &Trait) -> impl Iterator<Item = &GenericBound> + '_ {
+    let direct_bounds = trait_inner.bounds.iter();
+
+    let where_predicate_bounds = trait_inner.generics.where_predicates.iter().filter_map(|predicate| {
+        match predicate {
+            // Only `where Self: SomeTrait` predicates are relevant for sealed trait analysis.
+            // Ignore all other predicate types.
+            rustdoc_types::WherePredicate::BoundPredicate { type_, bounds, .. } => {
+                // If the predicate isn't over `Self`, it isn't relevant.
+                if matches!(type_, rustdoc_types::Type::Generic(generic) if generic.as_str() == "Self") {
+                    // We found a trait similar to:
+                    // `pub trait Example where Self: SealedTrait { ... }`
+                    //
+                    // Even though `SealedTrait` isn't *explicitly* a supertrait,
+                    // any implementer of `Example` would still have to implement it too.
+                    // This makes it equivalent to a supertrait bound for purposes
+                    // of trait sealing.
+                    Some(bounds)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }).flatten();
+
+    direct_bounds
+        .chain(where_predicate_bounds)
+        .filter(|bound| matches!(bound, GenericBound::TraitBound { .. }))
+}
+
+fn can_blanket_impl_target_include_downstream_types(impl_item: &rustdoc_types::Impl) -> bool {
     let mut current_type = &impl_item.for_;
 
     loop {
         match current_type {
+            rustdoc_types::Type::BorrowedRef { type_, .. } => {
+                current_type = type_;
+            }
             rustdoc_types::Type::ResolvedPath { .. } |  // e.g. `Arc<T>`
-            rustdoc_types::Type::DynTrait { .. } |      // e.g. `dyn Iterator`
             rustdoc_types::Type::Tuple { .. } |         // e.g. `(T,)`
             rustdoc_types::Type::Slice { .. } |         // e.g. `[T]`
             rustdoc_types::Type::Array { .. } |         // e.g. `[T; 1]`
+            rustdoc_types::Type::RawPointer { .. } |    // e.g. `*const T`
             rustdoc_types::Type::Pat { .. } => {        // unstable feature, syntax isn't finalized
                 // These are all specific types that simply have a generic parameter.
                 // They are not blanket implementations.
-                return None;
+                //
+                // All these types are considered "foreign" by trait coherence,
+                // so Rust does not allow implementing another crate's trait on them.
+                return false;
             }
             rustdoc_types::Type::Generic(..) => {
-                // Blanket impl!
-                break;
+                // Blanket impl that covers downstream types!
+                return true;
             }
-            rustdoc_types::Type::Primitive { .. } |
+            rustdoc_types::Type::DynTrait { .. } |        // e.g. `dyn Iterator`
+            rustdoc_types::Type::Primitive { .. } |       // e.g. `i64`
             rustdoc_types::Type::FunctionPointer { .. } |
             rustdoc_types::Type::Infer |
             rustdoc_types::Type::ImplTrait { .. } |
             rustdoc_types::Type::QualifiedPath { .. } => {
-                // Not a blanket impl.
-                return None;
-            }
-            rustdoc_types::Type::RawPointer { type_, .. } |
-            rustdoc_types::Type::BorrowedRef { type_, .. } => {
-                current_type = type_;
-            }
-        }
-    }
-
-    Some(&impl_item.for_)
-}
-
-fn is_bounded_on_local_sealed_trait_without_blankets(
-    indexed_crate: &IndexedCrate<'_>,
-    bound: &rustdoc_types::GenericBound,
-) -> bool {
-    match bound {
-        rustdoc_types::GenericBound::TraitBound { trait_, .. } => {
-            let bound_trait_id = &trait_.id;
-            let Some(item) = indexed_crate.inner.index.get(bound_trait_id) else {
-                // Not a trait from this crate.
-                return false;
-            };
-
-            // We cannot have an infinite loop here, since Rust won't allow cyclic bounds.
-            if !is_trait_sealed(indexed_crate, item) {
+                // Not a blanket impl. None of these can cover a type in a downstream crate.
                 return false;
             }
-
-            has_no_externally_satisfiable_blanket_impls(indexed_crate, item)
-        }
-        rustdoc_types::GenericBound::Outlives(_) | rustdoc_types::GenericBound::Use(_) => {
-            // Other kinds of generic bounds aren't relevant here.
-            false
         }
     }
 }
 
-fn blanket_type_might_cover_types_in_downstream_crate(blanket_type: &rustdoc_types::Type) -> bool {
-    match blanket_type {
-        rustdoc_types::Type::Generic(..) => {
-            // Blanket implementation over a bare generic type, like `T`.
-            // This matches!
-            true
-        }
-        rustdoc_types::Type::BorrowedRef { type_, .. } => {
-            // Blanket implementation over a reference, like `&T`.
-            // It matches if the underlying type beheath the reference matches.
-            blanket_type_might_cover_types_in_downstream_crate(type_)
-        }
-        rustdoc_types::Type::ResolvedPath { .. } |  // e.g. `Arc<T>`
-        rustdoc_types::Type::Tuple { .. } |         // e.g. `(T,)`
-        rustdoc_types::Type::Slice { .. } |         // e.g. `[T]`
-        rustdoc_types::Type::Array { .. } |         // e.g. `[T; 1]`
-        rustdoc_types::Type::RawPointer { .. } => { // e.g. `*const T`
-            // All these types are considered "foreign" by trait coherence,
-            // so Rust does not allow implementing another crate's trait on them.
-            false
-        }
-        rustdoc_types::Type::DynTrait { .. } |
-        rustdoc_types::Type::Primitive { .. } |
-        rustdoc_types::Type::FunctionPointer { .. } |
-        rustdoc_types::Type::Pat { .. } |
-        rustdoc_types::Type::ImplTrait { .. } |
-        rustdoc_types::Type::Infer { .. } |
-        rustdoc_types::Type::QualifiedPath { .. } => {
-            // None of these can cover a type in a downstream crate.
-            false
-        }
+fn unwrap_trait(item: &Item) -> &'_ Trait {
+    match &item.inner {
+        rustdoc_types::ItemEnum::Trait(t) => t,
+        _ => unreachable!("item {item:?} is not a trait"),
     }
-}
-
-fn is_local_pub_in_priv_path<'a>(
-    indexed_crate: &IndexedCrate<'a>,
-    path: &'a rustdoc_types::Path,
-) -> bool {
-    let Some(item) = indexed_crate.inner.index.get(&path.id) else {
-        // Not an item in this crate.
-        return false;
-    };
-    is_pub_in_priv_item(indexed_crate, &item.id)
 }

--- a/src/sealed_trait.rs
+++ b/src/sealed_trait.rs
@@ -8,10 +8,6 @@ use rustdoc_types::{GenericBound, Id, Item, Trait};
 
 use crate::item_flags::ItemFlag;
 
-// TODO: update terminology: `doc-hidden-sealed` is inappropriate because
-//       deprecated doc-hidden items are considered public API.
-//       we want something like "sealed in public API"
-
 /// Update the `flags` with trait sealing and blanket impls information.
 ///
 /// # Preconditions
@@ -36,24 +32,19 @@ pub(crate) fn compute_trait_flags(index: &HashMap<Id, Item>, flags: &mut HashMap
             let impl_inner = match &impl_item.inner {
                 rustdoc_types::ItemEnum::Impl(impl_inner) => impl_inner,
                 _ => {
-                    // Probably a rustdoc bug -- we referenced an item as an impl but it isn't one.
-                    continue;
+                    unreachable!(
+                        "referenced trait impl is actually not an impl item: {impl_item:?}"
+                    );
                 }
             };
 
-            // Ensure our opinion on whether downstream types can gain impls via a blanket
-            // matches rustdoc's opinion on what counts as a blanket impl.
+            // N.B.: Confusingly, the `blanket_impl` field in rustdoc JSON uses
+            // a different definition of "blanket" that only covers synthetic impls.
             //
-            // N.B.: The `blanket_impl` field in rustdoc JSON is *not* trustworthy!
+            // More info:
+            // https://github.com/rust-lang/rust/issues/136557#issuecomment-2634994515
             //
-            // The following `impl` has `blanket_impl = None`,
-            // seven though it seems to clearly be a blanket impl.
-            // ```rust
-            // mod private {
-            //     pub trait FullBlanket {}
-            //     impl<T> FullBlanket for T {}
-            // }
-            // ```
+            // As a result, we have our own logic to determine if the impl is a blanket impl.
             if can_blanket_impl_target_include_downstream_types(impl_inner) {
                 item_flags.set_trait_has_blanket_impls();
             }
@@ -63,13 +54,13 @@ pub(crate) fn compute_trait_flags(index: &HashMap<Id, Item>, flags: &mut HashMap
             // The trait isn't importable at all.
             // Either it's pub-in-priv or just not pub at all.
             // So it's trivially sealed. Nothing further to check here.
-            item_flags.set_sealed();
+            item_flags.set_unconditionally_sealed();
             continue;
         } else if item_flags.is_non_pub_api_reachable() {
             // The trait is reachable only via `doc(hidden)` paths.
             // Downstream crates can only `impl` it by naming such a non-public-API path,
-            // so the trait is doc-hidden-sealed.
-            item_flags.set_doc_hidden_sealed();
+            // so the trait is public-API-sealed.
+            item_flags.set_pub_api_sealed();
 
             // The trait might be completely sealed though, so we'll keep looking.
         }
@@ -83,11 +74,11 @@ pub(crate) fn compute_trait_flags(index: &HashMap<Id, Item>, flags: &mut HashMap
         // https://predr.ag/blog/definitive-guide-to-sealed-traits-in-rust/#sealing-traits-via-method-signatures
         //
         // Instead, if the argument is only `doc(hidden)`-reachable,
-        // then the trait is doc-hidden-sealed. Similarly, if a non-defaulted associated item
-        // is `doc(hidden)` and not deprecated, the trait is doc-hidden-sealed.
+        // then the trait is public-API-sealed. Similarly, if a non-defaulted associated item
+        // is `doc(hidden)` and not deprecated, the trait is public-API-sealed.
         //
         // This method applies the flags internally, and returns `true` only if
-        // the trait is sealed, meaning that we can skip further analysis for it.
+        // the trait is unconditionally sealed, meaning that we can skip further analysis for it.
         if is_method_or_item_sealed(index, id, trait_inner, flags) {
             continue;
         }
@@ -127,7 +118,7 @@ pub(crate) fn compute_trait_flags(index: &HashMap<Id, Item>, flags: &mut HashMap
                         // Not an item from this crate, so it can't cause sealing.
                         //
                         // TODO: Update this when we have cross-crate analysis,
-                        //       since this can cause doc-hidden-sealing.
+                        //       since this can cause public-API-sealing.
                         continue;
                     }
                 }
@@ -137,12 +128,12 @@ pub(crate) fn compute_trait_flags(index: &HashMap<Id, Item>, flags: &mut HashMap
             let supertrait_flags = flags[&supertrait_item.id];
             if supertrait_flags.trait_has_blanket_impls() {
                 blankets_found = true;
-            } else if supertrait_flags.is_sealed() {
+            } else if supertrait_flags.is_unconditionally_sealed() {
                 // Sealed supertrait with no blanket impls! This seals our trait, and is final.
                 flags
                     .get_mut(&trait_item.id)
                     .expect("no flag for trait item")
-                    .set_sealed();
+                    .set_unconditionally_sealed();
                 proven_sealed = true;
                 break;
             } else {
@@ -151,12 +142,13 @@ pub(crate) fn compute_trait_flags(index: &HashMap<Id, Item>, flags: &mut HashMap
                 }
 
                 if supertrait_flags.is_only_pub_api_sealed() {
-                    // Doc-hidden-sealed supertrait with no blanket impls. This means our trait
-                    // is *at least* doc-hidden-sealed. But it might still be sealed!
+                    // Public-API-sealed supertrait with no blanket impls.
+                    // This means our trait is *at least* public-API-sealed.
+                    // But it might still be unconditionally sealed!
                     flags
                         .get_mut(&trait_item.id)
                         .expect("no flag for trait item")
-                        .set_doc_hidden_sealed();
+                        .set_pub_api_sealed();
                 }
             }
         }
@@ -166,10 +158,12 @@ pub(crate) fn compute_trait_flags(index: &HashMap<Id, Item>, flags: &mut HashMap
     }
 
     // We've resolved all the easy cases. Time to deal with traits with possible cyclic bounds.
+    //
+    // First, check for unconditional sealing.
     let mut visited_trait_ids: HashSet<Id> = HashSet::default();
     for trait_item in &possible_cycles {
         visited_trait_ids.insert(trait_item.id);
-        determine_if_trait_is_supertrait_sealed_avoiding_cycles(
+        is_trait_supertrait_sealed_avoiding_cycles(
             index,
             trait_item,
             flags,
@@ -178,9 +172,11 @@ pub(crate) fn compute_trait_flags(index: &HashMap<Id, Item>, flags: &mut HashMap
         );
         visited_trait_ids.clear();
     }
+
+    // Then, check for public-API-sealed traits.
     for trait_item in &possible_cycles {
         visited_trait_ids.insert(trait_item.id);
-        determine_if_trait_is_supertrait_sealed_avoiding_cycles(
+        is_trait_supertrait_sealed_avoiding_cycles(
             index,
             trait_item,
             flags,
@@ -196,35 +192,35 @@ fn determine_if_trait_is_sealed_with_no_external_blankets(
     trait_item: &Item,
     flags: &mut HashMap<Id, ItemFlag>,
     visited_trait_ids: &mut HashSet<Id>,
-    consider_doc_hidden_sealed: bool,
+    consider_public_api_sealed: bool,
 ) -> bool {
     if !visited_trait_ids.insert(trait_item.id) {
         // Already visited this supertrait, we're in a cycle. Unwind the cycle,
         // marking all traits in it as sealed.
-        if consider_doc_hidden_sealed {
+        if consider_public_api_sealed {
             visited_trait_ids.iter().for_each(|id| {
                 flags
                     .get_mut(id)
                     .expect("no flags for trait ID")
-                    .set_doc_hidden_sealed();
+                    .set_pub_api_sealed();
             });
         } else {
             visited_trait_ids.iter().for_each(|id| {
                 flags
                     .get_mut(id)
                     .expect("no flags for trait ID")
-                    .set_sealed();
+                    .set_unconditionally_sealed();
             });
         }
         return true;
     }
 
-    if determine_if_trait_is_supertrait_sealed_avoiding_cycles(
+    if is_trait_supertrait_sealed_avoiding_cycles(
         index,
         trait_item,
         flags,
         visited_trait_ids,
-        consider_doc_hidden_sealed,
+        consider_public_api_sealed,
     ) {
         let trait_flags = flags[&trait_item.id];
         let trait_inner = unwrap_trait(trait_item);
@@ -234,7 +230,7 @@ fn determine_if_trait_is_sealed_with_no_external_blankets(
                 trait_inner,
                 flags,
                 visited_trait_ids,
-                consider_doc_hidden_sealed,
+                consider_public_api_sealed,
             )
         {
             return true;
@@ -244,15 +240,16 @@ fn determine_if_trait_is_sealed_with_no_external_blankets(
     false
 }
 
-fn determine_if_trait_is_supertrait_sealed_avoiding_cycles(
+fn is_trait_supertrait_sealed_avoiding_cycles(
     index: &HashMap<Id, Item>,
     trait_item: &Item,
     flags: &mut HashMap<Id, ItemFlag>,
     visited_trait_ids: &mut HashSet<Id>,
-    consider_doc_hidden_sealed: bool,
+    consider_public_api_sealed: bool,
 ) -> bool {
     let trait_flag = flags[&trait_item.id];
-    if trait_flag.is_sealed() || (consider_doc_hidden_sealed && trait_flag.is_only_pub_api_sealed())
+    if trait_flag.is_unconditionally_sealed()
+        || (consider_public_api_sealed && trait_flag.is_only_pub_api_sealed())
     {
         return true;
     }
@@ -267,7 +264,7 @@ fn determine_if_trait_is_supertrait_sealed_avoiding_cycles(
                     // Not an item from this crate, so it can't cause sealing.
                     //
                     // TODO: Update this when we have cross-crate analysis,
-                    //       since this can cause doc-hidden-sealing.
+                    //       since this can cause public-API-sealing.
                     continue;
                 }
             }
@@ -278,22 +275,23 @@ fn determine_if_trait_is_supertrait_sealed_avoiding_cycles(
             supertrait_item,
             flags,
             visited_trait_ids,
-            consider_doc_hidden_sealed,
+            consider_public_api_sealed,
         ) {
             let trait_flags = flags
                 .get_mut(&trait_item.id)
                 .expect("no flags for trait ID");
-            if consider_doc_hidden_sealed {
-                trait_flags.set_doc_hidden_sealed();
+            if consider_public_api_sealed {
+                trait_flags.set_pub_api_sealed();
             } else {
-                trait_flags.set_sealed();
+                trait_flags.set_unconditionally_sealed();
                 break;
             }
         }
     }
 
     let trait_flag = flags[&trait_item.id];
-    trait_flag.is_sealed() || (consider_doc_hidden_sealed && trait_flag.is_only_pub_api_sealed())
+    trait_flag.is_unconditionally_sealed()
+        || (consider_public_api_sealed && trait_flag.is_only_pub_api_sealed())
 }
 
 fn has_no_externally_satifiable_blanket_impls(
@@ -301,7 +299,7 @@ fn has_no_externally_satifiable_blanket_impls(
     trait_inner: &Trait,
     flags: &mut HashMap<Id, ItemFlag>,
     visited_trait_ids: &mut HashSet<Id>,
-    consider_doc_hidden_sealed: bool,
+    consider_public_api_sealed: bool,
 ) -> bool {
     for impl_id in &trait_inner.implementations {
         let impl_item = match index.get(impl_id).map(|item| {
@@ -322,7 +320,7 @@ fn has_no_externally_satifiable_blanket_impls(
             impl_item,
             flags,
             visited_trait_ids,
-            consider_doc_hidden_sealed,
+            consider_public_api_sealed,
         ) {
             return false;
         }
@@ -336,7 +334,7 @@ fn is_externally_satisfiable_blanket_impl(
     impl_item: &rustdoc_types::Impl,
     flags: &mut HashMap<Id, ItemFlag>,
     visited_trait_ids: &mut HashSet<Id>,
-    consider_doc_hidden_sealed: bool,
+    consider_public_api_sealed: bool,
 ) -> bool {
     // Is this a blanket impl, and can the blanket cover a type defined in a downstream crate?
     // For example, `T` and `&T` count, whereas `Vec<T>`, `[T]`, and `*const T` do not.
@@ -361,7 +359,7 @@ fn is_externally_satisfiable_blanket_impl(
                 // The blanket impl is only not externally satisfiable if at least one trait bound
                 // references a trait where all of the following apply:
                 // - The trait is local to the crate we're analyzing.
-                // - The trait is sealed / doc-hidden-sealed (depending on our bool input flag).
+                // - The trait is sealed / public-API-sealed (depending on our bool input flag).
                 // - The trait has no blanket impls that are externally satisfiable.
                 //   (The same criterion we're in the middle of evaluating for another trait here.)
                 for bound in bounds {
@@ -375,7 +373,7 @@ fn is_externally_satisfiable_blanket_impl(
                         // Not a trait from this crate.
                         //
                         // TODO: Update this when we have cross-crate analysis,
-                        //       since this can cause doc-hidden-sealing.
+                        //       since this can cause public-API-sealing.
                         continue;
                     };
 
@@ -384,7 +382,7 @@ fn is_externally_satisfiable_blanket_impl(
                         bound_item,
                         flags,
                         visited_trait_ids,
-                        consider_doc_hidden_sealed,
+                        consider_public_api_sealed,
                     ) {
                         return false;
                     }
@@ -431,11 +429,11 @@ fn is_method_or_item_sealed<'a>(
                 if !assoc_item_flag.is_pub_reachable() && assoc_item_flag.is_non_pub_api_reachable()
                 {
                     // This associated item is `doc(hidden)` and required to implement the trait.
-                    // That makes the trait doc-hidden-sealed.
+                    // That makes the trait public-API-sealed.
                     flags
                         .get_mut(trait_id)
                         .expect("no flags entry for trait item ID")
-                        .set_doc_hidden_sealed();
+                        .set_pub_api_sealed();
                 }
 
                 // Check for pub-in-priv function parameters.
@@ -447,13 +445,13 @@ fn is_method_or_item_sealed<'a>(
                                 flags
                                     .get_mut(trait_id)
                                     .expect("no flags entry for trait item ID")
-                                    .set_sealed();
+                                    .set_unconditionally_sealed();
                                 return true;
                             } else if item_flag.is_non_pub_api_reachable() {
                                 flags
                                     .get_mut(trait_id)
                                     .expect("no flags entry for trait item ID")
-                                    .set_doc_hidden_sealed();
+                                    .set_pub_api_sealed();
                             }
                         };
                     }
@@ -467,41 +465,41 @@ fn is_method_or_item_sealed<'a>(
                             flags
                                 .get_mut(trait_id)
                                 .expect("no flags entry for trait item ID")
-                                .set_sealed();
+                                .set_unconditionally_sealed();
                             return true;
                         } else if item_flag.is_non_pub_api_reachable() {
                             flags
                                 .get_mut(trait_id)
                                 .expect("no flags entry for trait item ID")
-                                .set_doc_hidden_sealed();
+                                .set_pub_api_sealed();
                         }
                     };
                 }
             }
             rustdoc_types::ItemEnum::AssocType { type_, .. } if type_.is_none() => {
-                // Associated types without a default can cause a trait to be doc-hidden-sealed.
+                // Associated types without a default can cause a trait to be public-API-sealed.
 
                 if !assoc_item_flag.is_pub_reachable() && assoc_item_flag.is_non_pub_api_reachable()
                 {
                     // This associated item is `doc(hidden)` and required to implement the trait.
-                    // That makes the trait doc-hidden-sealed.
+                    // That makes the trait public-API-sealed.
                     flags
                         .get_mut(trait_id)
                         .expect("no flags entry for trait item ID")
-                        .set_doc_hidden_sealed();
+                        .set_pub_api_sealed();
                 }
             }
             rustdoc_types::ItemEnum::AssocConst { type_, value } if value.is_none() => {
-                // Associated constants without a default can cause a trait to be doc-hidden-sealed.
+                // Associated constants without a default can cause a trait to be public-API-sealed.
 
                 if !assoc_item_flag.is_pub_reachable() && assoc_item_flag.is_non_pub_api_reachable()
                 {
                     // This associated item is `doc(hidden)` and required to implement the trait.
-                    // That makes the trait doc-hidden-sealed.
+                    // That makes the trait public-API-sealed.
                     flags
                         .get_mut(trait_id)
                         .expect("no flags entry for trait item ID")
-                        .set_doc_hidden_sealed();
+                        .set_pub_api_sealed();
                 }
 
                 if let rustdoc_types::Type::ResolvedPath(path) = type_ {
@@ -511,13 +509,13 @@ fn is_method_or_item_sealed<'a>(
                             flags
                                 .get_mut(trait_id)
                                 .expect("no flags entry for trait item ID")
-                                .set_sealed();
+                                .set_unconditionally_sealed();
                             return true;
                         } else if type_flag.is_non_pub_api_reachable() {
                             flags
                                 .get_mut(trait_id)
                                 .expect("no flags entry for trait item ID")
-                                .set_doc_hidden_sealed();
+                                .set_pub_api_sealed();
                         }
                     };
                 }

--- a/src/sealed_trait.rs
+++ b/src/sealed_trait.rs
@@ -490,7 +490,8 @@ fn is_method_or_item_sealed<'a>(
                 }
             }
             rustdoc_types::ItemEnum::AssocConst { type_, value } if value.is_none() => {
-                // Associated constants without a default can cause a trait to be public-API-sealed.
+                // Associated constants without a default can cause a trait to be sealed,
+                // either unconditionally or just public-API-sealed.
 
                 if !assoc_item_flag.is_pub_reachable() && assoc_item_flag.is_non_pub_api_reachable()
                 {
@@ -505,7 +506,7 @@ fn is_method_or_item_sealed<'a>(
                 if let rustdoc_types::Type::ResolvedPath(path) = type_ {
                     if let Some(type_flag) = flags.get(&path.id) {
                         if !type_flag.is_reachable() {
-                            // Non-importable item, so this trait is method-sealed.
+                            // Non-importable item, so this trait is unconditionally item-sealed.
                             flags
                                 .get_mut(trait_id)
                                 .expect("no flags entry for trait item ID")

--- a/test_crates/sealed_traits/src/doc_hidden.rs
+++ b/test_crates/sealed_traits/src/doc_hidden.rs
@@ -77,6 +77,13 @@ pub trait HiddenSealedAssocConst {
     const N: usize;
 }
 
+/// This trait is public-API-sealed because impls require
+/// setting the non-public-API associated const, which requires naming its type.
+/// The const's type name is not public API, hence the trait is public-API-sealed.
+pub trait HiddenSealedAssocConstType {
+    const N: hidden_module::Token;
+}
+
 /// This trait is not sealed, since naming the doc-hidden const isn't necessary
 /// as we can use its default value.
 pub trait UnsealedDefaultAssocConst {

--- a/test_crates/sealed_traits/src/doc_hidden.rs
+++ b/test_crates/sealed_traits/src/doc_hidden.rs
@@ -1,6 +1,6 @@
 #[doc(hidden)]
 pub mod hidden_module {
-    /// This trait is doc-hidden-sealed because implementing it
+    /// This trait is public-API-sealed because implementing it
     /// requires going outside the public API.
     pub trait HiddenSealed {}
 
@@ -12,46 +12,46 @@ pub mod hidden_module {
 
 pub trait Unsealed {}
 
-/// This trait is doc-hidden-sealed since it isn't public API in the first place.
+/// This trait is public-API-sealed since it isn't public API in the first place.
 #[doc(hidden)]
 pub trait DirectlyHiddenSealed {}
 
-/// This trait is doc-hidden-sealed since implementing it requires naming
+/// This trait is public-API-sealed since implementing it requires naming
 /// its non-public-API supertrait.
 pub trait HiddenSealedInherited: hidden_module::HiddenSealed {}
 
-/// This trait is doc-hidden-sealed transitively because of its supertrait.
+/// This trait is public-API-sealed transitively because of its supertrait.
 pub trait TransitivelyHiddenSealed: HiddenSealedInherited {}
 
-/// This trait is doc-hidden-sealed, since `Self: hidden_module::HiddenSealed`
-/// still requires that `Self` implement a doc-hidden-sealed trait,
-/// even though the doc-hidden-sealed trait isn't *exactly* a supertrait.
+/// This trait is public-API-sealed, since `Self: hidden_module::HiddenSealed`
+/// still requires that `Self` implement a public-API-sealed trait,
+/// even though the public-API-sealed trait isn't *exactly* a supertrait.
 pub trait HiddenSealedWithWhereSelfBound where Self: hidden_module::HiddenSealed {}
 
-/// This trait is doc-hidden-sealed because its method's argument type is doc-hidden,
+/// This trait is public-API-sealed because its method's argument type is doc-hidden,
 /// so external implementers would have to name a non-public-API type to write the impl.
 pub trait MethodHiddenSealed {
     fn method(&self, token: hidden_module::Token);
 }
 
-/// This trait is doc-hidden-sealed because its method's return type is doc-hidden,
+/// This trait is public-API-sealed because its method's return type is doc-hidden,
 /// so external implementers would have to name a non-public-API type to write the impl.
 pub trait MethodReturnHiddenSealed {
     fn method(&self) -> hidden_module::Token;
 }
 
-/// This trait is doc-hidden-sealed because its required method is doc-hidden,
+/// This trait is public-API-sealed because its required method is doc-hidden,
 /// so external implementers would have to name a non-public-API method to write the impl.
 pub trait HiddenMethodHiddenSealed {
     #[doc(hidden)]
     fn method(&self);
 }
 
-/// This trait is doc-hidden-sealed since implementing its supertrait requires
+/// This trait is public-API-sealed since implementing its supertrait requires
 /// naming a non-public-API type.
 pub trait TransitivelyMethodHiddenSealed: MethodHiddenSealed {}
 
-/// This trait is *not* doc-hidden-sealed. Its method cannot be overridden within public API,
+/// This trait is *not* public-API-sealed. Its method cannot be overridden within public API,
 /// but implementing it is not required since the trait offers a default impl.
 pub trait NotMethodHiddenSealedBecauseOfDefaultImpl {
     #[doc(hidden)]
@@ -60,7 +60,7 @@ pub trait NotMethodHiddenSealedBecauseOfDefaultImpl {
     }
 }
 
-/// This trait is doc-hidden-sealed because impls require
+/// This trait is public-API-sealed because impls require
 /// setting the non-public-API associated type.
 //
 // TODO: Add a test case with a default value on the associated type, when those become stable.
@@ -70,7 +70,7 @@ pub trait HiddenSealedAssocType {
     type T;
 }
 
-/// This trait is doc-hidden-sealed because impls require
+/// This trait is public-API-sealed because impls require
 /// setting the non-public-API associated const.
 pub trait HiddenSealedAssocConst {
     #[doc(hidden)]
@@ -85,7 +85,7 @@ pub trait UnsealedDefaultAssocConst {
 }
 
 /// This trait's method has a bound on a doc-hidden trait,
-/// but the trait itself is *not* doc-hidden-sealed!
+/// but the trait itself is *not* public-API-sealed!
 /// Downstream implementations are possible without using non-public-API:
 ///
 /// ```rust
@@ -220,13 +220,13 @@ pub trait IteratorBlanketUnsealed: blanket_impls::IteratorBlanket {}
 /// ```
 pub trait BlanketOverLocalUnsealedTraitUnsealed: blanket_impls::BlanketOverLocalUnsealedTrait {}
 
-/// This one is doc-hidden-sealed, since the blanket is over a doc-hidden-sealed trait
+/// This one is public-API-sealed, since the blanket is over a public-API-sealed trait
 /// which we cannot impl without touching non-public-API items:
-/// - either we directly implement the doc-hidden-sealed supertrait ourselves,
-/// - or we implement the doc-hidden-sealed trait for the supertrait's blanket impl.
+/// - either we directly implement the public-API-sealed supertrait ourselves,
+/// - or we implement the public-API-sealed trait for the supertrait's blanket impl.
 pub trait BlanketOverSealedTraitSealed: blanket_impls::BlanketOverSealedTrait {}
 
-/// This trait is doc-hidden-sealed because the bound on the blanket impl
+/// This trait is public-API-sealed because the bound on the blanket impl
 /// includes a trait we cannot impl without doc-hidden-API items. The proof is the same as above.
 pub trait BlanketSealedOverMultiple: blanket_impls::BlanketOverSealedAndUnsealedTrait {}
 
@@ -241,23 +241,23 @@ pub trait BlanketSealedOverMultiple: blanket_impls::BlanketOverSealedAndUnsealed
 /// ```
 pub trait TransitiveBlanketUnsealed: blanket_impls::TransitiveBlanket {}
 
-/// This trait is doc-hidden-sealed.
+/// This trait is public-API-sealed.
 /// - Its supertrait has a blanket impl over `Arc<T>`, but it isn't usable:
 ///   in order for a crate to implement a trait for a type, the crate needs to define
 ///   either the trait or the type. A downstream crate doesn't define either.
 /// - That means the supertrait must be implemented directly, but it's `doc(hidden)`.
 pub trait BlanketOverArcSealed: blanket_impls::BlanketOverArc {}
 
-/// Doc-hidden-sealed since tuples/slices/arrays/pointers are always considered foreign types.
+/// Public-API-sealed since tuples/slices/arrays/pointers are always considered foreign types.
 pub trait BlanketOverTupleSealed: blanket_impls::BlanketOverTuple {}
 
-/// Doc-hidden-sealed since tuples/slices/arrays/pointers are always considered foreign types.
+/// Public-API-sealed since tuples/slices/arrays/pointers are always considered foreign types.
 pub trait BlanketOverSliceSealed: blanket_impls::BlanketOverSlice {}
 
-/// Doc-hidden-sealed since tuples/slices/arrays/pointers are always considered foreign types.
+/// Public-API-sealed since tuples/slices/arrays/pointers are always considered foreign types.
 pub trait BlanketOverArraySealed: blanket_impls::BlanketOverArray {}
 
-/// Doc-hidden-sealed since tuples/slices/arrays/pointers are always considered foreign types.
+/// Public-API-sealed since tuples/slices/arrays/pointers are always considered foreign types.
 pub trait BlanketOverPointerSealed: blanket_impls::BlanketOverPointer {}
 
 /// Not sealed due to being deprecated and therefore public API, regardless of `doc(hidden)`.

--- a/test_crates/sealed_traits/src/doc_hidden.rs
+++ b/test_crates/sealed_traits/src/doc_hidden.rs
@@ -1,0 +1,296 @@
+#[doc(hidden)]
+pub mod hidden_module {
+    /// This trait is doc-hidden-sealed because implementing it
+    /// requires going outside the public API.
+    pub trait HiddenSealed {}
+
+    pub struct Token;
+
+    #[deprecated]
+    pub struct DeprecatedToken;
+}
+
+pub trait Unsealed {}
+
+/// This trait is doc-hidden-sealed since it isn't public API in the first place.
+#[doc(hidden)]
+pub trait DirectlyHiddenSealed {}
+
+/// This trait is doc-hidden-sealed since implementing it requires naming
+/// its non-public-API supertrait.
+pub trait HiddenSealedInherited: hidden_module::HiddenSealed {}
+
+/// This trait is doc-hidden-sealed transitively because of its supertrait.
+pub trait TransitivelyHiddenSealed: HiddenSealedInherited {}
+
+/// This trait is doc-hidden-sealed, since `Self: hidden_module::HiddenSealed`
+/// still requires that `Self` implement a doc-hidden-sealed trait,
+/// even though the doc-hidden-sealed trait isn't *exactly* a supertrait.
+pub trait HiddenSealedWithWhereSelfBound where Self: hidden_module::HiddenSealed {}
+
+/// This trait is doc-hidden-sealed because its method's argument type is doc-hidden,
+/// so external implementers would have to name a non-public-API type to write the impl.
+pub trait MethodHiddenSealed {
+    fn method(&self, token: hidden_module::Token);
+}
+
+/// This trait is doc-hidden-sealed because its method's return type is doc-hidden,
+/// so external implementers would have to name a non-public-API type to write the impl.
+pub trait MethodReturnHiddenSealed {
+    fn method(&self) -> hidden_module::Token;
+}
+
+/// This trait is doc-hidden-sealed because its required method is doc-hidden,
+/// so external implementers would have to name a non-public-API method to write the impl.
+pub trait HiddenMethodHiddenSealed {
+    #[doc(hidden)]
+    fn method(&self);
+}
+
+/// This trait is doc-hidden-sealed since implementing its supertrait requires
+/// naming a non-public-API type.
+pub trait TransitivelyMethodHiddenSealed: MethodHiddenSealed {}
+
+/// This trait is *not* doc-hidden-sealed. Its method cannot be overridden within public API,
+/// but implementing it is not required since the trait offers a default impl.
+pub trait NotMethodHiddenSealedBecauseOfDefaultImpl {
+    #[doc(hidden)]
+    fn method(&self, _token: hidden_module::Token) -> i64 {
+        0
+    }
+}
+
+/// This trait is doc-hidden-sealed because impls require
+/// setting the non-public-API associated type.
+//
+// TODO: Add a test case with a default value on the associated type, when those become stable.
+//       That would make the trait not sealed.
+pub trait HiddenSealedAssocType {
+    #[doc(hidden)]
+    type T;
+}
+
+/// This trait is doc-hidden-sealed because impls require
+/// setting the non-public-API associated const.
+pub trait HiddenSealedAssocConst {
+    #[doc(hidden)]
+    const N: usize;
+}
+
+/// This trait is not sealed, since naming the doc-hidden const isn't necessary
+/// as we can use its default value.
+pub trait UnsealedDefaultAssocConst {
+    #[doc(hidden)]
+    const N: usize = 0;
+}
+
+/// This trait's method has a bound on a doc-hidden trait,
+/// but the trait itself is *not* doc-hidden-sealed!
+/// Downstream implementations are possible without using non-public-API:
+///
+/// ```rust
+/// struct Foo;
+///
+/// impl sealed_traits::doc_hidden::MethodWithHiddenBound for Foo {
+///     fn method<IM>(&self) {}
+/// }
+/// ```
+pub trait MethodWithHiddenBound {
+    fn method<IM: hidden_module::HiddenSealed>(&self);
+}
+
+#[doc(hidden)]
+pub mod blanket_impls {
+    pub trait FullBlanket {}
+    impl<T> FullBlanket for T {}
+
+    pub trait RefBlanket {}
+    impl<T> RefBlanket for &T {}
+
+    pub trait ExternalSupertraitsBlanket {}
+    impl<T: std::fmt::Debug + Clone> ExternalSupertraitsBlanket for T {}
+
+    // In Rust this is syntax sugar for `impl<T: Clone>`, but let's make sure rustdoc thinks so too.
+    pub trait BlanketWithWhereClause {}
+    impl<T> BlanketWithWhereClause for T where T: Clone {}
+
+    // The iterator trait is special because we don't manually inline it into rustdoc info.
+    // See `MANUAL_TRAIT_ITEMS` inside `indexed_crate.rs` for more details.
+    pub trait IteratorBlanket {}
+    impl<T: Iterator> IteratorBlanket for T {}
+
+    pub trait BlanketOverLocalUnsealedTrait {}
+    impl<T: super::Unsealed> BlanketOverLocalUnsealedTrait for T {}
+
+    pub trait BlanketOverSealedTrait {}
+    impl<T: super::DirectlyHiddenSealed> BlanketOverSealedTrait for T {}
+
+    pub trait BlanketOverSealedAndUnsealedTrait {}
+    impl<T: super::Unsealed + super::DirectlyHiddenSealed> BlanketOverSealedAndUnsealedTrait for T {}
+
+    // The blanket impl here is over everything,
+    // because `FullBlanket` has a blanket impl for everything.
+    pub trait TransitiveBlanket {}
+    impl<T: FullBlanket> TransitiveBlanket for T {}
+
+    pub trait BlanketOverArc {}
+    impl<T> BlanketOverArc for std::sync::Arc<T> {}
+
+    pub trait BlanketOverTuple {}
+    impl<T> BlanketOverTuple for (T,) {}
+
+    pub trait BlanketOverSlice {}
+    impl<T> BlanketOverSlice for [T] {}
+
+    pub trait BlanketOverArray {}
+    impl<T> BlanketOverArray for [T; 1] {}
+
+    pub trait BlanketOverPointer {}
+    impl<T> BlanketOverPointer for *const T {}
+}
+
+/// Not sealed due to blanket impl. No `doc(hidden)` items needed to impl it.
+///
+/// ```rust
+/// struct Example;
+///
+/// impl sealed_traits::doc_hidden::BlanketUnsealed for Example {}
+/// ```
+pub trait BlanketUnsealed: blanket_impls::FullBlanket {}
+
+/// Not sealed due to blanket impl. No `doc(hidden)` items needed to impl it.
+///
+/// Proof:
+/// ```rust
+/// struct Example;
+///
+/// impl sealed_traits::doc_hidden::RefBlanketUnsealed for &Example {}
+/// ```
+pub trait RefBlanketUnsealed: blanket_impls::RefBlanket {}
+
+/// Not sealed due to blanket impl. No `doc(hidden)` items needed to impl it.
+///
+/// Proof:
+/// ```rust
+/// #[derive(Debug, Clone)]
+/// struct Example;
+///
+/// impl sealed_traits::doc_hidden::ExternalSupertraitsBlanketUnsealed for Example {}
+/// ```
+pub trait ExternalSupertraitsBlanketUnsealed: blanket_impls::ExternalSupertraitsBlanket {}
+
+/// Not sealed due to blanket impl. No `doc(hidden)` items needed to impl it.
+///
+/// Proof:
+/// ```rust
+/// #[derive(Clone)]
+/// struct Example;
+///
+/// impl sealed_traits::doc_hidden::BlanketWithWhereClauseUnsealed for Example {}
+/// ```
+pub trait BlanketWithWhereClauseUnsealed: blanket_impls::BlanketWithWhereClause {}
+
+/// Not sealed due to blanket impl. No `doc(hidden)` items needed to impl it.
+///
+/// Proof:
+/// ```rust
+/// struct ExampleIter;
+///
+/// impl Iterator for ExampleIter {
+///     type Item = ();
+///
+///     fn next(&mut self) -> Option<Self::Item> {
+///         None
+///     }
+/// }
+///
+/// impl sealed_traits::doc_hidden::IteratorBlanketUnsealed for ExampleIter {}
+/// ```
+pub trait IteratorBlanketUnsealed: blanket_impls::IteratorBlanket {}
+
+/// Not sealed due to blanket impl. No `doc(hidden)` items needed to impl it.
+///
+/// Proof:
+/// ```rust
+/// struct Example;
+///
+/// impl sealed_traits::doc_hidden::Unsealed for Example {}
+///
+/// impl sealed_traits::doc_hidden::BlanketOverLocalUnsealedTraitUnsealed for Example {}
+/// ```
+pub trait BlanketOverLocalUnsealedTraitUnsealed: blanket_impls::BlanketOverLocalUnsealedTrait {}
+
+/// This one is doc-hidden-sealed, since the blanket is over a doc-hidden-sealed trait
+/// which we cannot impl without touching non-public-API items:
+/// - either we directly implement the doc-hidden-sealed supertrait ourselves,
+/// - or we implement the doc-hidden-sealed trait for the supertrait's blanket impl.
+pub trait BlanketOverSealedTraitSealed: blanket_impls::BlanketOverSealedTrait {}
+
+/// This trait is doc-hidden-sealed because the bound on the blanket impl
+/// includes a trait we cannot impl without doc-hidden-API items. The proof is the same as above.
+pub trait BlanketSealedOverMultiple: blanket_impls::BlanketOverSealedAndUnsealedTrait {}
+
+/// This trait is not sealed, since its supertrait has a blanket impl whose bound
+/// is always satisfied due to its own blanket impl.
+///
+/// Proof:
+/// ```rust
+/// struct Example;
+///
+/// impl sealed_traits::doc_hidden::TransitiveBlanketUnsealed for Example {}
+/// ```
+pub trait TransitiveBlanketUnsealed: blanket_impls::TransitiveBlanket {}
+
+/// This trait is doc-hidden-sealed.
+/// - Its supertrait has a blanket impl over `Arc<T>`, but it isn't usable:
+///   in order for a crate to implement a trait for a type, the crate needs to define
+///   either the trait or the type. A downstream crate doesn't define either.
+/// - That means the supertrait must be implemented directly, but it's `doc(hidden)`.
+pub trait BlanketOverArcSealed: blanket_impls::BlanketOverArc {}
+
+/// Doc-hidden-sealed since tuples/slices/arrays/pointers are always considered foreign types.
+pub trait BlanketOverTupleSealed: blanket_impls::BlanketOverTuple {}
+
+/// Doc-hidden-sealed since tuples/slices/arrays/pointers are always considered foreign types.
+pub trait BlanketOverSliceSealed: blanket_impls::BlanketOverSlice {}
+
+/// Doc-hidden-sealed since tuples/slices/arrays/pointers are always considered foreign types.
+pub trait BlanketOverArraySealed: blanket_impls::BlanketOverArray {}
+
+/// Doc-hidden-sealed since tuples/slices/arrays/pointers are always considered foreign types.
+pub trait BlanketOverPointerSealed: blanket_impls::BlanketOverPointer {}
+
+/// Not sealed due to being deprecated and therefore public API, regardless of `doc(hidden)`.
+#[deprecated]
+#[doc(hidden)]
+pub trait DeprecatedHidden {}
+
+/// Not sealed despite the supertrait, since the supertrait is deprecated and therefore public API.
+pub trait UnsealedDueToDeprecatedSuper: DeprecatedHidden {}
+
+/// Not sealed because the `doc(hidden)` associated type is deprecated and therefore public API.
+pub trait DeprecatedAssocType {
+    #[deprecated]
+    #[doc(hidden)]
+    type X;
+}
+
+/// Not sealed because the `doc(hidden)` associated const is deprecated and therefore public API.
+pub trait DeprecatedAssocConst {
+    #[deprecated]
+    #[doc(hidden)]
+    const N: usize;
+}
+
+/// Not sealed because the `doc(hidden)` method is deprecated and therefore public API.
+pub trait DeprecatedMethod {
+    #[deprecated]
+    #[doc(hidden)]
+    fn method(&self) {}
+}
+
+/// This trait is not sealed. Its method's argument type is doc-hidden but also deprecated,
+/// which makes it public API.
+pub trait MethodDeprecatedArgType {
+    fn method(&self, token: hidden_module::DeprecatedToken);
+}

--- a/test_crates/sealed_traits/src/lib.rs
+++ b/test_crates/sealed_traits/src/lib.rs
@@ -340,3 +340,24 @@ pub trait BlanketOverArraySealed: blanket_impls::BlanketOverArray {}
 /// impl sealed_traits::BlanketOverPointerSealed for *const Example {}
 /// ```
 pub trait BlanketOverPointerSealed: blanket_impls::BlanketOverPointer {}
+
+/// Tests for <https://github.com/obi1kenobi/cargo-semver-checks/issues/1076>
+pub mod cyclic_bounds {
+    /// Both `RecursiveSealed` and `SealedPlusRecursiveBlanket` are sealed.
+    ///
+    /// `RecursiveSealed` is sealed because it's pub-in-priv.
+    ///
+    /// `SealedPlusRecursiveBlanket` is sealed because:
+    /// - it has a pub-in-priv supertrait
+    /// - the supertrait's blanket impl on `&T` requires the trait to already be implemented on `T`.
+    /// - no user-defined `T` can implement the trait due to a cyclic requirement.
+    mod recursive {
+        pub trait RecursiveSealed {}
+
+        impl<T: super::SealedPlusRecursiveBlanket> RecursiveSealed for &T {}
+    }
+
+    pub trait SealedPlusRecursiveBlanket: recursive::RecursiveSealed {}
+
+    impl<T: SealedPlusRecursiveBlanket> SealedPlusRecursiveBlanket for &T {}
+}

--- a/test_crates/sealed_traits/src/lib.rs
+++ b/test_crates/sealed_traits/src/lib.rs
@@ -52,6 +52,18 @@ pub trait NotMethodSealedBecauseOfDefaultImpl {
     }
 }
 
+/// This trait is sealed since its associated const is of pub-in-priv type,
+/// and implementing the trait requires naming its type.
+pub trait ConstItemPubInPrivTypeSealed {
+    const TOKEN: private::Token;
+}
+
+/// This trait is *not* sealed, since its associated const has a default value
+/// so it doesn't matter that its type is pub-in-priv.
+pub trait NotSealedDueToConstDefaultValue {
+    const TOKEN: private::Token = private::Token;
+}
+
 /// This trait is *not* sealed. Its supertrait is also not sealed.
 pub trait NotTransitivelySealed: NotMethodSealedBecauseOfDefaultImpl {}
 

--- a/test_crates/sealed_traits/src/lib.rs
+++ b/test_crates/sealed_traits/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod doc_hidden;
+
 mod private {
     pub trait Sealed {}
 
@@ -31,6 +33,12 @@ pub trait Unsealed {}
 /// so external implementers cannot name it.
 pub trait MethodSealed {
     fn method(&self, token: private::Token) -> i64;
+}
+
+/// This trait is sealed because its return type is pub-in-priv,
+/// so external implementers cannot name it.
+pub trait MethodReturnSealed {
+    fn method(&self) -> private::Token;
 }
 
 /// This trait is sealed since nobody can implement its supertrait.
@@ -215,7 +223,6 @@ pub trait ExternalSupertraitsBlanketUnsealed: blanket_impls::ExternalSupertraits
 /// impl sealed_traits::BlanketWithWhereClauseUnsealed for Example {}
 /// ```
 pub trait BlanketWithWhereClauseUnsealed: blanket_impls::BlanketWithWhereClause {}
-
 
 /// Not sealed due to blanket impl.
 ///


### PR DESCRIPTION
This implementation is improved in two big ways:
- It handles cyclic trait bounds correctly instead of overflowing the stack. This prevents crashes like https://github.com/obi1kenobi/cargo-semver-checks/issues/1076
- It now can also tell if a trait is "public API sealed": adding a downstream `impl` for such a trait requires using non-public-API items, so the trait's public API does not support adding downstream impls. This will help us resolve issues like https://github.com/obi1kenobi/cargo-semver-checks/issues/999

## Public API sealed traits

An example of a "public API sealed" trait is:
```rust
pub trait Example {
    #[doc(hidden)]
    type X;
}
```

Any `impl` of `Example` outside of its crate must name the `Example::X` item, and in doing so refer to non-public-API. Therefore, such an `impl` is outside the public API of `Example`, and may suffer breakage outside of major version bumps of `Example`'s crate.

Crates can be public-API-sealed in many ways, including:
- `#[doc(hidden)]` (without `#[deprecated]`) on associated types without a default
- `#[doc(hidden)]` (without `#[deprecated]`) on associated constants without a default value
- `#[doc(hidden)]` (without `#[deprecated]`) on associated functions / methods without a default implementation
- associated functions / methods taking an "importable but not public API" parameter
- associated functions / methods returning an "importable but not public API" type

**"Importable but not public API"** means:
- The item has at least one path by which it can be imported from an external crate. That path passes through at least one item that is simultaneously `#[doc(hidden)]` and _not_ `#[deprecated]`, such as the imported item itself, a module, or a re-export.
- The item has no paths by which it can be imported such that no item along that path is `#[doc(hidden)]` and _not_ `#[deprecated]`.

Note that generic bounds _do not_ cause public API sealing. For example:
```rust
#[doc(hidden)]
pub mod hidden {
    pub trait Marker {}
}

/// An unbounded implementation is entirely legal:
/// ` ``rust
/// use this_crate::NotPubAPISealed;
///
/// struct Example;
///
/// impl NotPubAPISealed for Example {
///     fn method<M>(&self) {}
/// }
/// ` ``
pub trait NotPubAPISealed {
    fn method<M: hidden::Marker>(&self);
}
```