### PR TITLE
Add schema and test cases for method receivers.

### DIFF
--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -1466,6 +1466,10 @@ type Function implements Item & FunctionLike & Importable & GenericItem {
 }
 
 """
+An associated function ("method") associated with a struct, enum, union, or trait type.
+
+It may or may not take a receiver argument (such as `&self`, `self`, or `&mut self`).
+
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Item.html
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/enum.ItemEnum.html
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Method.html
@@ -1549,6 +1553,75 @@ type Method implements Item & FunctionLike & GenericItem {
   since its desugaring is different: it's more like an associated type than a generic.
   """
   generic_parameter: [GenericParameter]
+
+  # own edges
+  """
+  The kind of `self` value that the method takes, if any.
+  """
+  receiver: Receiver
+}
+
+"""
+The kind of `self` value that a method takes.
+
+For example:
+- `fn method(self) {}` has `Self` as a receiver: its kind is `"Self"` and it's taken by value.
+- `fn method(&self) {}` has `&Self` as a receiver: its kind is `"Self"` and it's taken by reference.
+- `fn method(&mut self) {}` has `&mut Self` as a receiver: its kind is `"Self"` and it's taken by
+  mutable reference.
+- `fn method(self: Pin<&mut Self>) {}` has `Pin<&mut Self>` as a receiver:
+  its kind is `"Pin<&mut Self>"` and it's taken by value.
+"""
+type Receiver {
+  """
+  Whether the receiver takes `self` by value, regardless of its type.
+
+  Mutually exclusive with both `by_reference` and `by_mut_reference`; exactly one of them is `true`.
+
+  For example:
+  - `true` for receiver types `Self` and `Pin<&mut Self>`.
+  - `false` for receiver types `&Self` and `&mut Self`.
+  """
+  by_value: Boolean!
+
+  """
+  Whether the receiver takes `self` by immutable reference, regardless of its type.
+
+  Mutually exclusive with both `by_value` and `by_mut_reference`; exactly one of them is `true`.
+
+  For example:
+  - `true` for receiver types `&Self` (commonly used as `&self`) and `&Box<Self>`.
+  - `false` for receiver types `Self`, `&mut Self`, and `Pin<&Self>`.
+  """
+  by_reference: Boolean!
+
+  """
+  Whether the receiver takes `self` by mutable reference, regardless of its type.
+
+  Mutually exclusive with both `by_value` and `by_reference`; exactly one of them is `true`.
+
+  For example:
+  - `true` for receiver types `&mut Self` (commonly used as `&mut self`) and `&mut Box<Self>`.
+  - `false` for receiver types `Self`, `&Self`, and `Pin<&mut Self>`.
+  """
+  by_mut_reference: Boolean!
+
+  """
+  The portion of the receiver type aside from any outer `&`/`&mut` applied to it.
+
+  For example:
+  - `"Self"` for `self`, `&self`, and `&mut self` receivers.
+    `mut self` is identical to `self` for our purposes since its mutability is information
+    for the method body only and has no visible effect externally.
+  - `"Box<Self>"` for `Box<Self>`, `&Box<Self>`, and `&mut Box<Self>` receivers.
+  - `"Pin<&mut Self>"` for `Pin<&mut Self>`, `&Pin<&mut Self>`, and `&mut Pin<&mut Self>` receivers.
+  - `"Rc<Box<Self>>"` for a receiver like `self: &Rc<Box<Self>`.
+  - Assuming a `CustomReceiver` type that implements the `Receiver` trait,
+    `"CustomReceiver<Self>"` for a receiver like `self: &CustomReceiver<Self>`.
+    Only the direct declared name of the type will be present, even if the type is
+    publicly re-exported under a different name and/or path.
+  """
+  kind: String!
 }
 
 """

--- a/test_crates/method_self_receivers/Cargo.toml
+++ b/test_crates/method_self_receivers/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "method_self_receivers"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/test_crates/method_self_receivers/src/lib.rs
+++ b/test_crates/method_self_receivers/src/lib.rs
@@ -1,0 +1,77 @@
+#![feature(arbitrary_self_types)]
+
+pub struct Example(i64);
+
+pub struct CustomReceiver<T>(T);
+
+/// Per the docs: https://doc.rust-lang.org/std/ops/trait.Receiver.html
+///
+/// N.B.: `Pin` currently doesn't appear to be able to be combined with custom receivers.
+///
+/// ```compile_fail
+/// struct Example;
+///
+/// impl Example {
+///     pub fn by_pinned_custom_receiver(
+///         self: std::pin::Pin<method_self_receivers::CustomReceiver<Self>>,
+///     ) {}
+/// }
+/// ```
+impl<T> std::ops::Receiver for CustomReceiver<T> {
+    type Target = T;
+}
+
+impl Example {
+    pub fn by_ref(&self) {}
+
+    pub fn by_mut_ref(&mut self) {}
+
+    pub fn by_value(self) {}
+
+    // From the caller's perspective, the receiver here is still `Self`.
+    // The `mut` communicates information about the function body
+    // which is invisible and irrelevant to the caller.
+    pub fn by_mut_value(mut self) {
+        self.0 += 1;
+    }
+
+    pub fn by_pinned_mut_ref(self: std::pin::Pin<&mut Self>) {}
+
+    pub fn by_ref_pinned_mut_ref(self: &std::pin::Pin<&mut Self>) {}
+
+    pub fn by_mut_ref_pinned_mut_ref(self: &mut std::pin::Pin<&mut Self>) {}
+
+    pub fn by_boxed_value(self: Box<Self>) {}
+
+    pub fn by_ref_boxed_value(self: &Box<Self>) {}
+
+    pub fn by_mut_ref_boxed_value(self: &mut Box<Self>) {}
+
+    pub fn by_rc_value(self: std::rc::Rc<Self>) {}
+
+    pub fn by_ref_rc_value(self: &std::rc::Rc<Self>) {}
+
+    pub fn by_mut_ref_rc_value(self: &mut std::rc::Rc<Self>) {}
+
+    pub fn by_arc_value(self: std::sync::Arc<Self>) {}
+
+    pub fn by_ref_arc_value(self: &std::sync::Arc<Self>) {}
+
+    pub fn by_mut_ref_arc_value(self: &mut std::sync::Arc<Self>) {}
+
+    pub fn by_box_of_rc_ref(self: &std::rc::Rc<Box<Self>>) {}
+
+    pub fn by_custom_receiver_value(self: CustomReceiver<Self>) {}
+
+    pub fn by_custom_receiver_ref(self: &CustomReceiver<Self>) {}
+
+    pub fn by_custom_receiver_mut_ref(self: &mut CustomReceiver<Self>) {}
+
+    pub fn by_custom_receiver_with_ref_self(self: CustomReceiver<&Self>) {}
+
+    // Pin can be combined with other receivers too.
+
+    pub fn by_pinned_box(self: std::pin::Pin<Box<Self>>) {}
+
+    pub fn by_pinned_ref_arc(self: std::pin::Pin<&std::sync::Arc<Self>>) {}
+}


### PR DESCRIPTION
Needs implementation in the adapter — tests are failing because the schema declares items that aren't implemented in the adapter yet.