### PR TITLE
feat: add method `receiver` edge (#807)

### DIFF
--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -14,6 +14,7 @@ use super::{
     enum_variant::LazyDiscriminants,
     optimizations,
     origin::Origin,
+    receiver::Receiver,
     vertex::{Feature, Vertex},
     RustdocAdapter,
 };
@@ -258,6 +259,34 @@ pub(super) fn resolve_function_like_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
             Box::new(std::iter::once(origin.make_function_abi_vertex(abi)))
         }),
         _ => unreachable!("resolve_function_like_edge {edge_name}"),
+    }
+}
+
+pub(super) fn resolve_receiver_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
+    contexts: ContextIterator<'a, V>,
+    edge_name: &str,
+) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
+    match edge_name {
+        "receiver" => resolve_neighbors_with(contexts, move |vertex| {
+            let origin = vertex.origin;
+            let method = vertex.as_function().expect("vertex was not a Function");
+
+            // Check if the first parameter is a self receiver
+            let receiver = method.sig.inputs.first().and_then(|(name, ty)| {
+                if name == "self" {
+                    Some(Receiver::new(ty))
+                } else {
+                    None
+                }
+            });
+
+            Box::new(
+                receiver
+                    .into_iter()
+                    .map(move |r| origin.make_receiver_vertex(r)),
+            )
+        }),
+        _ => unreachable!("resolve_receiver_edge {edge_name}"),
     }
 }
 

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -21,6 +21,7 @@ mod enum_variant;
 mod optimizations;
 mod origin;
 mod properties;
+mod receiver;
 mod rust_type_name;
 mod vertex;
 
@@ -217,6 +218,7 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
                 "GenericConstParameter" => {
                     properties::resolve_generic_const_parameter_property(contexts, property_name)
                 }
+                "Receiver" => properties::resolve_receiver_property(contexts, property_name),
                 _ => unreachable!("resolve_property {type_name} {property_name}"),
             }
         }
@@ -303,6 +305,9 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
                 if matches!(edge_name.as_ref(), "generic_parameter") =>
             {
                 edges::resolve_generic_parameter_edge(contexts, edge_name)
+            }
+            "Method" if matches!(edge_name.as_ref(), "receiver") => {
+                edges::resolve_receiver_edge(contexts, edge_name)
             }
             "Module" => edges::resolve_module_edge(
                 contexts,

--- a/src/adapter/origin.rs
+++ b/src/adapter/origin.rs
@@ -9,6 +9,7 @@ use crate::{
 
 use super::{
     enum_variant::{EnumVariant, LazyDiscriminants},
+    receiver::Receiver,
     vertex::{ImplementedTrait, Vertex, VertexKind},
 };
 
@@ -161,6 +162,13 @@ impl Origin {
         Vertex {
             origin: *self,
             kind: VertexKind::GenericParameter(generics, param, position),
+        }
+    }
+
+    pub(super) fn make_receiver_vertex<'a>(&self, receiver: Receiver<'a>) -> Vertex<'a> {
+        Vertex {
+            origin: *self,
+            kind: VertexKind::Receiver(receiver),
         }
     }
 }

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -306,6 +306,31 @@ pub(super) fn resolve_function_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
     }
 }
 
+pub(super) fn resolve_receiver_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
+    contexts: ContextIterator<'a, V>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, V, FieldValue> {
+    match property_name {
+        "by_value" => resolve_property_with(contexts, |vertex| {
+            let receiver = vertex.as_receiver().expect("not a Receiver");
+            receiver.by_value().into()
+        }),
+        "by_reference" => resolve_property_with(contexts, |vertex| {
+            let receiver = vertex.as_receiver().expect("not a Receiver");
+            receiver.by_reference().into()
+        }),
+        "by_mut_reference" => resolve_property_with(contexts, |vertex| {
+            let receiver = vertex.as_receiver().expect("not a Receiver");
+            receiver.by_mut_reference().into()
+        }),
+        "kind" => resolve_property_with(contexts, |vertex| {
+            let receiver = vertex.as_receiver().expect("not a Receiver");
+            receiver.kind().as_ref().into()
+        }),
+        _ => unreachable!("Receiver property {property_name}"),
+    }
+}
+
 pub(super) fn resolve_function_parameter_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     property_name: &str,

--- a/src/adapter/receiver.rs
+++ b/src/adapter/receiver.rs
@@ -1,0 +1,109 @@
+use std::borrow::Cow;
+
+use rustdoc_types::{GenericArgs, Type};
+
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct Receiver<'a>(&'a Type);
+
+impl<'a> Receiver<'a> {
+    pub(super) fn new(ty: &'a Type) -> Self {
+        Self(ty)
+    }
+
+    #[inline]
+    pub(super) fn by_value(&self) -> bool {
+        !matches!(self.0, Type::BorrowedRef { .. })
+    }
+
+    #[inline]
+    pub(super) fn by_reference(&self) -> bool {
+        matches!(
+            self.0,
+            Type::BorrowedRef {
+                is_mutable: false,
+                ..
+            }
+        )
+    }
+
+    #[inline]
+    pub(super) fn by_mut_reference(&self) -> bool {
+        matches!(
+            self.0,
+            Type::BorrowedRef {
+                is_mutable: true,
+                ..
+            }
+        )
+    }
+
+    pub(super) fn kind(&self) -> Cow<'_, str> {
+        extract_kind_string(self.0)
+    }
+}
+
+fn extract_kind_string(ty: &Type) -> Cow<'_, str> {
+    match ty {
+        // For &self and &mut self, we need to extract the inner type
+        Type::BorrowedRef { type_, .. } => extract_kind_string(type_),
+
+        // Self is the simplest case - this handles both 'self' and 'mut self'
+        Type::Generic(name) if name == "Self" => Cow::Borrowed("Self"),
+
+        // Handle ResolvedPath types like Box<Self>, Pin<&mut Self>, etc.
+        Type::ResolvedPath(path) => {
+            // Get just the type name without the path
+            let name = path.name.split("::").last().unwrap_or(&path.name);
+
+            if let Some(args) = &path.args {
+                match args.as_ref() {
+                    GenericArgs::AngleBracketed { args, .. } => {
+                        let args_str: Vec<Cow<'_, str>> = args
+                            .iter()
+                            .map(|arg| match arg {
+                                rustdoc_types::GenericArg::Type(t) => {
+                                    // For Pin<&mut Self>, we need to preserve the &mut
+                                    match t {
+                                        Type::BorrowedRef {
+                                            is_mutable, type_, ..
+                                        } => {
+                                            let inner = extract_kind_string(type_);
+                                            if *is_mutable {
+                                                Cow::Owned(format!("&mut {}", inner))
+                                            } else {
+                                                Cow::Owned(format!("&{}", inner))
+                                            }
+                                        }
+                                        _ => extract_kind_string(t),
+                                    }
+                                }
+                                rustdoc_types::GenericArg::Lifetime(lt) => {
+                                    Cow::Borrowed(lt.as_str())
+                                }
+                                rustdoc_types::GenericArg::Const(c) => {
+                                    Cow::Borrowed(c.expr.as_str())
+                                }
+                                _ => unreachable!("should not encounter infer"),
+                            })
+                            .collect();
+
+                        let args_joined = args_str
+                            .iter()
+                            .map(|cow| cow.as_ref())
+                            .collect::<Vec<_>>()
+                            .join(", ");
+
+                        Cow::Owned(format!("{}<{}>", name, args_joined))
+                    }
+                    _ => Cow::Borrowed(name),
+                }
+            } else {
+                Cow::Borrowed(name)
+            }
+        }
+
+        // should not encounter other types
+        _ => unreachable!("unsupported type: {:?}", ty),
+    }
+}

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -6249,3 +6249,261 @@ fn enum_repr_attributes() {
 
     similar_asserts::assert_eq!(expected_results, results);
 }
+
+#[test]
+fn method_self_receiver() {
+    get_test_data!(data, method_self_receivers);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+    {
+        Crate {
+            item {
+                ... on Struct {
+                    struct_name: name @output
+                    attrs @output
+
+                    inherent_impl {
+                        method {
+                            method_name: name @output
+                            receiver {
+                                by_value @output
+                                by_reference @output
+                                by_mut_reference @output
+                                kind @output
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    "#;
+
+    let variables: BTreeMap<&str, &str> = BTreeMap::new();
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        struct_name: String,
+        method_name: String,
+        by_value: bool,
+        by_reference: bool,
+        by_mut_reference: bool,
+        kind: String,
+    }
+
+    let mut results: Vec<Output> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables)
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    let mut expected_results = vec![
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_ref".into(),
+            by_value: false,
+            by_reference: true,
+            by_mut_reference: false,
+            kind: "Self".into(),
+        },
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_mut_ref".into(),
+            by_value: false,
+            by_reference: false,
+            by_mut_reference: true,
+            kind: "Self".into(),
+        },
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_value".into(),
+            by_value: true,
+            by_reference: false,
+            by_mut_reference: false,
+            kind: "Self".into(),
+        },
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_mut_value".into(),
+            by_value: true,
+            by_reference: false,
+            by_mut_reference: false,
+            kind: "Self".into(),
+        },
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_pinned_mut_ref".into(),
+            by_value: true,
+            by_reference: false,
+            by_mut_reference: false,
+            kind: "Pin<&mut Self>".into(),
+        },
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_ref_pinned_mut_ref".into(),
+            by_value: false,
+            by_reference: true,
+            by_mut_reference: false,
+            kind: "Pin<&mut Self>".into(),
+        },
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_ref_pinned_mut_ref_lifetime".into(),
+            by_value: false,
+            by_reference: true,
+            by_mut_reference: false,
+            kind: "Pin<&mut Self>".into(),
+        },
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_mut_ref_pinned_mut_ref".into(),
+            by_value: false,
+            by_reference: false,
+            by_mut_reference: true,
+            kind: "Pin<&mut Self>".into(),
+        },
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_mut_ref_pinned_mut_ref_lifetime".into(),
+            by_value: false,
+            by_reference: false,
+            by_mut_reference: true,
+            kind: "Pin<&mut Self>".into(),
+        },
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_boxed_value".into(),
+            by_value: true,
+            by_reference: false,
+            by_mut_reference: false,
+            kind: "Box<Self>".into(),
+        },
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_ref_boxed_value".into(),
+            by_value: false,
+            by_reference: true,
+            by_mut_reference: false,
+            kind: "Box<Self>".into(),
+        },
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_mut_ref_boxed_value".into(),
+            by_value: false,
+            by_reference: false,
+            by_mut_reference: true,
+            kind: "Box<Self>".into(),
+        },
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_rc_value".into(),
+            by_value: true,
+            by_reference: false,
+            by_mut_reference: false,
+            kind: "Rc<Self>".into(),
+        },
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_ref_rc_value".into(),
+            by_value: false,
+            by_reference: true,
+            by_mut_reference: false,
+            kind: "Rc<Self>".into(),
+        },
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_mut_ref_rc_value".into(),
+            by_value: false,
+            by_reference: false,
+            by_mut_reference: true,
+            kind: "Rc<Self>".into(),
+        },
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_arc_value".into(),
+            by_value: true,
+            by_reference: false,
+            by_mut_reference: false,
+            kind: "Arc<Self>".into(),
+        },
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_ref_arc_value".into(),
+            by_value: false,
+            by_reference: true,
+            by_mut_reference: false,
+            kind: "Arc<Self>".into(),
+        },
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_mut_ref_arc_value".into(),
+            by_value: false,
+            by_reference: false,
+            by_mut_reference: true,
+            kind: "Arc<Self>".into(),
+        },
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_box_of_rc_ref".into(),
+            by_value: false,
+            by_reference: true,
+            by_mut_reference: false,
+            kind: "Rc<Box<Self>>".into(),
+        },
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_custom_receiver_value".into(),
+            by_value: true,
+            by_reference: false,
+            by_mut_reference: false,
+            kind: "CustomReceiver<Self>".into(),
+        },
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_custom_receiver_ref".into(),
+            by_value: false,
+            by_reference: true,
+            by_mut_reference: false,
+            kind: "CustomReceiver<Self>".into(),
+        },
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_custom_receiver_mut_ref".into(),
+            by_value: false,
+            by_reference: false,
+            by_mut_reference: true,
+            kind: "CustomReceiver<Self>".into(),
+        },
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_custom_receiver_with_ref_self".into(),
+            by_value: true,
+            by_reference: false,
+            by_mut_reference: false,
+            kind: "CustomReceiver<&Self>".into(),
+        },
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_pinned_box".into(),
+            by_value: true,
+            by_reference: false,
+            by_mut_reference: false,
+            kind: "Pin<Box<Self>>".into(),
+        },
+        Output {
+            struct_name: "Example".into(),
+            method_name: "by_pinned_ref_arc".into(),
+            by_value: true,
+            by_reference: false,
+            by_mut_reference: false,
+            kind: "Pin<&Arc<Self>>".into(),
+        },
+    ];
+    expected_results.sort_unstable();
+    similar_asserts::assert_eq!(expected_results, results);
+}

--- a/src/adapter/vertex.rs
+++ b/src/adapter/vertex.rs
@@ -11,7 +11,7 @@ use crate::{
     ImportablePath, IndexedCrate, PackageIndex,
 };
 
-use super::{enum_variant::EnumVariant, origin::Origin};
+use super::{enum_variant::EnumVariant, origin::Origin, receiver::Receiver};
 
 #[non_exhaustive]
 #[derive(Debug, Clone)]
@@ -58,6 +58,9 @@ pub enum VertexKind<'a> {
 
     #[non_exhaustive]
     FunctionAbi(&'a Abi),
+
+    #[non_exhaustive]
+    Receiver(Receiver<'a>),
 
     #[non_exhaustive]
     Discriminant(Cow<'a, str>),
@@ -126,6 +129,7 @@ impl Typename for Vertex<'_> {
                 _ => "RawType",
             },
             VertexKind::FunctionParameter(..) => "FunctionParameter",
+            VertexKind::Receiver(..) => "Receiver",
             VertexKind::FunctionAbi(..) => "FunctionAbi",
             VertexKind::Discriminant(..) => "Discriminant",
             VertexKind::Variant(ref ev) => match ev.variant().kind {
@@ -389,6 +393,13 @@ impl<'a> Vertex<'a> {
             rustdoc_types::ItemEnum::Impl(x) => Some(&x.generics),
             _ => None,
         })
+    }
+
+    pub(super) fn as_receiver(&self) -> Option<&Receiver> {
+        match &self.kind {
+            VertexKind::Receiver(receiver) => Some(receiver),
+            _ => None,
+        }
     }
 }
 

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -1466,6 +1466,10 @@ type Function implements Item & FunctionLike & Importable & GenericItem {
 }
 
 """
+An associated function ("method") associated with a struct, enum, union, or trait type.
+
+It may or may not take a receiver argument (such as `&self`, `self`, or `&mut self`).
+
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Item.html
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/enum.ItemEnum.html
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Method.html
@@ -1549,6 +1553,75 @@ type Method implements Item & FunctionLike & GenericItem {
   since its desugaring is different: it's more like an associated type than a generic.
   """
   generic_parameter: [GenericParameter]
+
+  # own edges
+  """
+  The kind of `self` value that the method takes, if any.
+  """
+  receiver: Receiver
+}
+
+"""
+The kind of `self` value that a method takes.
+
+For example:
+- `fn method(self) {}` has `Self` as a receiver: its kind is `"Self"` and it's taken by value.
+- `fn method(&self) {}` has `&Self` as a receiver: its kind is `"Self"` and it's taken by reference.
+- `fn method(&mut self) {}` has `&mut Self` as a receiver: its kind is `"Self"` and it's taken by
+  mutable reference.
+- `fn method(self: Pin<&mut Self>) {}` has `Pin<&mut Self>` as a receiver:
+  its kind is `"Pin<&mut Self>"` and it's taken by value.
+"""
+type Receiver {
+  """
+  Whether the receiver takes `self` by value, regardless of its type.
+
+  Mutually exclusive with both `by_reference` and `by_mut_reference`; exactly one of them is `true`.
+
+  For example:
+  - `true` for receiver types `Self` and `Pin<&mut Self>`.
+  - `false` for receiver types `&Self` and `&mut Self`.
+  """
+  by_value: Boolean!
+
+  """
+  Whether the receiver takes `self` by immutable reference, regardless of its type.
+
+  Mutually exclusive with both `by_value` and `by_mut_reference`; exactly one of them is `true`.
+
+  For example:
+  - `true` for receiver types `&Self` (commonly used as `&self`) and `&Box<Self>`.
+  - `false` for receiver types `Self`, `&mut Self`, and `Pin<&Self>`.
+  """
+  by_reference: Boolean!
+
+  """
+  Whether the receiver takes `self` by mutable reference, regardless of its type.
+
+  Mutually exclusive with both `by_value` and `by_reference`; exactly one of them is `true`.
+
+  For example:
+  - `true` for receiver types `&mut Self` (commonly used as `&mut self`) and `&mut Box<Self>`.
+  - `false` for receiver types `Self`, `&Self`, and `Pin<&mut Self>`.
+  """
+  by_mut_reference: Boolean!
+
+  """
+  The portion of the receiver type aside from any outer `&`/`&mut` applied to it.
+
+  For example:
+  - `"Self"` for `self`, `&self`, and `&mut self` receivers.
+    `mut self` is identical to `self` for our purposes since its mutability is information
+    for the method body only and has no visible effect externally.
+  - `"Box<Self>"` for `Box<Self>`, `&Box<Self>`, and `&mut Box<Self>` receivers.
+  - `"Pin<&mut Self>"` for `Pin<&mut Self>`, `&Pin<&mut Self>`, and `&mut Pin<&mut Self>` receivers.
+  - `"Rc<Box<Self>>"` for a receiver like `self: &Rc<Box<Self>`.
+  - Assuming a `CustomReceiver` type that implements the `Receiver` trait,
+    `"CustomReceiver<Self>"` for a receiver like `self: &CustomReceiver<Self>`.
+    Only the direct declared name of the type will be present, even if the type is
+    publicly re-exported under a different name and/or path.
+  """
+  kind: String!
 }
 
 """

--- a/test_crates/method_self_receivers/Cargo.toml
+++ b/test_crates/method_self_receivers/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "method_self_receivers"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/test_crates/method_self_receivers/src/lib.rs
+++ b/test_crates/method_self_receivers/src/lib.rs
@@ -1,0 +1,81 @@
+#![feature(arbitrary_self_types)]
+
+pub struct Example(i64);
+
+pub struct CustomReceiver<T>(T);
+
+/// Per the docs: https://doc.rust-lang.org/std/ops/trait.Receiver.html
+///
+/// N.B.: `Pin` currently doesn't appear to be able to be combined with custom receivers.
+///
+/// ```compile_fail
+/// struct Example;
+///
+/// impl Example {
+///     pub fn by_pinned_custom_receiver(
+///         self: std::pin::Pin<method_self_receivers::CustomReceiver<Self>>,
+///     ) {}
+/// }
+/// ```
+impl<T> std::ops::Receiver for CustomReceiver<T> {
+    type Target = T;
+}
+
+impl Example {
+    pub fn by_ref(&self) {}
+
+    pub fn by_mut_ref(&mut self) {}
+
+    pub fn by_value(self) {}
+
+    // From the caller's perspective, the receiver here is still `Self`.
+    // The `mut` communicates information about the function body
+    // which is invisible and irrelevant to the caller.
+    pub fn by_mut_value(mut self) {
+        self.0 += 1;
+    }
+
+    pub fn by_pinned_mut_ref(self: std::pin::Pin<&mut Self>) {}
+
+    pub fn by_ref_pinned_mut_ref(self: &std::pin::Pin<&'_ mut Self>) {}
+
+    pub fn by_ref_pinned_mut_ref_lifetime<'a>(self: &std::pin::Pin<&'a mut Self>) {}
+
+    pub fn by_mut_ref_pinned_mut_ref(self: &mut std::pin::Pin<&mut Self>) {}
+
+    pub fn by_mut_ref_pinned_mut_ref_lifetime(self: &mut std::pin::Pin<&'_ mut Self>) {}
+
+    pub fn by_boxed_value(self: Box<Self>) {}
+
+    pub fn by_ref_boxed_value(self: &Box<Self>) {}
+
+    pub fn by_mut_ref_boxed_value(self: &mut Box<Self>) {}
+
+    pub fn by_rc_value(self: std::rc::Rc<Self>) {}
+
+    pub fn by_ref_rc_value(self: &std::rc::Rc<Self>) {}
+
+    pub fn by_mut_ref_rc_value(self: &mut std::rc::Rc<Self>) {}
+
+    pub fn by_arc_value(self: std::sync::Arc<Self>) {}
+
+    pub fn by_ref_arc_value(self: &std::sync::Arc<Self>) {}
+
+    pub fn by_mut_ref_arc_value(self: &mut std::sync::Arc<Self>) {}
+
+    pub fn by_box_of_rc_ref(self: &std::rc::Rc<Box<Self>>) {}
+
+    pub fn by_custom_receiver_value(self: CustomReceiver<Self>) {}
+
+    pub fn by_custom_receiver_ref(self: &CustomReceiver<Self>) {}
+
+    pub fn by_custom_receiver_mut_ref(self: &mut CustomReceiver<Self>) {}
+
+    pub fn by_custom_receiver_with_ref_self(self: CustomReceiver<&'_ Self>) {}
+
+    pub fn by_pinned_box(self: std::pin::Pin<Box<Self>>) {}
+
+    pub fn by_pinned_ref_arc(self: std::pin::Pin<&std::sync::Arc<Self>>) {}
+
+    pub fn wrong_self(selfless: ()) {}
+}


### PR DESCRIPTION
finish on top of: #806

one thing I need to dive into would be that we wrap a lot of things in a
`Rc`, is it because of how trustfall engine works, the examples there
seem to do the same, but I think we don't need this for the `Receiver`?

---------

Co-authored-by: Predrag Gruevski <obi1kenobi82@gmail.com>
