### PR TITLE
Pin the rustdoc version for `v36` to the latest nightly that supports v36

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,5 @@
 # emits the desired format.
 
 [toolchain]
-channel = "nightly"
+# Pin to the latest nightly version that supports version 36.
+channel = "nightly-2024-12-02"


### PR DESCRIPTION
**Purpose of change**
When developing on a rustdoc version that is not the latest supported, or when testing changes across different rustdoc versions, the current workflow involves manually setting the nightly version. 

**Describe the solution**
Set the nightly version to the latest that supports v36. I know that on Zulip you mentioned that toolchain pinning for main was inappropriate - to be clear, I am only proposing pinning the toolchain version for branches which are known to have failures - i.e. `v36`, `v37`, and `v39`. 

If this is accepted, then I'll go ahead and make PR's for `v37` and `v39`.

**Testing**
Set the version and verified that running `regenerate_test_rustdocs.sh` followed by `cargo test` passes all tests.

**Additional Context**
I borrowed the formatting of this PR from https://github.com/CleverRaven/Cataclysm-DDA, since I find it helps me to organise my thoughts. If there's a particular format you would like me to use for my PRs in the future please let me know. 

I found the last applicable nightly version using https://github.githistory.xyz/rust-lang/rust/blob/master/src/rustdoc-json-types/lib.rs. Due to differences between git commit times and rust nightly publish dates, it's possible that the chosen nightly isn't actually the latest by a few days, so I manually verified that picking a later date caused failure.