### PR TITLE
Fix in place the cargo toolchain in `prepare_benchmark_data.sh`

### DIFF
--- a/scripts/prepare_benchmark_data.sh
+++ b/scripts/prepare_benchmark_data.sh
@@ -46,9 +46,19 @@ else
 	tar -x -f "${source_tarball}" -C "${cache_path}"
 fi
 
+cd "${repo_path}" || bail "failed to cd into the source repository"
+
+# Cargo outputs a version string that looks like:
+# cargo 1.85.0-nightly (c86f4b3a1 2024-12-24)
+# In order to get the date from the end, we get all characters after the
+# last ' ' and then remove the final parentheses.
+cargo_version=`cargo --version`
+cargo_version="${cargo_version##* }"
+cargo_version="${cargo_version%?}"
+
 cd "${source_dir}/sdk/ec2" || bail "failed to cd into the extracted sources"
 
 echo "Generating rustdoc JSON..."
-RUSTDOCFLAGS="-Z unstable-options --document-private-items --document-hidden-items --output-format=json --cap-lints=allow" cargo +nightly doc --lib --no-deps || bail "failed to generate rustdoc JSON"
+RUSTDOCFLAGS="-Z unstable-options --document-private-items --document-hidden-items --output-format=json --cap-lints=allow" cargo +nightly-${cargo_version} doc --lib --no-deps || bail "failed to generate rustdoc JSON"
 
 cp -v "$source_dir/target/doc/aws_sdk_ec2.json" "$bench_data_path"


### PR DESCRIPTION
**Purpose of change**
Explicitly setting the toolchain to `+nightly` overrides the toolchain set in rust-toolchain.toml. In practice, this means that the script has to be hand-edited with the nightly version that corresponds to the version of `trustfall-rustdoc-adapter` that is being worked on.

**Describe the solution**
Set the nightly version to the same version that is run in the source repository. If a specific version is pinned in rust-toolchain.toml, this will use that version, otherwise it will use the default system nightly version.

I don't think that the string manipulation is the best way to extract the toolchain version, but I am very unfamiliar with bash - any guidance would be appreciated.