### PR TITLE
Handle edge cases due to type aliases in sealed trait analysis.

### DIFF
--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -1228,6 +1228,182 @@ fn rustdoc_sealed_traits() {
             sealed: false,
             public_api_sealed: true,
         },
+        Output {
+            name: "TakeTypeAlias".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "type_alias".into(),
+                "pub_type_alias".into(),
+                "TakeTypeAlias".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "ReturnTypeAlias".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "type_alias".into(),
+                "pub_type_alias".into(),
+                "ReturnTypeAlias".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "TakeTypeAlias".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "type_alias".into(),
+                "private_type_alias".into(),
+                "TakeTypeAlias".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "ReturnTypeAlias".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "type_alias".into(),
+                "private_type_alias".into(),
+                "ReturnTypeAlias".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "TakeTypeAlias".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "type_alias".into(),
+                "private_type".into(),
+                "TakeTypeAlias".into(),
+            ]],
+            sealed: true,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "ReturnTypeAlias".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "type_alias".into(),
+                "private_type".into(),
+                "ReturnTypeAlias".into(),
+            ]],
+            sealed: true,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "TakeTypeAlias".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "type_alias".into(),
+                "generic_private_type".into(),
+                "TakeTypeAlias".into(),
+            ]],
+            sealed: true,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "ReturnTypeAlias".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "type_alias".into(),
+                "generic_private_type".into(),
+                "ReturnTypeAlias".into(),
+            ]],
+            sealed: true,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "TakeTypeAlias".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "type_alias".into(),
+                "hidden_alias".into(),
+                "TakeTypeAlias".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "ReturnTypeAlias".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "type_alias".into(),
+                "hidden_alias".into(),
+                "ReturnTypeAlias".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "TakeTypeAlias".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "type_alias".into(),
+                "private_alias_to_hidden".into(),
+                "TakeTypeAlias".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "ReturnTypeAlias".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "type_alias".into(),
+                "private_alias_to_hidden".into(),
+                "ReturnTypeAlias".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "TakeTypeAlias".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "type_alias".into(),
+                "pub_alias_to_hidden".into(),
+                "TakeTypeAlias".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "ReturnTypeAlias".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "type_alias".into(),
+                "pub_alias_to_hidden".into(),
+                "ReturnTypeAlias".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "TakeTypeAlias".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "type_alias".into(),
+                "hidden_alias_to_hidden".into(),
+                "TakeTypeAlias".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "ReturnTypeAlias".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "type_alias".into(),
+                "hidden_alias_to_hidden".into(),
+                "ReturnTypeAlias".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: true,
+        },
     ];
     expected_results.sort_unstable();
 

--- a/src/item_flags.rs
+++ b/src/item_flags.rs
@@ -233,6 +233,10 @@ pub(crate) fn build_flags_index(
         .values()
         .flatten()
         .for_each(|(item, modifiers)| {
+            // TODO: When we start tracking importable type aliases (`pub type`),
+            //       be very careful here. The alias might not be importable,
+            //       but the underlying type it points to might be.
+            //       See `test_crates/sealed_trait/type_alias.rs` for some edge cases.
             let flag = flags.entry(item.id).or_default();
             if !modifiers.deprecated && modifiers.doc_hidden {
                 flag.set_doc_hidden_reachable();

--- a/src/sealed_trait.rs
+++ b/src/sealed_trait.rs
@@ -436,44 +436,46 @@ fn is_method_or_item_sealed(
                         .set_pub_api_sealed();
                 }
 
-                // Check for pub-in-priv function parameters.
+                // Check for sealing caused by function parameters.
+                // Any implementations of the trait must name the function parameter types.
                 for (_, param) in &func.sig.inputs {
-                    if let rustdoc_types::Type::ResolvedPath(path) = param {
-                        if let Some(item_flag) = flags.get(&path.id) {
-                            if !item_flag.is_reachable() {
-                                // Non-importable item, so this trait is method-sealed.
-                                flags
-                                    .get_mut(trait_id)
-                                    .expect("no flags entry for trait item ID")
-                                    .set_unconditionally_sealed();
-                                return true;
-                            } else if item_flag.is_non_pub_api_reachable() {
-                                flags
-                                    .get_mut(trait_id)
-                                    .expect("no flags entry for trait item ID")
-                                    .set_pub_api_sealed();
-                            }
-                        };
-                    }
-                }
-
-                // Check for pub-in-priv function return values.
-                if let Some(rustdoc_types::Type::ResolvedPath(path)) = &func.sig.output {
-                    if let Some(item_flag) = flags.get(&path.id) {
-                        if !item_flag.is_reachable() {
-                            // Non-importable item, so this trait is method-sealed.
-                            flags
-                                .get_mut(trait_id)
-                                .expect("no flags entry for trait item ID")
-                                .set_unconditionally_sealed();
-                            return true;
-                        } else if item_flag.is_non_pub_api_reachable() {
+                    match is_sealed_due_to_type(index, flags, param) {
+                        SealedStatus::Unknown => {}
+                        SealedStatus::PubApiSealed => {
                             flags
                                 .get_mut(trait_id)
                                 .expect("no flags entry for trait item ID")
                                 .set_pub_api_sealed();
                         }
-                    };
+                        SealedStatus::UnconditionallySealed => {
+                            flags
+                                .get_mut(trait_id)
+                                .expect("no flags entry for trait item ID")
+                                .set_unconditionally_sealed();
+                            return true;
+                        }
+                    }
+                }
+
+                // Check for sealing caused by function return values.
+                // Any implementations of the trait must name the function return type.
+                if let Some(ty) = &func.sig.output {
+                    match is_sealed_due_to_type(index, flags, ty) {
+                        SealedStatus::Unknown => {}
+                        SealedStatus::PubApiSealed => {
+                            flags
+                                .get_mut(trait_id)
+                                .expect("no flags entry for trait item ID")
+                                .set_pub_api_sealed();
+                        }
+                        SealedStatus::UnconditionallySealed => {
+                            flags
+                                .get_mut(trait_id)
+                                .expect("no flags entry for trait item ID")
+                                .set_unconditionally_sealed();
+                            return true;
+                        }
+                    }
                 }
             }
             rustdoc_types::ItemEnum::AssocType { type_, .. } if type_.is_none() => {
@@ -503,22 +505,22 @@ fn is_method_or_item_sealed(
                         .set_pub_api_sealed();
                 }
 
-                if let rustdoc_types::Type::ResolvedPath(path) = type_ {
-                    if let Some(type_flag) = flags.get(&path.id) {
-                        if !type_flag.is_reachable() {
-                            // Non-importable item, so this trait is unconditionally item-sealed.
-                            flags
-                                .get_mut(trait_id)
-                                .expect("no flags entry for trait item ID")
-                                .set_unconditionally_sealed();
-                            return true;
-                        } else if type_flag.is_non_pub_api_reachable() {
-                            flags
-                                .get_mut(trait_id)
-                                .expect("no flags entry for trait item ID")
-                                .set_pub_api_sealed();
-                        }
-                    };
+                // Any implementations of the trait must name the constant's type.
+                match is_sealed_due_to_type(index, flags, type_) {
+                    SealedStatus::Unknown => {}
+                    SealedStatus::PubApiSealed => {
+                        flags
+                            .get_mut(trait_id)
+                            .expect("no flags entry for trait item ID")
+                            .set_pub_api_sealed();
+                    }
+                    SealedStatus::UnconditionallySealed => {
+                        flags
+                            .get_mut(trait_id)
+                            .expect("no flags entry for trait item ID")
+                            .set_unconditionally_sealed();
+                        return true;
+                    }
                 }
             }
             _ => {}
@@ -526,6 +528,149 @@ fn is_method_or_item_sealed(
     }
 
     false
+}
+
+#[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+enum SealedStatus {
+    #[default]
+    Unknown = 0,
+    PubApiSealed = 1,
+    UnconditionallySealed = 2,
+}
+
+fn is_sealed_due_to_type(
+    index: &HashMap<Id, Item>,
+    flags: &HashMap<Id, ItemFlag>,
+    type_: &rustdoc_types::Type,
+) -> SealedStatus {
+    match type_ {
+        rustdoc_types::Type::ResolvedPath(path) => {
+            is_sealed_due_to_path_type(index, flags, path)
+        }
+        rustdoc_types::Type::DynTrait(dyn_trait) => {
+            // TODO: Cover this case with test cases.
+            dyn_trait.traits.iter().map(|t| is_sealed_due_to_path_type(index, flags,&t.trait_)).max().unwrap_or_default()
+        }
+        rustdoc_types::Type::FunctionPointer(_function_pointer) => {
+            // TODO: Cover this case properly.
+            todo!()
+        }
+        rustdoc_types::Type::Tuple(items) => {
+            // TODO: Cover this with test cases.
+            items.iter().map(|ty| is_sealed_due_to_type(index, flags, ty)).max().unwrap_or_default()
+        }
+        rustdoc_types::Type::ImplTrait(generic_bounds) => {
+            // TODO: Cover this with test cases.
+            generic_bounds.iter().filter_map(|bound| match bound {
+                GenericBound::TraitBound { trait_, .. } => {
+                    // TODO: For `impl Trait`, can anything other than the trait cause sealing?
+                    //       Perhaps via generic parameter definitions?
+                    //       The answer isn't obvious; revisit this.
+                    Some(is_sealed_due_to_path_type(index, flags, trait_))
+                }
+                GenericBound::Outlives { .. } |
+                GenericBound::Use { .. } => None,
+            }).next().unwrap_or_default()
+        }
+        rustdoc_types::Type::Slice(inner) |
+        rustdoc_types::Type::Array { type_: inner, .. } |
+        rustdoc_types::Type::Pat { type_: inner, .. } |
+        rustdoc_types::Type::RawPointer { type_: inner, .. } |
+        rustdoc_types::Type::BorrowedRef { type_: inner, .. } => {
+            is_sealed_due_to_type(index, flags, inner)
+        }
+        rustdoc_types::Type::Generic(_) | // a direct generic parameter like `T`
+        rustdoc_types::Type::Primitive(_) |
+        rustdoc_types::Type::Infer => SealedStatus::Unknown,
+        rustdoc_types::Type::QualifiedPath { .. } => {
+            // TODO: I'm genuinely not sure if qualified paths can affect trait sealing at all.
+            //       Figure this out, then implement this properly.
+            SealedStatus::Unknown
+        }
+    }
+}
+
+fn is_sealed_due_to_path_type(
+    index: &HashMap<Id, Item>,
+    flags: &HashMap<Id, ItemFlag>,
+    path: &rustdoc_types::Path,
+) -> SealedStatus {
+    let Some(item) = index.get(&path.id) else {
+        // Not an item from our crate.
+        return SealedStatus::Unknown;
+    };
+    if let rustdoc_types::ItemEnum::TypeAlias(alias) = &item.inner {
+        return is_sealed_due_to_type_alias(index, flags, item, alias);
+    }
+
+    if let Some(item_flag) = flags.get(&path.id) {
+        if !item_flag.is_reachable() {
+            // Non-importable item, so this trait is sealed.
+            SealedStatus::UnconditionallySealed
+        } else if item_flag.is_non_pub_api_reachable() {
+            SealedStatus::PubApiSealed
+        } else {
+            // TODO: Can paths cause type-related sealing in any way other than importability?
+            //       For example, somehow via their generic arguments,
+            //       like `Foo<Bar>` if `Foo` is public API but `Bar` is not.
+            //       Explore this further, the answer might be "yes" and isn't obvious.
+            SealedStatus::Unknown
+        }
+    } else {
+        SealedStatus::Unknown
+    }
+}
+
+fn is_sealed_due_to_type_alias(
+    index: &HashMap<Id, Item>,
+    flags: &HashMap<Id, ItemFlag>,
+    alias_item: &Item,
+    alias_info: &rustdoc_types::TypeAlias,
+) -> SealedStatus {
+    // The sealed status here depends on a complex interaction between sealing effects from:
+    // - the alias item itself
+    // - the underlying type it points to.
+
+    let type_alias_flags = flags.get(&alias_item.id).expect("no flags entry for type alias item ID");
+    let type_alias_status = if type_alias_flags.is_pub_reachable() {
+        SealedStatus::Unknown
+    } else if type_alias_flags.is_non_pub_api_reachable() {
+        SealedStatus::PubApiSealed
+    } else {
+        SealedStatus::UnconditionallySealed
+    };
+
+    let underlying_status = is_sealed_due_to_type(index, flags, &alias_info.type_);
+
+    match (underlying_status, type_alias_status) {
+        (SealedStatus::Unknown, _) => {
+            // The underlying type is directly usable without any sealing effects.
+            // Trait impls can just desugar away the type alias and ignore it entirely.
+            SealedStatus::Unknown
+        }
+        (SealedStatus::PubApiSealed, SealedStatus::Unknown) => {
+            // The underlying is non-public API but the type alias is public API.
+            // Trait impls can avoid the non-public API effect by just using the type alias.
+            SealedStatus::Unknown
+        }
+        (SealedStatus::PubApiSealed, _) => {
+            // The underlying is non-public API, and the type alias is either private or
+            // also pub but non-public API. Trait impls can use the underlying directly again,
+            // to get only non-public API sealing effects.
+            SealedStatus::PubApiSealed
+        }
+        (SealedStatus::UnconditionallySealed, type_alias_status) => {
+            // Unconditional sealing only happens if the underlying is private or pub-in-priv.
+            // It's an error in Rust to have a public type alias that exposes a private type,
+            // regardless of the public API status of the type alias.
+            //
+            // If the underlying is private, the type alias must be private too.
+            //
+            // If the underlying is pub-in-priv, then the type alias' own status overrides it
+            // since it may make the underlying reachable again.
+            type_alias_status
+        }
+    }
 }
 
 fn effective_supertraits_iter(trait_inner: &Trait) -> impl Iterator<Item = &GenericBound> + '_ {

--- a/test_crates/sealed_traits/src/lib.rs
+++ b/test_crates/sealed_traits/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod doc_hidden;
+pub mod type_alias;
 
 mod private {
     pub trait Sealed {}

--- a/test_crates/sealed_traits/src/type_alias.rs
+++ b/test_crates/sealed_traits/src/type_alias.rs
@@ -1,0 +1,329 @@
+struct Private;
+
+#[doc(hidden)]
+pub struct Hidden;
+
+pub type IntRange = std::ops::Range<i64>;
+type PrivateRange = std::ops::Range<i64>;
+
+#[warn(private_interfaces)]
+pub type AliasOfPrivate = Private;
+
+#[warn(private_interfaces)]
+pub type PrivateGeneric = std::ops::Range<Private>;
+
+#[doc(hidden)]
+pub type HiddenAlias = i64;
+
+type PrivateAliasToHidden = Hidden;
+
+pub type PubAliasToHidden = Hidden;
+
+#[doc(hidden)]
+pub type HiddenAliasToHidden = Hidden;
+
+pub mod pub_type_alias {
+    use super::IntRange;
+    /// This trait is not sealed; the type alias is public.
+    ///
+    /// Proof:
+    /// ```
+    /// struct Witness;
+    ///
+    /// impl sealed_traits::type_alias::pub_type_alias::TakeTypeAlias for Witness {
+    ///     fn method(&self, range: sealed_traits::type_alias::IntRange) {}
+    /// }
+    /// ```
+    pub trait TakeTypeAlias {
+        fn method(&self, range: IntRange);
+    }
+
+    /// This trait is not sealed; the type alias is public.
+    ///
+    /// Proof:
+    /// ```
+    /// struct Witness;
+    ///
+    /// impl sealed_traits::type_alias::pub_type_alias::ReturnTypeAlias for Witness {
+    ///     fn method(&self) -> sealed_traits::type_alias::IntRange {
+    ///         todo!()
+    ///     }
+    /// }
+    /// ```
+    pub trait ReturnTypeAlias {
+        fn method(&self) -> IntRange;
+    }
+}
+
+pub mod private_type_alias {
+    use super::PrivateRange;
+
+    /// The type alias is private, but type aliases are just shorthand.
+    /// The implementer can just use the explicit version of the type,
+    /// which means this trait isn't sealed.
+    ///
+    /// Proof:
+    /// ```
+    /// struct Witness;
+    ///
+    /// impl sealed_traits::type_alias::private_type_alias::TakeTypeAlias for Witness {
+    ///     fn method(&self, range: std::ops::Range<i64>) {}
+    /// }
+    /// ```
+    pub trait TakeTypeAlias {
+        fn method(&self, range: PrivateRange);
+    }
+
+    /// The type alias is private, but type aliases are just shorthand.
+    /// The implementer can just use the explicit version of the type,
+    /// which means this trait isn't sealed.
+    ///
+    /// Proof:
+    /// ```
+    /// struct Witness;
+    ///
+    /// impl sealed_traits::type_alias::private_type_alias::ReturnTypeAlias for Witness {
+    ///     fn method(&self) -> std::ops::Range<i64> {
+    ///         todo!()
+    ///     }
+    /// }
+    /// ```
+    pub trait ReturnTypeAlias {
+        fn method(&self) -> PrivateRange;
+    }
+}
+
+pub mod private_type {
+    use super::AliasOfPrivate;
+
+    /// The type alias is pub, but the type it points to is private.
+    /// The implementer cannot name the type and cannot use the alias.
+    ///
+    /// Proof:
+    /// ```compile_fail
+    /// fn witness(value: sealed_traits::type_alias::AliasOfPrivate) {}
+    /// ```
+    ///
+    /// That means this trait is sealed.
+    ///
+    /// Proof:
+    /// ```compile_fail
+    /// struct Witness;
+    ///
+    /// impl sealed_traits::type_alias::private_type::TakeTypeAlias for Witness {
+    ///     fn method(&self, range: sealed_traits::type_alias::AliasOfPrivate) {}
+    /// }
+    /// ```
+    pub trait TakeTypeAlias {
+        fn method(&self, range: AliasOfPrivate);
+    }
+
+    /// By the same reasoning as above, this trait is sealed too.
+    ///
+    /// Proof:
+    /// ```compile_fail
+    /// struct Witness;
+    ///
+    /// impl sealed_traits::type_alias::private_type::ReturnTypeAlias for Witness {
+    ///     fn method(&self) -> sealed_traits::type_alias::AliasOfPrivate {
+    ///         todo!()
+    ///     }
+    /// }
+    /// ```
+    pub trait ReturnTypeAlias {
+        fn method(&self) -> AliasOfPrivate;
+    }
+}
+
+pub mod generic_private_type {
+    use super::PrivateGeneric;
+
+    /// The type alias is pub, but the type it points to is private due to the generic.
+    /// The implementer cannot name the type and cannot use the alias.
+    ///
+    /// Proof:
+    /// ```compile_fail
+    /// fn witness(value: sealed_traits::type_alias::PrivateGeneric) {}
+    /// ```
+    ///
+    /// That means this trait is sealed.
+    ///
+    /// Proof:
+    /// ```compile_fail
+    /// struct Witness;
+    ///
+    /// impl sealed_traits::type_alias::generic_private_type::TakeTypeAlias for Witness {
+    ///     fn method(&self, range: sealed_traits::type_alias::PrivateGeneric) {}
+    /// }
+    /// ```
+    pub trait TakeTypeAlias {
+        fn method(&self, range: PrivateGeneric);
+    }
+
+    /// By the same reasoning as above, this trait is sealed too.
+    ///
+    /// Proof:
+    /// ```compile_fail
+    /// struct Witness;
+    ///
+    /// impl sealed_traits::type_alias::generic_private_type::ReturnTypeAlias for Witness {
+    ///     fn method(&self) -> sealed_traits::type_alias::PrivateGeneric {
+    ///         todo!()
+    ///     }
+    /// }
+    /// ```
+    pub trait ReturnTypeAlias {
+        fn method(&self) -> PrivateGeneric;
+    }
+}
+
+pub mod hidden_alias {
+    use super::HiddenAlias;
+
+    /// The type alias is `doc(hidden)` but the underlying type is completely public API.
+    /// The implementer can avoid the type alias and instead use the underlying type directly.
+    ///
+    /// That means this trait is not sealed at all.
+    ///
+    /// Proof:
+    /// ```
+    /// struct Witness;
+    ///
+    /// impl sealed_traits::type_alias::hidden_alias::TakeTypeAlias for Witness {
+    ///     fn method(&self, value: i64) {}
+    /// }
+    /// ```
+    pub trait TakeTypeAlias {
+        fn method(&self, value: HiddenAlias);
+    }
+
+    /// By the same reasoning as above, this trait is unsealed too.
+    ///
+    /// Proof:
+    /// ```
+    /// struct Witness;
+    ///
+    /// impl sealed_traits::type_alias::hidden_alias::ReturnTypeAlias for Witness {
+    ///     fn method(&self) -> i64 {
+    ///         todo!()
+    ///     }
+    /// }
+    /// ```
+    pub trait ReturnTypeAlias {
+        fn method(&self) -> HiddenAlias;
+    }
+}
+
+pub mod private_alias_to_hidden {
+    use super::PrivateAliasToHidden;
+
+    /// The type alias is private, and the type it points to is `#[doc(hidden)]`.
+    /// The implementer cannot name the type alias,
+    /// and cannot name the underlying type via public API.
+    ///
+    /// That means this trait is public API sealed; note the use of
+    /// the `#[doc(hidden)] Hidden` type in the implementation.
+    ///
+    /// Proof:
+    /// ```
+    /// struct Witness;
+    ///
+    /// impl sealed_traits::type_alias::private_alias_to_hidden::TakeTypeAlias for Witness {
+    ///     fn method(&self, value: sealed_traits::type_alias::Hidden) {}
+    /// }
+    /// ```
+    pub trait TakeTypeAlias {
+        fn method(&self, value: PrivateAliasToHidden);
+    }
+
+    /// By the same reasoning as above, this trait is public API sealed too.
+    ///
+    /// Proof:
+    /// ```
+    /// struct Witness;
+    ///
+    /// impl sealed_traits::type_alias::private_alias_to_hidden::ReturnTypeAlias for Witness {
+    ///     fn method(&self) -> sealed_traits::type_alias::Hidden {
+    ///         todo!()
+    ///     }
+    /// }
+    /// ```
+    pub trait ReturnTypeAlias {
+        fn method(&self) -> PrivateAliasToHidden;
+    }
+}
+
+pub mod pub_alias_to_hidden {
+    use super::PubAliasToHidden;
+
+    /// The type alias is public API, but the type it points to is private due to the generic.
+    /// The underlying type is not public API, but the type alias is.
+    /// Downstream users can use the public type alias to implement this trait
+    /// without using any non-public API.
+    ///
+    /// That means this trait is unsealed.
+    ///
+    /// Proof:
+    /// ```
+    /// struct Witness;
+    ///
+    /// impl sealed_traits::type_alias::pub_alias_to_hidden::TakeTypeAlias for Witness {
+    ///     fn method(&self, range: sealed_traits::type_alias::PubAliasToHidden) {}
+    /// }
+    /// ```
+    pub trait TakeTypeAlias {
+        fn method(&self, range: PubAliasToHidden);
+    }
+
+    /// By the same reasoning as above, this trait is unsealed too.
+    ///
+    /// Proof:
+    /// ```
+    /// struct Witness;
+    ///
+    /// impl sealed_traits::type_alias::pub_alias_to_hidden::ReturnTypeAlias for Witness {
+    ///     fn method(&self) -> sealed_traits::type_alias::PubAliasToHidden {
+    ///         todo!()
+    ///     }
+    /// }
+    /// ```
+    pub trait ReturnTypeAlias {
+        fn method(&self) -> PubAliasToHidden;
+    }
+}
+
+pub mod hidden_alias_to_hidden {
+    use super::HiddenAliasToHidden;
+
+    /// Both the type alias and its underlying type are `#[doc(hidden)]`.
+    /// The implementer cannot name either via public API,
+    /// so this trait is public API sealed.
+    ///
+    /// Proof:
+    /// ```
+    /// struct Witness;
+    ///
+    /// impl sealed_traits::type_alias::hidden_alias_to_hidden::TakeTypeAlias for Witness {
+    ///     fn method(&self, value: sealed_traits::type_alias::HiddenAliasToHidden) {}
+    /// }
+    /// ```
+    pub trait TakeTypeAlias {
+        fn method(&self, value: HiddenAliasToHidden);
+    }
+
+    /// By the same reasoning as above, this trait is public API sealed too.
+    ///
+    /// Proof:
+    /// ```
+    /// struct Witness;
+    ///
+    /// impl sealed_traits::type_alias::hidden_alias_to_hidden::ReturnTypeAlias for Witness {
+    ///     fn method(&self) -> sealed_traits::type_alias::HiddenAliasToHidden {
+    ///         todo!()
+    ///     }
+    /// }
+    /// ```
+    pub trait ReturnTypeAlias {
+        fn method(&self) -> HiddenAliasToHidden;
+    }
+}


### PR DESCRIPTION
Traits that use type aliases like `pub type` in their functions' parameter or return values may be misclassified as sealed.
