### PR TITLE
Fix cycle-tracking in sealed traits to disregard diamond DAGs.

### DIFF
--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -1228,6 +1228,46 @@ fn rustdoc_sealed_traits() {
             sealed: false,
             public_api_sealed: true,
         },
+        Output {
+            name: "Base".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "regression_csc_1200".into(),
+                "Base".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "Left".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "regression_csc_1200".into(),
+                "Left".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "Right".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "regression_csc_1200".into(),
+                "Right".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "Top".into(),
+            path: vec![vec![
+                "sealed_traits".into(),
+                "regression_csc_1200".into(),
+                "Top".into(),
+            ]],
+            sealed: false,
+            public_api_sealed: false,
+        },
     ];
     expected_results.sort_unstable();
 

--- a/src/sealed_trait.rs
+++ b/src/sealed_trait.rs
@@ -237,6 +237,8 @@ fn determine_if_trait_is_sealed_with_no_external_blankets(
         }
     }
 
+    visited_trait_ids.remove(&trait_item.id);
+
     false
 }
 

--- a/test_crates/sealed_traits/src/lib.rs
+++ b/test_crates/sealed_traits/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod regression_csc_1200;
 pub mod doc_hidden;
 
 mod private {

--- a/test_crates/sealed_traits/src/regression_csc_1200.rs
+++ b/test_crates/sealed_traits/src/regression_csc_1200.rs
@@ -1,0 +1,14 @@
+//! Regression test for issue:
+//! <https://github.com/obi1kenobi/cargo-semver-checks/issues/1200>
+//!
+//! When traits form a diamond with supertrait dependency,
+//! that's not a cycle and the traits aren't sealed because of it.
+//! All of the traits below are unsealed.
+
+pub trait Base {}
+
+pub trait Left: Base {}
+
+pub trait Right: Base {}
+
+pub trait Top: Left + Right {}


### PR DESCRIPTION
Fixes https://github.com/obi1kenobi/cargo-semver-checks/issues/1200.

The old code forgot to remove trait IDs from the cycle-tracking set, so diamond DAGs were misdetected as cycles. This manifested as a particularly annoying Heisen-bug.