### PR TITLE
Add `maybe_sized` property to `GenericTypeParameter` (#822)

### DIFF
--- a/src/adapter/enum_variant.rs
+++ b/src/adapter/enum_variant.rs
@@ -130,10 +130,10 @@ impl DiscriminantValue {
 impl fmt::Display for DiscriminantValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            DiscriminantValue::I64(i) => write!(f, "{}", i),
-            DiscriminantValue::U64(i) => write!(f, "{}", i),
-            DiscriminantValue::I128(i) => write!(f, "{}", i),
-            DiscriminantValue::U128(i) => write!(f, "{}", i),
+            DiscriminantValue::I64(i) => write!(f, "{i}"),
+            DiscriminantValue::U64(i) => write!(f, "{i}"),
+            DiscriminantValue::I128(i) => write!(f, "{i}"),
+            DiscriminantValue::U128(i) => write!(f, "{i}"),
         }
     }
 }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -212,9 +212,12 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
                 {
                     properties::resolve_generic_parameter_property(contexts, property_name)
                 }
-                "GenericTypeParameter" => {
-                    properties::resolve_generic_type_parameter_property(contexts, property_name)
-                }
+                "GenericTypeParameter" => properties::resolve_generic_type_parameter_property(
+                    contexts,
+                    property_name,
+                    self.current_crate,
+                    self.previous_crate,
+                ),
                 "GenericConstParameter" => {
                     properties::resolve_generic_const_parameter_property(contexts, property_name)
                 }

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -1,4 +1,4 @@
-use rustdoc_types::{ItemEnum, Visibility};
+use rustdoc_types::{ItemEnum, Visibility, WherePredicate};
 use trustfall::{
     provider::{
         accessor_property, field_property, resolve_property_with, AsVertex, ContextIterator,
@@ -759,6 +759,8 @@ pub(crate) fn resolve_generic_parameter_property<'a, V: AsVertex<Vertex<'a>> + '
 pub(crate) fn resolve_generic_type_parameter_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     property_name: &str,
+    current_crate: &'a PackageIndex<'a>,
+    previous_crate: Option<&'a PackageIndex<'a>>,
 ) -> ContextOutcomeIterator<'a, V, FieldValue> {
     match property_name {
         "has_default" => resolve_property_with(contexts, |vertex| {
@@ -784,6 +786,88 @@ pub(crate) fn resolve_generic_type_parameter_property<'a, V: AsVertex<Vertex<'a>
                 }
                 _ => unreachable!("vertex was not a GenericTypeParameter: {vertex:?}"),
             }
+        }),
+        "maybe_sized" => resolve_property_with(contexts, move |vertex| {
+            let (generics, param) = vertex
+                .as_generic_parameter()
+                .expect("vertex was not a GenericTypeParameter");
+
+            let sized_trait_id = match vertex.origin {
+                Origin::CurrentCrate => current_crate,
+                Origin::PreviousCrate => previous_crate.expect("no previous crate provided"),
+            }
+            .own_crate
+            .sized_trait;
+
+            let mut maybe_sized = false;
+
+            match &param.kind {
+                rustdoc_types::GenericParamDefKind::Type { bounds, .. } => {
+                    for bound in bounds {
+                        if let rustdoc_types::GenericBound::TraitBound {
+                            trait_, modifier, ..
+                        } = bound
+                        {
+                            if trait_.id == sized_trait_id {
+                                match modifier {
+                                    rustdoc_types::TraitBoundModifier::None => {
+                                        // The generic includes an explicit `Sized` bound.
+                                        // It is definitely sized, even if it also has `?Sized`.
+                                        return false.into();
+                                    }
+                                    rustdoc_types::TraitBoundModifier::Maybe => {
+                                        // The generic includes a `?Sized` bound relaxation.
+                                        // But it still might *not* be `?Sized` since it might
+                                        // include an explicit `Sized` bound too.
+                                        maybe_sized = true;
+                                    }
+                                    _ => {} // Other modifiers don't apply here.
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => unreachable!("vertex was not a GenericTypeParameter: {vertex:?}"),
+            }
+
+            for predicate in &generics.where_predicates {
+                if let WherePredicate::BoundPredicate {
+                    type_: rustdoc_types::Type::Generic(generic_name),
+                    bounds: where_bounds,
+                    ..
+                } = &predicate
+                {
+                    if generic_name.as_str() == param.name {
+                        for bound in where_bounds {
+                            if let rustdoc_types::GenericBound::TraitBound {
+                                trait_,
+                                modifier,
+                                ..
+                            } = bound
+                            {
+                                if trait_.id == sized_trait_id {
+                                    match modifier {
+                                        rustdoc_types::TraitBoundModifier::None => {
+                                            // The generic includes an explicit `Sized` bound.
+                                            // It is definitely sized, even if it also has `?Sized`.
+                                            return false.into();
+                                        }
+                                        rustdoc_types::TraitBoundModifier::Maybe => {
+                                            // The generic includes a `?Sized` bound relaxation.
+                                            // But it still might *not* be `?Sized` since it might
+                                            // include an explicit `Sized` bound too.
+                                            maybe_sized = true;
+                                        }
+                                        _ => {} // Other modifiers don't apply here.
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            maybe_sized.into()
         }),
         _ => unreachable!("GenericTypeParameter property {property_name}"),
     }

--- a/src/adapter/receiver.rs
+++ b/src/adapter/receiver.rs
@@ -70,9 +70,9 @@ fn extract_kind_string(ty: &Type) -> Cow<'_, str> {
                                         } => {
                                             let inner = extract_kind_string(type_);
                                             if *is_mutable {
-                                                Cow::Owned(format!("&mut {}", inner))
+                                                Cow::Owned(format!("&mut {inner}"))
                                             } else {
-                                                Cow::Owned(format!("&{}", inner))
+                                                Cow::Owned(format!("&{inner}"))
                                             }
                                         }
                                         _ => extract_kind_string(t),
@@ -94,7 +94,7 @@ fn extract_kind_string(ty: &Type) -> Cow<'_, str> {
                             .collect::<Vec<_>>()
                             .join(", ");
 
-                        Cow::Owned(format!("{}<{}>", name, args_joined))
+                        Cow::Owned(format!("{name}<{args_joined}>"))
                     }
                     _ => Cow::Borrowed(name),
                 }

--- a/src/adapter/rust_type_name.rs
+++ b/src/adapter/rust_type_name.rs
@@ -383,7 +383,7 @@ display_wrapper!(GenericBound, fmt_generic_bound, bool);
 
 fn fmt_constant(this: &Constant, f: &mut Formatter<'_>) -> Result {
     if let Some(val) = &this.0.value {
-        write!(f, "{}", val)
+        write!(f, "{val}")
     } else {
         // The stringified form is unstable.  For example, `{ 1 + 2 }` currently
         // becomes `{ _ }`.
@@ -631,13 +631,13 @@ mod tests {
     fn typename() {
         let test_case = "rust_type_name";
 
-        let rustdoc_path = format!("./localdata/test_data/{}/rustdoc.json", test_case);
+        let rustdoc_path = format!("./localdata/test_data/{test_case}/rustdoc.json");
         let content = std::fs::read_to_string(&rustdoc_path)
             .with_context(|| format!("Could not load {rustdoc_path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
             .expect("failed to load rustdoc");
         let crate_ = serde_json::from_str(&content).expect("failed to parse rustdoc");
 
-        let manifest_path = format!("./test_crates/{}/Cargo.toml", test_case);
+        let manifest_path = format!("./test_crates/{test_case}/Cargo.toml");
 
         let mut metadata = cargo_metadata::MetadataCommand::new()
             .manifest_path(&manifest_path)

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -6547,3 +6547,379 @@ fn method_self_receiver() {
     expected_results.sort_unstable();
     similar_asserts::assert_eq!(expected_results, results);
 }
+
+#[test]
+fn generic_type_param_maybe_sized() {
+    get_test_data!(data, generic_type_param_maybe_sized);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let top_level_query = r#"
+{
+    Crate {
+        item {
+            ... on GenericItem {
+                name @output
+                name @filter(op: "!=", value: ["$method_name"])
+
+                generic_parameter {
+                    ... on GenericTypeParameter {
+                        generic_name: name @output
+                        maybe_sized @output
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+    let impl_query = r#"
+{
+    Crate {
+        item {
+            ... on ImplOwner {
+                inherent_impl {
+                    generic_parameter {
+                        ... on GenericTypeParameter {
+                            generic_name: name @output
+                            maybe_sized @output
+                        }
+                    }
+
+                    method {
+                        name @output
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+    let impl_owner_methods_query = r#"
+{
+    Crate {
+        item {
+            ... on ImplOwner {
+                inherent_impl {
+                    method {
+                        name @output
+
+                        generic_parameter {
+                            ... on GenericTypeParameter {
+                                generic_name: name @output
+                                maybe_sized @output
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+    let trait_methods_query = r#"
+{
+    Crate {
+        item {
+            ... on Trait {
+                method {
+                    name @output
+
+                    generic_parameter {
+                        ... on GenericTypeParameter {
+                            generic_name: name @output
+                            maybe_sized @output
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+
+    let variables: BTreeMap<&str, i64> = BTreeMap::default();
+    let mut top_level_variables: BTreeMap<&str, &str> = BTreeMap::default();
+    top_level_variables.insert("method_name", "method");
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        generic_name: String,
+        maybe_sized: bool,
+    }
+
+    let mut results: Vec<Output> = trustfall::execute_query(
+        &schema,
+        adapter.clone(),
+        top_level_query,
+        top_level_variables.clone(),
+    )
+    .expect("failed to run top level query")
+    .chain(
+        trustfall::execute_query(&schema, adapter.clone(), impl_query, variables.clone())
+            .expect("failed to run impl query"),
+    )
+    .chain(
+        trustfall::execute_query(
+            &schema,
+            adapter.clone(),
+            impl_owner_methods_query,
+            variables.clone(),
+        )
+        .expect("failed to run impl owners query"),
+    )
+    .chain(
+        trustfall::execute_query(
+            &schema,
+            adapter.clone(),
+            trait_methods_query,
+            variables.clone(),
+        )
+        .expect("failed to run trait methods query"),
+    )
+    .map(|row| row.try_into_struct().expect("shape mismatch"))
+    .collect();
+
+    // Ensure that the results are in sorted order, and also that the aggregated bounds are sorted.
+    results.sort_unstable();
+
+    // We write the results in the order the items appear in the test file,
+    // and sort them afterward in order to compare with the (sorted) query results.
+    // This makes it easier to verify that the expected data here is correct
+    // by reading it side-by-side with the file.
+    let mut expected_results = vec![
+        Output {
+            name: "GenericStruct".into(),
+            generic_name: "T".into(),
+            maybe_sized: true,
+        },
+        Output {
+            name: "GenericStruct".into(),
+            generic_name: "U".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "GenericStruct".into(),
+            generic_name: "V".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "GenericEnum".into(),
+            generic_name: "T".into(),
+            maybe_sized: true,
+        },
+        Output {
+            name: "GenericEnum".into(),
+            generic_name: "U".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "GenericEnum".into(),
+            generic_name: "V".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "GenericUnion".into(),
+            generic_name: "T".into(),
+            maybe_sized: true,
+        },
+        Output {
+            name: "GenericUnion".into(),
+            generic_name: "U".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "GenericUnion".into(),
+            generic_name: "V".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "GenericTrait".into(),
+            generic_name: "T".into(),
+            maybe_sized: true,
+        },
+        Output {
+            name: "GenericTrait".into(),
+            generic_name: "U".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "GenericTrait".into(),
+            generic_name: "V".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "trait_method".into(),
+            generic_name: "W".into(),
+            maybe_sized: true,
+        },
+        Output {
+            name: "trait_method".into(),
+            generic_name: "X".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "trait_method".into(),
+            generic_name: "Y".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "generic_fn1".into(),
+            generic_name: "T".into(),
+            maybe_sized: true,
+        },
+        Output {
+            name: "generic_fn1".into(),
+            generic_name: "U".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "generic_fn1".into(),
+            generic_name: "V".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "generic_fn2".into(),
+            generic_name: "T".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "generic_fn3".into(),
+            generic_name: "T".into(),
+            maybe_sized: true,
+        },
+        Output {
+            name: "generic_fn3a".into(),
+            generic_name: "T".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "generic_fn4".into(),
+            generic_name: "T".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "generic_fn5".into(),
+            generic_name: "T".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "generic_fn6".into(),
+            generic_name: "T".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "generic_fn7".into(),
+            generic_name: "T".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "generic_fn7a".into(),
+            generic_name: "T".into(),
+            maybe_sized: true,
+        },
+        Output {
+            name: "generic_fn8".into(),
+            generic_name: "T".into(),
+            maybe_sized: true,
+        },
+        Output {
+            name: "generic_fn8".into(),
+            generic_name: "U".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "generic_fn8".into(),
+            generic_name: "V".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "generic_fn9".into(),
+            generic_name: "T".into(),
+            maybe_sized: true,
+        },
+        Output {
+            name: "impl_trait".into(),
+            generic_name: "T".into(),
+            maybe_sized: true,
+        },
+        Output {
+            name: "impl_trait".into(),
+            generic_name: "U".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "impl_trait".into(),
+            generic_name: "V".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "impl_trait".into(),
+            generic_name: "impl GenericTrait<T, U, V>".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "impl_trait2".into(),
+            generic_name: "T".into(),
+            maybe_sized: true,
+        },
+        Output {
+            name: "impl_trait2".into(),
+            generic_name: "U".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "impl_trait2".into(),
+            generic_name: "V".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "impl_trait2".into(),
+            generic_name: "impl GenericTrait<T, U, V> + ?core::marker::Sized".into(),
+            maybe_sized: true,
+        },
+        Output {
+            name: "generic_method".into(),
+            generic_name: "T".into(),
+            maybe_sized: true,
+        },
+        Output {
+            name: "generic_method".into(),
+            generic_name: "U".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "ImplNarrowing".into(),
+            generic_name: "T".into(),
+            maybe_sized: true,
+        },
+        Output {
+            name: "taking_sized_t".into(),
+            generic_name: "T".into(),
+            maybe_sized: false,
+        },
+        Output {
+            name: "ImplicitlySized".into(),
+            generic_name: "T".into(),
+            // See the note in the test crate.
+            // Our `maybe_sized` analysis is local, which believes this to be `true`.
+            // A smarter, global analysis would actually determine the correct answer is `false`.
+            maybe_sized: true,
+        },
+        Output {
+            name: "ImplicitlySizedFromBuiltInTrait".into(),
+            generic_name: "T".into(),
+            // See the note in the test crate.
+            // Our `maybe_sized` analysis is local, which believes this to be `true`.
+            // A smarter, global analysis would actually determine the correct answer is `false`.
+            maybe_sized: true,
+        },
+    ];
+    expected_results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+}

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -221,6 +221,10 @@ pub struct IndexedCrate<'a> {
     /// A more complete future solution may generate multiple crates' rustdoc JSON
     /// and link to the external crate's trait items as necessary.
     pub(crate) manually_inlined_builtin_traits: HashMap<Id, Item>,
+
+    /// The ID of the built-in `core::marker::Sized` trait.
+    /// Used for analyzing `?Sized` generic types.
+    pub(crate) sized_trait: Id,
 }
 
 /// Map a Key to a List (Vec) of values
@@ -412,10 +416,14 @@ fn build_impl_index(index: &HashMap<Id, Item>) -> MapList<ImplEntry<'_>, (&Item,
 
 impl<'a> IndexedCrate<'a> {
     pub fn new(crate_: &'a Crate) -> Self {
+        let (manually_inlined_builtin_traits, sized_trait) =
+            create_manually_inlined_builtin_traits(crate_);
+
         let mut value = Self {
             inner: crate_,
             visibility_tracker: VisibilityTracker::from_crate(crate_),
-            manually_inlined_builtin_traits: create_manually_inlined_builtin_traits(crate_),
+            manually_inlined_builtin_traits,
+            sized_trait,
             flags: None,
             imports_index: None,
             impl_index: None,
@@ -849,7 +857,7 @@ fn new_trait(manual_trait_item: &ManualTraitItem, id: Id, crate_id: u32) -> Item
     }
 }
 
-fn create_manually_inlined_builtin_traits(crate_: &Crate) -> HashMap<Id, Item> {
+fn create_manually_inlined_builtin_traits(crate_: &Crate) -> (HashMap<Id, Item>, Id) {
     let paths = &crate_.paths;
 
     // `paths` may have thousands of items.
@@ -858,19 +866,33 @@ fn create_manually_inlined_builtin_traits(crate_: &Crate) -> HashMap<Id, Item> {
     #[cfg(not(feature = "rayon"))]
     let iter = paths.iter();
 
-    iter.filter_map(|(id, entry)| {
-        if entry.kind != rustdoc_types::ItemKind::Trait {
-            return None;
-        }
+    let manually_inlined_builtin_traits: HashMap<Id, Item> = iter
+        .filter_map(|(id, entry)| {
+            if entry.kind != rustdoc_types::ItemKind::Trait {
+                return None;
+            }
 
-        // This is a linear scan, but across a tiny array.
-        // It isn't worth doing anything fancier here.
-        MANUAL_TRAIT_ITEMS
-            .iter()
-            .find(|t| t.path == entry.path)
-            .map(|manual| (*id, new_trait(manual, *id, entry.crate_id)))
-    })
-    .collect()
+            // This is a linear scan, but across a tiny array.
+            // It isn't worth doing anything fancier here.
+            MANUAL_TRAIT_ITEMS
+                .iter()
+                .find(|t| t.path == entry.path)
+                .map(|manual| (*id, new_trait(manual, *id, entry.crate_id)))
+        })
+        .collect();
+
+    assert_eq!(
+        manually_inlined_builtin_traits.len(), MANUAL_TRAIT_ITEMS.len(),
+        "failed to find some expected built-in traits: found only {manually_inlined_builtin_traits:?} and expected {MANUAL_TRAIT_ITEMS:?}",
+    );
+
+    let sized_id = manually_inlined_builtin_traits
+        .iter()
+        .find(|(_, item)| item.name.as_deref() == Some("Sized"))
+        .map(|(id, _)| *id)
+        .expect("failed to find `Sized` trait");
+
+    (manually_inlined_builtin_traits, sized_id)
 }
 
 #[cfg(test)]

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -2586,6 +2586,21 @@ type GenericTypeParameter implements GenericParameter {
   """
   type_bound: [ImplementedTrait!]
 
+  """
+  Whether the type parameter is `?Sized`.
+
+  Generic parameters are `Sized` by default, in which case this is `false`.
+  They may opt out of that implicit bound by specifying a bound on `?Sized`,
+  in which case the value here will be `true`.
+
+  This value considers all local bounds involving `Sized`.
+  For example:
+  - `T: Sized + ?Sized` is considered `Sized`, and the value here is `false`.
+  - `T: SomeTrait + ?Sized` is considered `?Sized` and the value here is `true`,
+    even if `SomeTrait` is defined as `trait SomeTrait: Sized`.
+  """
+  maybe_sized: Boolean!
+
   # TODO: needs lifetime bounds
   # lifetime_bound: ?
 }

--- a/test_crates/generic_type_param_maybe_sized/Cargo.toml
+++ b/test_crates/generic_type_param_maybe_sized/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "generic_type_param_maybe_sized"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/generic_type_param_maybe_sized/src/lib.rs
+++ b/test_crates/generic_type_param_maybe_sized/src/lib.rs
@@ -1,0 +1,177 @@
+#![deny(clippy::needless_maybe_sized)]
+
+use core::marker::Sized as SizedRenamed;
+
+// A trait used to guard against bugs due to name-based matching
+// for the built-in `Sized` trait when determining `?Sized` status.
+pub trait Sized {
+    fn method();
+}
+
+// `T` is maybe-sized.
+// `U` and `V` are sized.
+pub struct GenericStruct<T: ?core::marker::Sized, U: core::marker::Sized, V> {
+    _x: Box<T>,
+    _y: U,
+    _z: V,
+}
+
+// `T` is maybe-sized.
+// `U` and `V` are sized.
+pub enum GenericEnum<T: ?core::marker::Sized, U: core::marker::Sized, V> {
+    Variant(Box<T>),
+    Variant2(U),
+    Variant3(V),
+}
+
+// `T` is maybe-sized.
+// `U` and `V` are sized.
+pub union GenericUnion<T: ?core::marker::Sized, U: core::marker::Sized, V> {
+    _field: std::mem::ManuallyDrop<Box<T>>,
+    _field2: std::mem::ManuallyDrop<U>,
+    _field3: std::mem::ManuallyDrop<V>,
+}
+
+// `T` is maybe-sized.
+// `U` and `V` are sized.
+pub trait GenericTrait<T: ?core::marker::Sized, U: core::marker::Sized, V> {
+    // `W` is maybe-sized.
+    // `X` and `Y` are sized.
+    fn trait_method<W: ?core::marker::Sized, X: core::marker::Sized, Y>(_value: &T);
+}
+
+// `T` is maybe-sized.
+// `U` and `V` are sized.
+pub fn generic_fn1<T: ?core::marker::Sized, U: core::marker::Sized, V>(_value: &T) {}
+
+// `T` is sized. The `?Sized` is overridden by the explicit bound on `Sized`.
+#[allow(clippy::needless_maybe_sized)]
+pub fn generic_fn2<T: core::marker::Sized + ?core::marker::Sized>(_value: &T) {}
+
+// `T` is maybe-sized. The `Sized` here is the unrelated trait, not the built-in one.
+pub fn generic_fn3<T: Sized + ?core::marker::Sized>(_value: &T) {}
+
+// `T` is sized. `SizedRenamed` is an import rename of the built-in `Sized` trait.
+#[allow(clippy::needless_maybe_sized)]
+pub fn generic_fn3a<T: SizedRenamed + ?core::marker::Sized>(_value: T) {}
+
+// `T` is sized. The `?Sized` is overridden by both explicit bounds: the `where` and the `:` bound.
+#[allow(clippy::needless_maybe_sized)]
+#[allow(clippy::multiple_bound_locations)]
+pub fn generic_fn4<T: core::marker::Sized + ?core::marker::Sized>(_value: &T)
+where
+    T: core::marker::Sized,
+{
+}
+
+// `T` is sized. The `?Sized` is overridden by both explicit bounds: the `where` and the `:` bound.
+#[allow(clippy::needless_maybe_sized)]
+#[allow(clippy::multiple_bound_locations)]
+pub fn generic_fn5<T: ?core::marker::Sized + core::marker::Sized>(_value: &T)
+where
+    T: core::marker::Sized,
+{
+}
+
+// `T` is sized. The `?Sized` is overridden by the explicit bound in the `where` clause.
+#[allow(clippy::needless_maybe_sized)]
+#[allow(clippy::multiple_bound_locations)]
+pub fn generic_fn6<T: ?core::marker::Sized>(_value: &T)
+where
+    T: core::marker::Sized,
+{
+}
+
+// `T` is sized due to the bound in the `:` clause.
+#[allow(clippy::needless_maybe_sized)]
+#[allow(clippy::multiple_bound_locations)]
+pub fn generic_fn7<T: core::marker::Sized>(_value: &T)
+where
+    T: ?core::marker::Sized,
+{
+}
+
+// `T` is maybe-sized due to the `where` clause.
+pub fn generic_fn7a<T>(_value: &T)
+where
+    T: ?core::marker::Sized,
+{
+}
+
+// `T` is maybe-sized.
+// `U` and `V` are sized.
+pub fn generic_fn8<T, U, V>(_value: &T)
+where
+    T: ?core::marker::Sized,
+    U: core::marker::Sized,
+{
+}
+
+// `T` is maybe-sized.
+pub fn generic_fn9<T>(_value: &T)
+where
+    T: ?SizedRenamed,
+{
+}
+
+// `T` is maybe-sized.
+// `U` and `V` are sized.
+// The synthetic generic from the `impl Trait` is sized.
+pub fn impl_trait<T: ?core::marker::Sized, U: core::marker::Sized, V>(
+    _value: impl GenericTrait<T, U, V>,
+) {
+}
+
+// `T` is maybe-sized.
+// `U` and `V` are sized.
+// The synthetic generic from the `impl Trait` is maybe-sized.
+pub fn impl_trait2<T: ?core::marker::Sized, U: core::marker::Sized, V>(
+    _value: &(impl GenericTrait<T, U, V> + ?core::marker::Sized),
+) {
+}
+
+pub struct ExampleStruct;
+
+impl ExampleStruct {
+    // `T` is maybe-sized.
+    // `U` is sized.
+    pub fn generic_method<T: ?SizedRenamed, U>(_left: &T, _right: &U) {}
+}
+
+// `T` is maybe-sized here.
+pub struct ImplNarrowing<T: ?core::marker::Sized>(Box<T>);
+
+impl<T> ImplNarrowing<T> {
+    // Here `T` is sized because the `impl` didn't say it was `?Sized`.
+    pub fn taking_sized_t(_value: T) {}
+}
+
+// Anything that implements this trait must be `Sized`.
+trait SizedSuper: Sized {}
+
+// `T` here is a weird edge case:
+// - A *local* analysis of the bounds determines it to be `?Sized`.
+//   Our `maybe_sized` boolean property will say `true` because of this.
+// - However, a *global* analysis could determine that `T: SizedSuper` implies `T: Sized`.
+//   This is a fact that downstream users of `ImplicitlySized` can depend on,
+//   but is entirely non-obvious from the public API that this is the case.
+//
+// Note that `SizedSuper` is a private trait. This is another example where
+// knowledge of private items is required to determine the public API of a crate.
+//
+// This is also "infectious", auto-trait-like: a trait way upstream of `T`'s supertraits
+// may change its bounds in a way that changes whether `T` is sized or not.
+#[allow(private_bounds)]
+pub struct ImplicitlySized<T: SizedSuper + ?core::marker::Sized>(T);
+
+// `T` here is another such weird edge case:
+// - A *local* analysis of the bounds determines it to be `?Sized`.
+//   Our `maybe_sized` boolean property will say `true` because of this.
+// - However, a *global* analysis could determine that `T: Copy` implies `T: Sized`.
+//   This is a fact that downstream users of `ImplicitlySized` can depend on,
+//   but is entirely non-obvious from the public API that this is the case.
+//
+// Furthermore, this shows that determining whether a type is *actually* `?Sized`
+// requires cross-crate analysis. This is unfortunate.
+#[allow(clippy::needless_maybe_sized)]
+pub struct ImplicitlySizedFromBuiltInTrait<T: ?core::marker::Sized + Copy>(T);


### PR DESCRIPTION
*(PR description by @obi1kenobi to match the maintainer edits to this PR
that were made pre-merge)*

Add a `maybe_sized: Boolean!` property to `GenericTypeParameter`.

The computation of the property does only local reasoning about bounds.
In particular:
- `T: ?Sized + Sized` is considered sized.
- `T: ?Sized + SomeTrait` is considered maybe-sized, even if `SomeTrait:
Sized`.

Implementing correct global reasoning for precise `?Sized`
determinations requires either cross-crate querying, or explicit
information on this in rustdoc JSON.

---------

Co-authored-by: Predrag Gruevski <2348618+obi1kenobi@users.noreply.github.com>
Co-authored-by: Predrag Gruevski <obi1kenobi82@gmail.com>
