### PR TITLE
Expose FFI-exported functions: both functions and methods.

### DIFF
--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -128,6 +128,41 @@ pub(super) fn resolve_crate_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
                 )
             })
         }
+        "ffi_exported_function" => {
+            let current_crate = adapter.current_crate;
+            let previous_crate = adapter.previous_crate;
+
+            resolve_neighbors_with(contexts, move |vertex| {
+                let origin = vertex.origin;
+                let export_name_index = match origin {
+                    Origin::CurrentCrate => &current_crate.own_crate.export_name_index,
+                    Origin::PreviousCrate => {
+                        &previous_crate
+                            .expect("no previous crate provided")
+                            .own_crate
+                            .export_name_index
+                    }
+                }
+                .as_ref()
+                .expect("export_name_index was never constructed");
+
+                Box::new(
+                    export_name_index
+                        .values()
+                        .filter_map(move |item| match &item.inner {
+                            ItemEnum::Function(..) => {
+                                debug_assert!(
+                                    crate::exported_name::item_export_name(item).is_some(),
+                                    "item was part of export_name_index but did not have \
+                                an exported name: {item:?}"
+                                );
+                                Some(origin.make_item_vertex(item))
+                            }
+                            _ => None,
+                        }),
+                )
+            })
+        }
         _ => unreachable!("resolve_crate_edge {edge_name}"),
     }
 }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -110,6 +110,7 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
                 | "StructVariant"
                 | "Union"
                 | "Trait"
+                | "ExportableFunction"
                 | "Function"
                 | "Method"
                 | "Impl"
@@ -152,13 +153,18 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
                 "ImportablePath" => {
                     properties::resolve_importable_path_property(contexts, property_name)
                 }
-                "FunctionLike" | "Function" | "Method"
+                "FunctionLike" | "ExportableFunction" | "Function" | "Method"
                     if matches!(
                         property_name.as_ref(),
                         "const" | "unsafe" | "async" | "has_body" | "signature"
                     ) =>
                 {
                     properties::resolve_function_like_property(contexts, property_name)
+                }
+                "ExportableFunction" | "Function" | "Method"
+                    if matches!(property_name.as_ref(), "export_name") =>
+                {
+                    properties::resolve_exportable_function_property(contexts, property_name)
                 }
                 "Function" => properties::resolve_function_property(contexts, property_name),
                 "FunctionParameter" => {
@@ -275,6 +281,7 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
             | "Union"
             | "StructVariant"
             | "Trait"
+            | "ExportableFunction"
             | "Function"
             | "Method"
             | "Impl"
@@ -298,7 +305,7 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
             {
                 edges::resolve_impl_owner_edge(self, contexts, edge_name, resolve_info)
             }
-            "Function" | "Method" | "FunctionLike"
+            "Function" | "Method" | "FunctionLike" | "ExportableFunction"
                 if matches!(edge_name.as_ref(), "parameter" | "abi") =>
             {
                 edges::resolve_function_like_edge(contexts, edge_name)
@@ -381,8 +388,8 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
     ) -> ContextOutcomeIterator<'a, V, bool> {
         let coerce_to_type = coerce_to_type.clone();
         match type_name.as_ref() {
-            "Item" | "GenericItem" | "Variant" | "FunctionLike" | "Importable" | "ImplOwner"
-            | "RawType" | "GlobalValue" | "ProcMacro" => {
+            "Item" | "GenericItem" | "Variant" | "FunctionLike" | "ExportableFunction"
+            | "Importable" | "ImplOwner" | "RawType" | "GlobalValue" | "ProcMacro" => {
                 resolve_coercion_with(contexts, move |vertex| {
                     let actual_type_name = vertex.typename();
 
@@ -401,6 +408,7 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
                             actual_type_name,
                             "FunctionLikeProcMacro" | "AttributeProcMacro" | "DeriveProcMacro"
                         ),
+                        "ExportableFunction" => matches!(actual_type_name, "Function" | "Method"),
                         _ => {
                             // The remaining types are final (don't have any subtypes)
                             // so we can just compare the actual type name to

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -293,7 +293,7 @@ pub(super) fn resolve_function_like_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
     }
 }
 
-pub(super) fn resolve_function_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
+pub(super) fn resolve_exportable_function_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     property_name: &str,
 ) -> ContextOutcomeIterator<'a, V, FieldValue> {
@@ -302,6 +302,19 @@ pub(super) fn resolve_function_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
             let item = vertex.as_item().expect("not an Item vertex");
             crate::exported_name::item_export_name(item).into()
         }),
+        _ => unreachable!("ExportableFunction property {property_name}"),
+    }
+}
+
+pub(super) fn resolve_function_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
+    _contexts: ContextIterator<'a, V>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, V, FieldValue> {
+    #[expect(
+        clippy::match_single_binding,
+        reason = "we'll add more properties here eventually"
+    )]
+    match property_name {
         _ => unreachable!("Function property {property_name}"),
     }
 }

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -6923,3 +6923,149 @@ fn generic_type_param_maybe_sized() {
 
     similar_asserts::assert_eq!(expected_results, results);
 }
+
+#[test]
+fn rustdoc_ffi_exported_functions() {
+    get_test_data!(data, ffi_exported_functions);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+{
+    Crate {
+        ffi_exported_function {
+            name @output
+            export_name @output
+
+            abi {
+                abi: raw_name @output
+            }
+        }
+    }
+}
+"#;
+
+    let variables: BTreeMap<&str, &str> = BTreeMap::default();
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        export_name: String,
+        abi: String,
+    }
+
+    let mut expected_results = vec![
+        Output {
+            name: "top_level_no_mangle_fn".into(),
+            export_name: "top_level_no_mangle_fn".into(),
+            abi: "C".into(),
+        },
+        Output {
+            name: "top_level_export_name_fn".into(),
+            export_name: "exported".into(),
+            abi: "C-unwind".into(),
+        },
+        Output {
+            name: "associated_fn".into(),
+            export_name: "associated_fn".into(),
+            abi: "C".into(),
+        },
+        Output {
+            name: "assoc_exported_fn".into(),
+            export_name: "assoc_exported".into(),
+            abi: "C-unwind".into(),
+        },
+        Output {
+            name: "method".into(),
+            export_name: "method".into(),
+            abi: "C".into(),
+        },
+    ];
+    expected_results.sort_unstable();
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results,);
+}
+
+#[test]
+fn rustdoc_method_export_name() {
+    get_test_data!(data, ffi_exported_functions);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on ImplOwner {
+                owner: name @output
+
+                inherent_impl {
+                    method {
+                        name @output
+                        export_name @filter(op: "is_not_null") @output
+
+                        abi {
+                            abi: raw_name @output
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+
+    let variables: BTreeMap<&str, &str> = BTreeMap::default();
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        owner: String,
+        name: String,
+        export_name: String,
+        abi: String,
+    }
+
+    let mut expected_results = vec![
+        Output {
+            owner: "Example".into(),
+            name: "associated_fn".into(),
+            export_name: "associated_fn".into(),
+            abi: "C".into(),
+        },
+        Output {
+            owner: "Example".into(),
+            name: "assoc_exported_fn".into(),
+            export_name: "assoc_exported".into(),
+            abi: "C-unwind".into(),
+        },
+        Output {
+            owner: "Example".into(),
+            name: "method".into(),
+            export_name: "method".into(),
+            abi: "C".into(),
+        },
+    ];
+    expected_results.sort_unstable();
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results,);
+}

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -35,6 +35,16 @@ type Crate {
   item: [Item!]
 
   """
+  Functions whose symbol names are made available for use via FFI.
+
+  Such functions are marked with `#[no_mangle]` or `#[export_name]`, and may either be
+  top-level ("free") functions or ones associated with a type (i.e. defined within the type's
+  `impl` block). From an FFI perspective, this distinction is not relevant since the function call
+  is made via the exported symbol name.
+  """
+  ffi_exported_function: [ExportableFunction!]
+
+  """
   Features that are present in the crate.
 
   If feature data is not loaded into the adapter, this edge will not have any instances.
@@ -1299,6 +1309,100 @@ interface FunctionLike {
 }
 
 """
+A function that may be exported for FFI use. Either a top-level function or a method.
+
+This is a base interface for the `Function` and `Method` types.
+Not all `ExportableFunction` vertices are exported for FFI: such FFI export is supported
+if the appropriate item attributes are set.
+"""
+interface ExportableFunction implements Item & FunctionLike {
+  # properties from Item
+  id: String!
+  crate_id: Int!
+  name: String
+  docs: String
+  attrs: [String!]!
+
+  """
+  This item is hidden in documentation.
+  """
+  doc_hidden: Boolean!
+
+  """
+  This item is deprecated.
+  """
+  deprecated: Boolean!
+
+  """
+  Whether this item is eligible to be in the public API. This is true if both:
+  - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
+  - The item is visible in documentation, or is not visible but is deprecated,
+    since deprecated items are assumed to have been part of the public API in the past.
+
+  Being eligible to be part of the public API *does not* make an item public API!
+  An item that is not eligible by itself cannot be part of the public API,
+  but eligible items might not be public API -- for example, pub-in-priv items
+  (public items in a private module) are eligible but not public API. Another example
+  would be a public item that is only reachable via modules that are both
+  `#[doc(hidden)]` and not deprecated.
+
+  To check whether an item is part of the public API:
+  - For items that are legal in a `use` import statement, use the `importable_path` edge and the
+    path's `public_api` property.
+  - For all other items (e.g. struct fields), first check whether that parent item is public API
+    as above, and then check whether the item itself is `public_api_eligible`.
+  """
+  public_api_eligible: Boolean!
+
+  visibility_limit: String!
+
+  # properties from FunctionLike
+  const: Boolean!
+  unsafe: Boolean!
+  async: Boolean!
+  has_body: Boolean!
+  """
+  Stringified representation of the function's signature, as close to the
+  original source code as possible.  May not preserve whitespace, constant
+  expressions in types, or path names, but the output will be semantically
+  equivalent to the original.
+  """
+  signature: String!
+
+  # own properties
+  """
+  The unmangled or explicitly-specified export name of this item, if any.
+
+  Export names are defined using the `#[export_name]` or `#[no_mangle]` attributes.
+
+  For example:
+  - The following function has `export_name = "example"`:
+    ```rust
+    #[no_mangle]
+    extern "C" fn example() {}
+    ```
+  - The following function has `export_name = "other"`:
+    ```rust
+    #[export_name = "other"]
+    extern "C" fn example() {}
+    ```
+
+  More info:
+  https://doc.rust-lang.org/reference/abi.html#the-no_mangle-attribute
+  https://doc.rust-lang.org/reference/abi.html#the-export_name-attribute
+  """
+  export_name: String
+
+  # edges from Item
+  span: Span
+  attribute: [Attribute!]
+
+  # edges from FunctionLike
+  parameter: [FunctionParameter!]
+  abi: FunctionAbi!
+}
+
+"""
 A function parameter.
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.FnDecl.html
 """
@@ -1359,7 +1463,7 @@ https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Item.html
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/enum.ItemEnum.html
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Function.html
 """
-type Function implements Item & FunctionLike & Importable & GenericItem {
+type Function implements Item & FunctionLike & Importable & ExportableFunction & GenericItem {
   # properties from Item
   id: String!
   crate_id: Int!
@@ -1413,7 +1517,7 @@ type Function implements Item & FunctionLike & Importable & GenericItem {
   """
   signature: String!
 
-  # own properties
+  # properties from ExportableFunction
   """
   The unmangled or explicitly-specified export name of this item, if any.
 
@@ -1527,6 +1631,30 @@ type Method implements Item & FunctionLike & GenericItem {
   equivalent to the original.
   """
   signature: String!
+
+  # properties from ExportableFunction
+  """
+  The unmangled or explicitly-specified export name of this item, if any.
+
+  Export names are defined using the `#[export_name]` or `#[no_mangle]` attributes.
+
+  For example:
+  - The following function has `export_name = "example"`:
+    ```rust
+    #[no_mangle]
+    extern "C" fn example() {}
+    ```
+  - The following function has `export_name = "other"`:
+    ```rust
+    #[export_name = "other"]
+    extern "C" fn example() {}
+    ```
+
+  More info:
+  https://doc.rust-lang.org/reference/abi.html#the-no_mangle-attribute
+  https://doc.rust-lang.org/reference/abi.html#the-export_name-attribute
+  """
+  export_name: String
 
   # edge from Item
   span: Span

--- a/test_crates/ffi_exported_functions/Cargo.toml
+++ b/test_crates/ffi_exported_functions/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "ffi_exported_functions"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test_crates/ffi_exported_functions/src/lib.rs
+++ b/test_crates/ffi_exported_functions/src/lib.rs
@@ -1,0 +1,19 @@
+#[no_mangle]
+pub extern "C" fn top_level_no_mangle_fn() {}
+
+#[export_name = "exported"]
+pub extern "C-unwind" fn top_level_export_name_fn() {}
+
+#[repr(C)]
+pub struct Example;
+
+impl Example {
+    #[no_mangle]
+    pub extern "C" fn associated_fn() {}
+
+    #[export_name = "assoc_exported"]
+    pub extern "C-unwind" fn assoc_exported_fn() {}
+
+    #[no_mangle]
+    pub extern "C" fn method(&self) {}
+}


### PR DESCRIPTION
This should allow us to write FFI-specific lints that don't have false-positives if an exported free function becomes a method while keeping the same export name.