### PR TITLE
Omit trait-provided items from impl_index when overridden in impl. (#855)

### DIFF
--- a/src/adapter/optimizations/impl_lookup.rs
+++ b/src/adapter/optimizations/impl_lookup.rs
@@ -1,9 +1,3 @@
-#[cfg(not(feature = "rustc-hash"))]
-use std::collections::HashMap;
-
-#[cfg(feature = "rustc-hash")]
-use rustc_hash::FxHashMap as HashMap;
-
 use rustdoc_types::{Id, Item};
 use trustfall::{
     provider::{
@@ -13,7 +7,7 @@ use trustfall::{
     FieldValue,
 };
 
-use crate::{adapter::PackageIndex, indexed_crate::ImplEntry};
+use crate::{adapter::PackageIndex, hashtables::HashMap, indexed_crate::ImplEntry};
 
 use super::super::{origin::Origin, vertex::Vertex, RustdocAdapter};
 
@@ -109,13 +103,13 @@ fn resolve_impl_based_on_method_name_candidate<'a>(
     let impl_index = match origin {
         Origin::CurrentCrate => current_crate
             .own_crate
-            .impl_index
+            .impl_method_index
             .as_ref()
             .expect("no impl index present"),
         Origin::PreviousCrate => previous_crate
             .expect("no previous crate provided")
             .own_crate
-            .impl_index
+            .impl_method_index
             .as_ref()
             .expect("no impl index provided"),
     };

--- a/src/adapter/optimizations/method_lookup.rs
+++ b/src/adapter/optimizations/method_lookup.rs
@@ -1,11 +1,3 @@
-use std::collections::BTreeSet;
-
-#[cfg(not(feature = "rustc-hash"))]
-use std::collections::HashMap;
-
-#[cfg(feature = "rustc-hash")]
-use rustc_hash::FxHashMap as HashMap;
-
 use rustdoc_types::{Id, Impl, Item, ItemEnum, Type};
 use trustfall::{
     provider::{
@@ -17,6 +9,7 @@ use trustfall::{
 
 use crate::{
     adapter::{Origin, PackageIndex, Vertex},
+    hashtables::{HashMap, HashSet},
     indexed_crate::ImplEntry,
     RustdocAdapter,
 };
@@ -110,7 +103,7 @@ fn resolve_method_from_candidate_value<'a>(
             &current_crate.own_crate.inner.index,
             current_crate
                 .own_crate
-                .impl_index
+                .impl_method_index
                 .as_ref()
                 .expect("no impl index present"),
         ),
@@ -120,7 +113,7 @@ fn resolve_method_from_candidate_value<'a>(
                 &previous_crate.own_crate.inner.index,
                 previous_crate
                     .own_crate
-                    .impl_index
+                    .impl_method_index
                     .as_ref()
                     .expect("no impl index provided"),
             )
@@ -178,7 +171,7 @@ fn resolve_methods_slow_path<'a>(
         if impl_vertex.provided_trait_methods.is_empty() {
             Box::new(std::iter::empty())
         } else {
-            let method_names: BTreeSet<&str> = impl_vertex
+            let method_names: HashSet<&str> = impl_vertex
                 .provided_trait_methods
                 .iter()
                 .map(|x| x.as_str())
@@ -208,15 +201,30 @@ fn resolve_methods_slow_path<'a>(
             }
         };
 
+    let mut produced_methods: HashSet<&str> = Default::default();
     Box::new(
-        provided_methods
-            .chain(impl_vertex.items.iter())
+        // Iterate through explicitly-implemented items first, and trait-provided items next.
+        // This ensures we prefer the explicitly-implemented method in cases where
+        // the trait also provided a default impl (which is overridden and not used).
+        impl_vertex
+            .items
+            .iter()
+            .chain(provided_methods)
             .filter_map(move |item_id| {
                 let next_item = &item_index.get(item_id);
+
                 if let Some(next_item) = next_item {
+                    let item_name = next_item.name.as_deref()?;
                     match &next_item.inner {
                         rustdoc_types::ItemEnum::Function(..) => {
-                            Some(origin.make_item_vertex(next_item))
+                            // Ensure our iterator doesn't produce duplicate method names
+                            // in the case where a trait provided a default
+                            // but the impl had an override.
+                            if produced_methods.insert(item_name) {
+                                Some(origin.make_item_vertex(next_item))
+                            } else {
+                                None
+                            }
                         }
                         _ => None,
                     }

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -2637,6 +2637,127 @@ fn trait_associated_items_public_api_eligible() {
 }
 
 #[test]
+fn defaulted_trait_items_overridden_in_impls() {
+    get_test_data!(data, defaulted_trait_items_overridden_in_impls);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Struct {
+                name @output
+
+                impl {
+                    implemented_trait {
+                        bare_name @filter(op: "=", value: ["$trait_name"])
+                    }
+
+                    associated_constant @fold {
+                        consts: name @output
+                    }
+
+                    method @fold {
+                        methods: name @output
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+
+    let mut variables: BTreeMap<&str, &str> = BTreeMap::default();
+    variables.insert("trait_name", "Trait");
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        consts: Vec<String>,
+        methods: Vec<String>,
+    }
+
+    let mut expected_results = vec![Output {
+        name: "Example".into(),
+        consts: vec!["N".into()],
+        methods: vec!["method".into()],
+    }];
+    expected_results.sort_unstable();
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results,);
+}
+
+#[test]
+fn defaulted_trait_items_overridden_in_impls_when_looked_up_by_name() {
+    get_test_data!(data, defaulted_trait_items_overridden_in_impls);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Struct {
+                name @output
+
+                impl {
+                    method {
+                        method: name @filter(op: "=", value: ["$method"]) @output
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+
+    let mut variables: BTreeMap<&str, &str> = BTreeMap::default();
+    variables.insert("method", "method");
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        method: String,
+    }
+
+    let mut expected_results = vec![
+        // We *must* only get one result here.
+        //
+        // If we get two, we've erroneously returned both
+        // the trait's provided default impl for the method
+        // and the `impl Trait for Example` override for the method.
+        Output {
+            name: "Example".into(),
+            method: "method".into(),
+        },
+    ];
+    expected_results.sort_unstable();
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results,);
+}
+
+#[test]
 fn unions() {
     get_test_data!(data, unions);
     let adapter = RustdocAdapter::new(&data, None);

--- a/src/hashtables.rs
+++ b/src/hashtables.rs
@@ -1,0 +1,5 @@
+#[cfg(not(feature = "rustc-hash"))]
+pub(crate) use std::collections::{HashMap, HashSet};
+
+#[cfg(feature = "rustc-hash")]
+pub(crate) use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -1,17 +1,12 @@
 use std::{borrow::Borrow, collections::hash_map::Entry, sync::Arc};
 
-#[cfg(not(feature = "rustc-hash"))]
-use std::collections::{HashMap, HashSet};
-
-#[cfg(feature = "rustc-hash")]
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
 use rustdoc_types::{Crate, Id, Item};
 
 use crate::{
     adapter::supported_item_kind,
+    hashtables::{HashMap, HashSet},
     item_flags::{build_flags_index, ItemFlag},
     visibility_tracker::VisibilityTracker,
 };
@@ -196,8 +191,9 @@ pub struct IndexedCrate<'a> {
     /// index: item ID -> bit flags recording yes-no indicators for various item states
     pub(crate) flags: Option<HashMap<Id, ItemFlag>>,
 
-    /// index: impl owner + impl'd item name -> list of (impl itself, the named item))
-    pub(crate) impl_index: Option<HashMap<ImplEntry<'a>, Vec<(&'a Item, &'a Item)>>>,
+    /// index: impl owner + impl'd method item name -> list of (impl itself, the named item));
+    /// only holds associated function ("method") items!
+    pub(crate) impl_method_index: Option<HashMap<ImplEntry<'a>, Vec<(&'a Item, &'a Item)>>>,
 
     /// index: method ("owned function") `Id` -> the struct/enum/union/trait that defines it;
     /// functions at top level will not have an index entry here
@@ -352,6 +348,42 @@ fn build_impl_index(index: &HashMap<Id, Item>) -> MapList<ImplEntry<'_>, (&Item,
                 rustdoc_types::ItemEnum::Impl(impl_inner) => impl_inner,
                 _ => unreachable!("expected impl but got another item type: {impl_item:?}"),
             };
+
+            #[cfg(feature = "rayon")]
+            let impl_items = impl_inner.items.par_iter();
+            #[cfg(not(feature = "rayon"))]
+            let impl_items = impl_inner.items.iter();
+
+            let impl_entries = impl_items.filter_map(move |item_id| {
+                let item = index.get(item_id)?;
+                let item_name = item.name.as_deref()?;
+
+                // The `impl_index` contains only methods, discard other item types.
+                if matches!(item.inner, rustdoc_types::ItemEnum::Function { .. }) {
+                    Some((ImplEntry::new(id, item_name), (impl_item, item)))
+                } else {
+                    None
+                }
+            });
+
+            #[cfg(feature = "rayon")]
+            let impl_items = impl_inner.items.par_iter();
+            #[cfg(not(feature = "rayon"))]
+            let impl_items = impl_inner.items.iter();
+
+            let impl_item_names: HashSet<_> = impl_items
+                .filter_map(move |item_id| {
+                    let item = index.get(item_id)?;
+                    let item_name = item.name.as_deref()?;
+
+                    if matches!(item.inner, rustdoc_types::ItemEnum::Function { .. }) {
+                        Some(item_name)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
             let trait_provided_methods: HashSet<_> = impl_inner
                 .provided_trait_methods
                 .iter()
@@ -381,7 +413,9 @@ fn build_impl_index(index: &HashMap<Id, Item>) -> MapList<ImplEntry<'_>, (&Item,
                 .filter(move |item| {
                     item.name
                         .as_deref()
-                        .map(|name| trait_provided_methods.contains(name))
+                        .map(|name| {
+                            trait_provided_methods.contains(name) && !impl_item_names.contains(name)
+                        })
                         .unwrap_or_default()
                 })
                 .map(move |provided_item| {
@@ -397,18 +431,7 @@ fn build_impl_index(index: &HashMap<Id, Item>) -> MapList<ImplEntry<'_>, (&Item,
                     )
                 });
 
-            #[cfg(feature = "rayon")]
-            let impl_items = impl_inner.items.par_iter();
-            #[cfg(not(feature = "rayon"))]
-            let impl_items = impl_inner.items.iter();
-
-            impl_items
-                .filter_map(move |item_id| {
-                    let item = index.get(item_id)?;
-                    let item_name = item.name.as_deref()?;
-                    Some((ImplEntry::new(id, item_name), (impl_item, item)))
-                })
-                .chain(trait_provided_items)
+            impl_entries.chain(trait_provided_items)
         })
     })
     .collect()
@@ -426,7 +449,7 @@ impl<'a> IndexedCrate<'a> {
             sized_trait,
             flags: None,
             imports_index: None,
-            impl_index: None,
+            impl_method_index: None,
             fn_owner_index: None,
             export_name_index: None,
         };
@@ -467,7 +490,7 @@ impl<'a> IndexedCrate<'a> {
         value.flags = Some(build_flags_index(&crate_.index, &imports_index));
         value.imports_index = Some(imports_index);
 
-        value.impl_index = Some(build_impl_index(&crate_.index).into_inner());
+        value.impl_method_index = Some(build_impl_index(&crate_.index).into_inner());
         value.fn_owner_index = Some(build_fn_owner_index(&crate_.index));
         value.export_name_index = Some(build_export_name_index(&crate_.index));
 
@@ -2454,6 +2477,65 @@ expected exactly one importable path for `Foo` items in this crate but got: {act
             };
 
             assert_exported_items_match(test_crate, &expected_items);
+        }
+    }
+
+    mod index_tests {
+        use itertools::Itertools;
+
+        use crate::{indexed_crate::ImplEntry, test_util::load_pregenerated_rustdoc, IndexedCrate};
+
+        #[test]
+        fn defaulted_trait_items_overridden_in_impls_have_single_item_in_index() {
+            let test_crate = "defaulted_trait_items_overridden_in_impls";
+
+            let rustdoc = load_pregenerated_rustdoc(test_crate);
+            let indexed_crate = IndexedCrate::new(&rustdoc);
+
+            let impl_owner = indexed_crate
+                .inner
+                .index
+                .values()
+                .filter(|item| item.name.as_deref() == Some("Example"))
+                .exactly_one()
+                .expect("failed to find exactly one Example item");
+            let trait_item = indexed_crate
+                .inner
+                .index
+                .values()
+                .filter(|item| item.name.as_deref() == Some("Trait"))
+                .exactly_one()
+                .expect("failed to find exactly one Trait item");
+            let trait_provided_items: Vec<_> = match &trait_item.inner {
+                rustdoc_types::ItemEnum::Trait(t) => t
+                    .items
+                    .iter()
+                    .map(|id| &indexed_crate.inner.index[id])
+                    .collect(),
+                _ => unreachable!(),
+            };
+            let trait_provided_method = trait_provided_items
+                .iter()
+                .copied()
+                .filter(|item| matches!(item.inner, rustdoc_types::ItemEnum::Function { .. }))
+                .exactly_one()
+                .expect("more than one provided method");
+
+            let impl_index = indexed_crate
+                .impl_method_index
+                .as_ref()
+                .expect("no impl index was built");
+            let method_entries = impl_index
+                .get(&ImplEntry::new(&impl_owner.id, "method"))
+                .expect("no method entries found");
+
+            // Associated const items aren't part of the `impl_index` at the moment, it's just methods.
+            let const_entries = impl_index.get(&ImplEntry::new(&impl_owner.id, "N"));
+            assert_eq!(const_entries, None, "{const_entries:#?}");
+
+            // There's exactly one provided method and it isn't the trait's default one.
+            assert_eq!(method_entries.len(), 1, "{method_entries:#?}");
+            assert_ne!(method_entries[0].1, trait_provided_method);
         }
     }
 }

--- a/src/item_flags.rs
+++ b/src/item_flags.rs
@@ -1,13 +1,8 @@
-#[cfg(not(feature = "rustc-hash"))]
-use std::collections::HashMap;
-
-#[cfg(feature = "rustc-hash")]
-use rustc_hash::FxHashMap as HashMap;
-
 use rustdoc_types::{Id, Item};
 
 use crate::{
     attributes::Attribute,
+    hashtables::HashMap,
     indexed_crate::{Modifiers, Path},
     sealed_trait,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 mod adapter;
 mod attributes;
 mod exported_name;
+mod hashtables;
 mod indexed_crate;
 mod item_flags;
 mod sealed_trait;

--- a/test_crates/defaulted_trait_items_overridden_in_impls/Cargo.toml
+++ b/test_crates/defaulted_trait_items_overridden_in_impls/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "defaulted_trait_items_overridden_in_impls"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/test_crates/defaulted_trait_items_overridden_in_impls/src/lib.rs
+++ b/test_crates/defaulted_trait_items_overridden_in_impls/src/lib.rs
@@ -1,0 +1,33 @@
+//! Ensuring that defaulted items overridden by the impl don't show up twice in queries.
+//!
+//! It is not allowed for a `const` and `method` to have the same name.
+//! ```compile_fail
+//! pub trait DefaultedType {
+//!     const N: usize = 0;
+//!
+//!     fn N() {}
+//! }
+//! ```
+//!
+//! As of today, associated type defaults are unstable and don't compile.
+//! ```compile_fail
+//! pub trait DefaultedType {
+//!     type Item = i64;
+//! }
+//! ```
+
+pub trait Trait {
+    const N: usize = 0;
+
+    fn method() {}
+}
+
+struct Example;
+
+impl Trait for Example {
+    const N: usize = 1;
+
+    fn method() {
+        println!("hello world!");
+    }
+}


### PR DESCRIPTION
Ensure we don't get duplicate items when looking up items by name.

- **Omit trait-provided items from `impl_index` when overridden in
`impl`.**
- **Rename `impl_index` to `impl_method_index` to reflect its role.**
