### PR TITLE
Include functions' `#[target_feature]` data in the schema. (#861)

### DIFF
--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -1,4 +1,4 @@
-use std::{num::NonZeroUsize, rc::Rc};
+use std::{collections::BTreeSet, num::NonZeroUsize, rc::Rc};
 
 use rustdoc_types::{
     GenericBound::TraitBound, GenericParamDefKind, Id, ItemEnum, VariantKind, WherePredicate,
@@ -8,7 +8,12 @@ use trustfall::provider::{
     VertexIterator,
 };
 
-use crate::{adapter::supported_item_kind, attributes::Attribute, PackageIndex};
+use crate::{
+    adapter::supported_item_kind,
+    attributes::Attribute,
+    hashtables::{HashMap, HashSet},
+    PackageIndex,
+};
 
 use super::{
     enum_variant::LazyDiscriminants,
@@ -1127,5 +1132,132 @@ pub(super) fn resolve_feature_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
             )
         }),
         _ => unreachable!("resolve_feature_edge {edge_name}"),
+    }
+}
+
+pub(super) fn resolve_requires_target_feature_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
+    contexts: ContextIterator<'a, V>,
+    current_crate: &'a PackageIndex<'a>,
+    previous_crate: Option<&'a PackageIndex<'a>>,
+) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
+    resolve_neighbors_with(contexts, move |vertex| {
+        let origin = vertex.origin;
+        let item = vertex.as_item().expect("vertex was not an Item");
+
+        let features_lookup = match origin {
+            Origin::CurrentCrate => &current_crate.own_crate.target_features,
+            Origin::PreviousCrate => {
+                &previous_crate
+                    .expect("no previous crate provided")
+                    .own_crate
+                    .target_features
+            }
+        };
+
+        let enabled_features = item
+            .attrs
+            .iter()
+            .filter(|&attr| attr.contains("target_feature"))
+            .filter_map(|attr| {
+                let attr = Attribute::new(attr.as_str());
+                if attr.content.base != "target_feature" {
+                    return None;
+                }
+
+                if let Some(args) = attr.content.arguments.as_ref() {
+                    for arg in args {
+                        if arg.base != "enable" {
+                            continue;
+                        }
+
+                        if let Some(feature_list) = arg.assigned_item {
+                            let feature_list = feature_list.trim().trim_matches('"').trim();
+                            return Some(feature_list.split(",").map(|feature| feature.trim()));
+                        }
+                    }
+                }
+
+                None
+            })
+            .flatten()
+            .map(|feature_name| {
+                features_lookup
+                    .get(feature_name)
+                    .copied()
+                    .unwrap_or_else(|| panic!("unrecognized target feature \"{feature_name}\""))
+            });
+
+        let resolver = TargetFeatureResolver::new(enabled_features, features_lookup);
+        Box::new(<TargetFeatureResolver<'_, _> as Iterator>::map(
+            resolver,
+            move |(feature, explicit)| origin.make_required_target_feature(feature, explicit),
+        ))
+    })
+}
+
+struct TargetFeatureResolver<'a, T> {
+    enabled_features: T,
+    features_lookup: &'a HashMap<&'a str, &'a rustdoc_types::TargetFeature>,
+    produced_features: HashSet<&'a str>,
+    implied_features: BTreeSet<&'a str>, // we return items from this set, we need determinism
+}
+
+impl<'a, T> TargetFeatureResolver<'a, T> {
+    fn new(
+        enabled_features: T,
+        features_lookup: &'a HashMap<&'a str, &'a rustdoc_types::TargetFeature>,
+    ) -> Self {
+        Self {
+            enabled_features,
+            features_lookup,
+            produced_features: Default::default(),
+            implied_features: Default::default(),
+        }
+    }
+}
+
+impl<'a, T> Iterator for TargetFeatureResolver<'a, T>
+where
+    T: Iterator<Item = &'a rustdoc_types::TargetFeature>,
+{
+    type Item = (&'a rustdoc_types::TargetFeature, bool);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(enabled_feature) = self.enabled_features.next() {
+            if self.produced_features.insert(enabled_feature.name.as_str()) {
+                // We have not already produced this feature.
+                // Record its unproduced implied features and produce it.
+                self.implied_features.extend(
+                    enabled_feature
+                        .implies_features
+                        .iter()
+                        .map(String::as_str)
+                        .filter(|feat| !self.produced_features.contains(feat)),
+                );
+
+                return Some((enabled_feature, true));
+            }
+        }
+
+        // We've run out of explicitly enabled features.
+        // Go through implicitly enabled ones.
+        while let Some(feature_name) = self.implied_features.pop_first() {
+            if self.produced_features.insert(feature_name) {
+                // We have not already produced this feature.
+                // Record its unproduced implied features and produce it.
+                let enabled_feature = &self.features_lookup[feature_name];
+                self.implied_features.extend(
+                    enabled_feature
+                        .implies_features
+                        .iter()
+                        .map(String::as_str)
+                        .filter(|feat| !self.produced_features.contains(feat)),
+                );
+
+                return Some((enabled_feature, false));
+            }
+        }
+
+        None
     }
 }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -228,6 +228,9 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
                     properties::resolve_generic_const_parameter_property(contexts, property_name)
                 }
                 "Receiver" => properties::resolve_receiver_property(contexts, property_name),
+                "RequiredTargetFeature" => {
+                    properties::resolve_required_target_feature_property(contexts, property_name)
+                }
                 _ => unreachable!("resolve_property {type_name} {property_name}"),
             }
         }
@@ -318,6 +321,13 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
             }
             "Method" if matches!(edge_name.as_ref(), "receiver") => {
                 edges::resolve_receiver_edge(contexts, edge_name)
+            }
+            "Function" | "Method" if matches!(edge_name.as_ref(), "requires_feature") => {
+                edges::resolve_requires_target_feature_edge(
+                    contexts,
+                    self.current_crate,
+                    self.previous_crate,
+                )
             }
             "Module" => edges::resolve_module_edge(
                 contexts,

--- a/src/adapter/origin.rs
+++ b/src/adapter/origin.rs
@@ -171,4 +171,15 @@ impl Origin {
             kind: VertexKind::Receiver(receiver),
         }
     }
+
+    pub(super) fn make_required_target_feature<'a>(
+        &self,
+        feature: &'a rustdoc_types::TargetFeature,
+        explicit: bool,
+    ) -> Vertex<'a> {
+        Vertex {
+            origin: *self,
+            kind: VertexKind::RequiredTargetFeature(feature, explicit),
+        }
+    }
 }

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -906,3 +906,30 @@ pub(crate) fn resolve_generic_const_parameter_property<'a, V: AsVertex<Vertex<'a
         _ => unreachable!("GenericConstParameter property {property_name}"),
     }
 }
+
+pub(crate) fn resolve_required_target_feature_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
+    contexts: ContextIterator<'a, V>,
+    property_name: &str,
+) -> ContextOutcomeIterator<'a, V, FieldValue> {
+    match property_name {
+        "name" => resolve_property_with(contexts, |vertex| {
+            let (feature, _) = vertex
+                .as_required_target_feature()
+                .expect("vertex was not a RequiredTargetFeature");
+            feature.name.as_str().into()
+        }),
+        "explicit" => resolve_property_with(contexts, |vertex| {
+            let (_, explicit) = vertex
+                .as_required_target_feature()
+                .expect("vertex was not a RequiredTargetFeature");
+            explicit.into()
+        }),
+        "globally_enabled" => resolve_property_with(contexts, |vertex| {
+            let (feature, _) = vertex
+                .as_required_target_feature()
+                .expect("vertex was not a RequiredTargetFeature");
+            feature.globally_enabled.into()
+        }),
+        _ => unreachable!("RequiredTargetFeature property {property_name}"),
+    }
+}

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -7190,3 +7190,427 @@ fn rustdoc_method_export_name() {
 
     similar_asserts::assert_eq!(expected_results, results,);
 }
+
+#[test]
+fn target_feature() {
+    get_test_data!(data, target_feature);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let top_level_query = r#"
+{
+    Crate {
+        item {
+            ... on Function {
+                name @output
+
+                requires_feature {
+                    feature: name @output
+                    explicit @output
+                    globally_enabled @output
+                }
+            }
+        }
+    }
+}
+"#;
+    let impl_owner_inherent_methods = r#"
+{
+    Crate {
+        item {
+            ... on ImplOwner {
+                inherent_impl {
+                    method {
+                        name @output
+
+                        requires_feature {
+                            feature: name @output
+                            explicit @output
+                            globally_enabled @output
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+    let trait_methods_query = r#"
+{
+    Crate {
+        item {
+            ... on Trait {
+                method {
+                    name @output
+
+                    requires_feature {
+                        feature: name @output
+                        explicit @output
+                        globally_enabled @output
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+
+    let variables: BTreeMap<&str, i64> = BTreeMap::default();
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        feature: String,
+        explicit: bool,
+        globally_enabled: bool,
+    }
+
+    let mut results: Vec<Output> =
+        trustfall::execute_query(&schema, adapter.clone(), top_level_query, variables.clone())
+            .expect("failed to run top level query")
+            .chain(
+                trustfall::execute_query(
+                    &schema,
+                    adapter.clone(),
+                    impl_owner_inherent_methods,
+                    variables.clone(),
+                )
+                .expect("failed to run impl owner inherent methods query"),
+            )
+            .chain(
+                trustfall::execute_query(
+                    &schema,
+                    adapter.clone(),
+                    trait_methods_query,
+                    variables.clone(),
+                )
+                .expect("failed to run trait methods query"),
+            )
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+
+    // Ensure that the results are in sorted order, and also that the aggregated bounds are sorted.
+    results.sort_unstable();
+
+    // We write the results in the order the items appear in the test file,
+    // and sort them afterward in order to compare with the (sorted) query results.
+    // This makes it easier to verify that the expected data here is correct
+    // by reading it side-by-side with the file.
+    let mut expected_results = vec![
+        Output {
+            name: "top_level_fn".into(),
+            feature: "sse2".into(),
+            explicit: true,
+            globally_enabled: true,
+        },
+        Output {
+            name: "top_level_fn".into(),
+            feature: "avx".into(),
+            explicit: true,
+            globally_enabled: false,
+        },
+        Output {
+            name: "top_level_fn".into(),
+            feature: "sse".into(),
+            explicit: false,
+            globally_enabled: true,
+        },
+        Output {
+            name: "top_level_fn".into(),
+            feature: "sse3".into(),
+            explicit: false,
+            globally_enabled: false,
+        },
+        Output {
+            name: "top_level_fn".into(),
+            feature: "sse4.1".into(),
+            explicit: false,
+            globally_enabled: false,
+        },
+        Output {
+            name: "top_level_fn".into(),
+            feature: "sse4.2".into(),
+            explicit: false,
+            globally_enabled: false,
+        },
+        Output {
+            name: "top_level_fn".into(),
+            feature: "ssse3".into(),
+            explicit: false,
+            globally_enabled: false,
+        },
+        Output {
+            name: "unsafe_top_level_fn".into(),
+            feature: "sse2".into(),
+            explicit: true,
+            globally_enabled: true,
+        },
+        Output {
+            name: "unsafe_top_level_fn".into(),
+            feature: "avx".into(),
+            explicit: true,
+            globally_enabled: false,
+        },
+        Output {
+            name: "unsafe_top_level_fn".into(),
+            feature: "avx2".into(),
+            explicit: true,
+            globally_enabled: false,
+        },
+        Output {
+            name: "unsafe_top_level_fn".into(),
+            feature: "sse".into(),
+            explicit: false,
+            globally_enabled: true,
+        },
+        Output {
+            name: "unsafe_top_level_fn".into(),
+            feature: "sse3".into(),
+            explicit: false,
+            globally_enabled: false,
+        },
+        Output {
+            name: "unsafe_top_level_fn".into(),
+            feature: "sse4.1".into(),
+            explicit: false,
+            globally_enabled: false,
+        },
+        Output {
+            name: "unsafe_top_level_fn".into(),
+            feature: "sse4.2".into(),
+            explicit: false,
+            globally_enabled: false,
+        },
+        Output {
+            name: "unsafe_top_level_fn".into(),
+            feature: "ssse3".into(),
+            explicit: false,
+            globally_enabled: false,
+        },
+        Output {
+            name: "implies_avx".into(),
+            feature: "sse2".into(),
+            explicit: true,
+            globally_enabled: true,
+        },
+        Output {
+            name: "implies_avx".into(),
+            feature: "avx2".into(),
+            explicit: true,
+            globally_enabled: false,
+        },
+        Output {
+            name: "implies_avx".into(),
+            feature: "avx".into(),
+            explicit: false,
+            globally_enabled: false,
+        },
+        Output {
+            name: "implies_avx".into(),
+            feature: "sse".into(),
+            explicit: false,
+            globally_enabled: true,
+        },
+        Output {
+            name: "implies_avx".into(),
+            feature: "sse3".into(),
+            explicit: false,
+            globally_enabled: false,
+        },
+        Output {
+            name: "implies_avx".into(),
+            feature: "sse4.1".into(),
+            explicit: false,
+            globally_enabled: false,
+        },
+        Output {
+            name: "implies_avx".into(),
+            feature: "sse4.2".into(),
+            explicit: false,
+            globally_enabled: false,
+        },
+        Output {
+            name: "implies_avx".into(),
+            feature: "ssse3".into(),
+            explicit: false,
+            globally_enabled: false,
+        },
+        Output {
+            name: "struct_method".into(),
+            feature: "sse2".into(),
+            explicit: true,
+            globally_enabled: true,
+        },
+        Output {
+            name: "struct_method".into(),
+            feature: "avx".into(),
+            explicit: true,
+            globally_enabled: false,
+        },
+        Output {
+            name: "struct_method".into(),
+            feature: "avx2".into(),
+            explicit: true,
+            globally_enabled: false,
+        },
+        Output {
+            name: "struct_method".into(),
+            feature: "sse".into(),
+            explicit: false,
+            globally_enabled: true,
+        },
+        Output {
+            name: "struct_method".into(),
+            feature: "sse3".into(),
+            explicit: false,
+            globally_enabled: false,
+        },
+        Output {
+            name: "struct_method".into(),
+            feature: "sse4.1".into(),
+            explicit: false,
+            globally_enabled: false,
+        },
+        Output {
+            name: "struct_method".into(),
+            feature: "sse4.2".into(),
+            explicit: false,
+            globally_enabled: false,
+        },
+        Output {
+            name: "struct_method".into(),
+            feature: "ssse3".into(),
+            explicit: false,
+            globally_enabled: false,
+        },
+        Output {
+            name: "unsafe_struct_method".into(),
+            feature: "sse2".into(),
+            explicit: true,
+            globally_enabled: true,
+        },
+        Output {
+            name: "unsafe_struct_method".into(),
+            feature: "sse".into(),
+            explicit: false,
+            globally_enabled: true,
+        },
+        Output {
+            name: "defaulted_trait_method".into(),
+            feature: "sse".into(),
+            explicit: false,
+            globally_enabled: true,
+        },
+        Output {
+            name: "defaulted_trait_method".into(),
+            feature: "sse2".into(),
+            explicit: true,
+            globally_enabled: true,
+        },
+    ];
+    expected_results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+
+    let impl_owner_impld_methods = r#"
+    {
+        Crate {
+            item {
+                ... on ImplOwner {
+                    impl {
+                        implemented_trait {
+                            bare_name @filter(op: "=", value: ["$trait_name"])
+                        }
+
+                        method {
+                            name @output
+
+                            requires_feature {
+                                feature: name @output
+                                explicit @output
+                                globally_enabled @output
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    "#;
+
+    let mut trait_impl_variables: BTreeMap<&str, &str> = BTreeMap::default();
+    trait_impl_variables.insert("trait_name", "Trait");
+
+    let mut results: Vec<Output> = trustfall::execute_query(
+        &schema,
+        adapter.clone(),
+        impl_owner_impld_methods,
+        trait_impl_variables,
+    )
+    .expect("failed to run impl owner impld methods query")
+    .map(|row| row.try_into_struct().expect("shape mismatch"))
+    .collect();
+
+    results.sort_unstable();
+
+    // We write the results in the order the items appear in the test file,
+    // and sort them afterward in order to compare with the (sorted) query results.
+    // This makes it easier to verify that the expected data here is correct
+    // by reading it side-by-side with the file.
+    let mut expected_results = vec![
+        Output {
+            name: "defaulted_trait_method".into(),
+            feature: "sse2".into(),
+            explicit: true,
+            globally_enabled: true,
+        },
+        Output {
+            name: "defaulted_trait_method".into(),
+            feature: "avx".into(),
+            explicit: false,
+            globally_enabled: false,
+        },
+        Output {
+            name: "defaulted_trait_method".into(),
+            feature: "avx2".into(),
+            explicit: true,
+            globally_enabled: false,
+        },
+        Output {
+            name: "defaulted_trait_method".into(),
+            feature: "sse".into(),
+            explicit: false,
+            globally_enabled: true,
+        },
+        Output {
+            name: "defaulted_trait_method".into(),
+            feature: "sse3".into(),
+            explicit: false,
+            globally_enabled: false,
+        },
+        Output {
+            name: "defaulted_trait_method".into(),
+            feature: "sse4.1".into(),
+            explicit: false,
+            globally_enabled: false,
+        },
+        Output {
+            name: "defaulted_trait_method".into(),
+            feature: "sse4.2".into(),
+            explicit: false,
+            globally_enabled: false,
+        },
+        Output {
+            name: "defaulted_trait_method".into(),
+            feature: "ssse3".into(),
+            explicit: false,
+            globally_enabled: false,
+        },
+    ];
+    expected_results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+}

--- a/src/adapter/vertex.rs
+++ b/src/adapter/vertex.rs
@@ -83,6 +83,9 @@ pub enum VertexKind<'a> {
 
     #[non_exhaustive]
     PositionedItem(usize, &'a Item),
+
+    #[non_exhaustive]
+    RequiredTargetFeature(&'a rustdoc_types::TargetFeature, bool),
 }
 
 impl Typename for Vertex<'_> {
@@ -144,6 +147,7 @@ impl Typename for Vertex<'_> {
                 rustdoc_types::GenericParamDefKind::Const { .. } => "GenericConstParameter",
             },
             VertexKind::Feature(..) => "Feature",
+            VertexKind::RequiredTargetFeature(..) => "RequiredTargetFeature",
         }
     }
 }
@@ -398,6 +402,15 @@ impl<'a> Vertex<'a> {
     pub(super) fn as_receiver(&self) -> Option<&Receiver<'a>> {
         match &self.kind {
             VertexKind::Receiver(receiver) => Some(receiver),
+            _ => None,
+        }
+    }
+
+    pub(super) fn as_required_target_feature(
+        &self,
+    ) -> Option<(&'a rustdoc_types::TargetFeature, bool)> {
+        match &self.kind {
+            VertexKind::RequiredTargetFeature(feature, explicit) => Some((*feature, *explicit)),
             _ => None,
         }
     }

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -221,6 +221,9 @@ pub struct IndexedCrate<'a> {
     /// The ID of the built-in `core::marker::Sized` trait.
     /// Used for analyzing `?Sized` generic types.
     pub(crate) sized_trait: Id,
+
+    /// Target feature information about our current target triple.
+    pub(crate) target_features: HashMap<&'a str, &'a rustdoc_types::TargetFeature>,
 }
 
 /// Map a Key to a List (Vec) of values
@@ -442,6 +445,13 @@ impl<'a> IndexedCrate<'a> {
         let (manually_inlined_builtin_traits, sized_trait) =
             create_manually_inlined_builtin_traits(crate_);
 
+        let target_features = crate_
+            .target
+            .target_features
+            .iter()
+            .map(|feat| (feat.name.as_str(), feat))
+            .collect();
+
         let mut value = Self {
             inner: crate_,
             visibility_tracker: VisibilityTracker::from_crate(crate_),
@@ -452,6 +462,7 @@ impl<'a> IndexedCrate<'a> {
             impl_method_index: None,
             fn_owner_index: None,
             export_name_index: None,
+            target_features,
         };
 
         debug_assert!(

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -1459,6 +1459,37 @@ type FunctionAbi {
 }
 
 """
+A feature that must be enabled in order for a function to be valid to use.
+
+For example, the following function explicitly requires the `"sse2"` feature:
+```
+#[target_feature(enable = "sse2")]
+fn example() { }
+```
+
+Different target triples and Rust versions globally enable different combinations of features.
+Target features may be enabled explicitly, or might be implied by another enabled feature.
+"""
+type RequiredTargetFeature {
+  """
+  The feature's name.
+
+  For example, in `#[target_feature(enable = "sse2")]`, this property's value is `"sse2"`.
+  """
+  name: String!
+
+  """
+  Whether the target feature is explicitly enabled, or is implied by another feature.
+  """
+  explicit: Boolean!
+
+  """
+  Whether the feature is already globally enabled on the current target triple.
+  """
+  globally_enabled: Boolean!
+}
+
+"""
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Item.html
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/enum.ItemEnum.html
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Function.html
@@ -1567,6 +1598,18 @@ type Function implements Item & FunctionLike & Importable & ExportableFunction &
   since its desugaring is different: it's more like an associated type than a generic.
   """
   generic_parameter: [GenericParameter]
+
+  # own edges
+  """
+  The target features this function requires to be enabled in order for calling it to be valid.
+
+  For example, the following function explicitly requires the `"sse2"` feature:
+  ```
+  #[target_feature(enable = "sse2")]
+  fn example() { }
+  ```
+  """
+  requires_feature: [RequiredTargetFeature!]
 }
 
 """
@@ -1687,6 +1730,17 @@ type Method implements Item & FunctionLike & GenericItem {
   The kind of `self` value that the method takes, if any.
   """
   receiver: Receiver
+
+  """
+  The target features this method requires to be enabled in order for calling it to be valid.
+
+  For example, the following function explicitly requires the `"sse2"` feature:
+  ```
+  #[target_feature(enable = "sse2")]
+  fn example() { }
+  ```
+  """
+  requires_feature: [RequiredTargetFeature!]
 }
 
 """

--- a/test_crates/target_feature/Cargo.toml
+++ b/test_crates/target_feature/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "target_feature"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/test_crates/target_feature/src/lib.rs
+++ b/test_crates/target_feature/src/lib.rs
@@ -1,0 +1,63 @@
+//! Using `#[target_feature]` on functions and methods.
+//!
+//! Certain combinations don't compile.
+//!
+//! - Having whitespace in the feature list:
+//! ```compile_fail
+//! #[target_feature(enable = "sse2, avx")]
+//! pub fn features_with_spaces() {}
+//! ```
+//!
+//! - `#[target_feature]` featuring unrecognized features
+//! ```compile_fail
+//! pub trait Trait {
+//!     #[target_feature(enable = "unrecognized")]
+//!     fn non_defaulted_method();
+//! }
+//! ```
+//!
+//! - `#[target_feature]` on safe trait associated functions
+//! ```compile_fail
+//! pub trait Trait {
+//!     #[target_feature(enable = "sse2")]
+//!     fn safe_trait_method() {}
+//! }
+//! ```
+//!
+//! - `#[target_feature]` on trait associated functions without default impls
+//! ```compile_fail
+//! pub trait Trait {
+//!     #[target_feature(enable = "sse2")]
+//!     fn non_defaulted_method();
+//! }
+//! ```
+
+#[target_feature(enable = "sse2,avx")]
+pub fn top_level_fn() {}
+
+#[target_feature(enable = "sse2,avx,avx2")]
+pub unsafe fn unsafe_top_level_fn() {}
+
+#[target_feature(enable = "sse2,avx2")]
+pub fn implies_avx() {}
+
+pub struct Example;
+
+impl Example {
+    #[target_feature(enable = "sse2,avx,avx2")]
+    pub fn struct_method() {}
+
+    #[target_feature(enable = "sse2")]
+    pub unsafe fn unsafe_struct_method() {}
+}
+
+pub trait Trait {
+    #[target_feature(enable = "sse2")]
+    unsafe fn defaulted_trait_method() {}
+}
+
+impl Trait for Example {
+    // Enable more features than the trait described.
+    #[target_feature(enable = "sse2,avx2")]
+    unsafe fn defaulted_trait_method() {}
+}


### PR DESCRIPTION
Based on #860 but without the 3rd party dependency, and instead using
rustdoc JSON's own target data.

- **Use 3rd party crate to expose target feature data.**
- **Implement `RequiredTargetFeature` in the adapter.**
- **Add test cases, fix bugs.**
- **Update new test.**
- **Use `hashtables` imports.**
- **Remove debugging output.**
- **Update target feature code for rustdoc that carries that info
inside.**