### PR TITLE
Add a per-item-kind index of public items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,9 +312,9 @@ checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -749,6 +749,7 @@ dependencies = [
  "cargo_metadata",
  "cargo_toml",
  "criterion",
+ "indexmap",
  "itertools 0.13.0",
  "maplit",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ cargo_toml = { version = "0.21.0", features = ["features"] }
 #
 trustfall = "0.8.0"
 cargo_metadata = "0.19.1"
+indexmap = "2.10.0"
 
 #
 # Keep this dependency last, its own block, since we change it often via automated means

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ rayon = ["dep:rayon"]
 # Use rustc-hash::{FxHashMap, FxHashSet} internally for improved performance
 rustc-hash = ["dep:rustc-hash", "rustdoc-types/rustc-hash"]
 
-
 [[bench]]
 name = "indexed_crate"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,12 +39,15 @@ rayon = ["dep:rayon"]
 # Use rustc-hash::{FxHashMap, FxHashSet} internally for improved performance
 rustc-hash = ["dep:rustc-hash", "rustdoc-types/rustc-hash"]
 
+
 [[bench]]
 name = "indexed_crate"
 harness = false
 
 [profile.bench]
 debug = 1 # We only need function name information (for flamegraphs)
+lto = "thin"
+codegen-units = 1
 
 [dev-dependencies]
 anyhow = "1.0.89"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ harness = false
 [profile.bench]
 debug = 1 # We only need function name information (for flamegraphs)
 lto = "thin"
-codegen-units = 1
 
 [dev-dependencies]
 anyhow = "1.0.89"

--- a/benches/indexed_crate.rs
+++ b/benches/indexed_crate.rs
@@ -8,8 +8,12 @@ use trustfall_rustdoc_adapter::IndexedCrate;
 fn new(c: &mut Criterion) {
     let mut group = c.benchmark_group("IndexedCrate");
     let crate_ = get_aws_sdk_crate();
+    group.sample_size(10);
     group.bench_function("new(aws-sdk-ec2)", |b| {
         b.iter_with_large_drop(|| IndexedCrate::new(crate_))
+    });
+    group.bench_function("new-parallel(aws-sdk-ec2)", |b| {
+        b.iter_with_large_drop(|| IndexedCrate::new_parallel(crate_))
     });
     group.finish();
 }

--- a/benches/indexed_crate.rs
+++ b/benches/indexed_crate.rs
@@ -12,9 +12,6 @@ fn new(c: &mut Criterion) {
     group.bench_function("new(aws-sdk-ec2)", |b| {
         b.iter_with_large_drop(|| IndexedCrate::new(crate_))
     });
-    group.bench_function("new-parallel(aws-sdk-ec2)", |b| {
-        b.iter_with_large_drop(|| IndexedCrate::new_parallel(crate_))
-    });
     group.finish();
 }
 

--- a/benches/indexed_crate.rs
+++ b/benches/indexed_crate.rs
@@ -8,7 +8,6 @@ use trustfall_rustdoc_adapter::IndexedCrate;
 fn new(c: &mut Criterion) {
     let mut group = c.benchmark_group("IndexedCrate");
     let crate_ = get_aws_sdk_crate();
-    group.sample_size(10);
     group.bench_function("new(aws-sdk-ec2)", |b| {
         b.iter_with_large_drop(|| IndexedCrate::new(crate_))
     });

--- a/src/adapter/optimizations/item_lookup.rs
+++ b/src/adapter/optimizations/item_lookup.rs
@@ -8,6 +8,7 @@ use trustfall::{
 };
 
 use super::super::{RustdocAdapter, origin::Origin, vertex::Vertex};
+use std::sync::Arc;
 
 use crate::IndexedCrate;
 
@@ -31,16 +32,26 @@ pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
         // statically vs dynamically, so we check the dynamic case first since
         // it might be more specific.
         if let Some(dynamic_value) = neighbor_info.dynamically_required_property("path") {
-            return dynamic_value.resolve_with(&adapter, contexts, |vertex, candidate| {
+            return dynamic_value.resolve_with(&adapter, contexts, move |vertex, candidate| {
                 let crate_vertex = vertex.as_indexed_crate().expect("vertex was not a Crate");
                 let origin = vertex.origin;
-                resolve_items_by_importable_path(crate_vertex, origin, candidate)
+                resolve_items_by_importable_path(
+                    crate_vertex,
+                    origin,
+                    destination.coerced_to_type().cloned(),
+                    candidate,
+                )
             });
         } else if let Some(path_value) = neighbor_info.statically_required_property("path") {
             return resolve_neighbors_with(contexts, move |vertex| {
                 let crate_vertex = vertex.as_indexed_crate().expect("vertex was not a Crate");
                 let origin = vertex.origin;
-                resolve_items_by_importable_path(crate_vertex, origin, path_value.clone())
+                resolve_items_by_importable_path(
+                    crate_vertex,
+                    origin,
+                    destination.coerced_to_type().cloned(),
+                    path_value.clone(),
+                )
             });
         }
     }
@@ -83,10 +94,10 @@ pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
                             crate_vertex
                                 .pub_item_kind_index
                                 .free_functions
-                                .iter()
+                                .values()
                                 .map(move |item| origin.make_item_vertex(item)),
                         )
-                    })
+                    });
                 }
                 "Struct" => {
                     return resolve_neighbors_with(contexts, move |vertex| {
@@ -97,10 +108,10 @@ pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
                             crate_vertex
                                 .pub_item_kind_index
                                 .structs
-                                .iter()
+                                .values()
                                 .map(move |item| origin.make_item_vertex(item)),
                         )
-                    })
+                    });
                 }
                 "Enum" => {
                     return resolve_neighbors_with(contexts, move |vertex| {
@@ -111,10 +122,10 @@ pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
                             crate_vertex
                                 .pub_item_kind_index
                                 .enums
-                                .iter()
+                                .values()
                                 .map(move |item| origin.make_item_vertex(item)),
                         )
-                    })
+                    });
                 }
                 "Union" => {
                     return resolve_neighbors_with(contexts, move |vertex| {
@@ -125,10 +136,10 @@ pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
                             crate_vertex
                                 .pub_item_kind_index
                                 .unions
-                                .iter()
+                                .values()
                                 .map(move |item| origin.make_item_vertex(item)),
                         )
-                    })
+                    });
                 }
                 "Trait" => {
                     return resolve_neighbors_with(contexts, move |vertex| {
@@ -139,10 +150,10 @@ pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
                             crate_vertex
                                 .pub_item_kind_index
                                 .traits
-                                .iter()
+                                .values()
                                 .map(move |item| origin.make_item_vertex(item)),
                         )
-                    })
+                    });
                 }
                 "ImplOwner" => {
                     return resolve_neighbors_with(contexts, move |vertex| {
@@ -153,12 +164,12 @@ pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
                             crate_vertex
                                 .pub_item_kind_index
                                 .structs
-                                .iter()
-                                .chain(crate_vertex.pub_item_kind_index.enums.iter())
-                                .chain(crate_vertex.pub_item_kind_index.unions.iter())
+                                .values()
+                                .chain(crate_vertex.pub_item_kind_index.enums.values())
+                                .chain(crate_vertex.pub_item_kind_index.unions.values())
                                 .map(move |item| origin.make_item_vertex(item)),
                         )
-                    })
+                    });
                 }
                 "Constant" => {
                     return resolve_neighbors_with(contexts, move |vertex| {
@@ -169,10 +180,10 @@ pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
                             crate_vertex
                                 .pub_item_kind_index
                                 .free_consts
-                                .iter()
+                                .values()
                                 .map(move |item| origin.make_item_vertex(item)),
                         )
-                    })
+                    });
                 }
                 "Static" => {
                     return resolve_neighbors_with(contexts, move |vertex| {
@@ -183,10 +194,10 @@ pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
                             crate_vertex
                                 .pub_item_kind_index
                                 .statics
-                                .iter()
+                                .values()
                                 .map(move |item| origin.make_item_vertex(item)),
                         )
-                    })
+                    });
                 }
                 "GlobalValue" => {
                     // const or static
@@ -198,8 +209,8 @@ pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
                             crate_vertex
                                 .pub_item_kind_index
                                 .free_consts
-                                .iter()
-                                .chain(crate_vertex.pub_item_kind_index.statics.iter())
+                                .values()
+                                .chain(crate_vertex.pub_item_kind_index.statics.values())
                                 .map(move |item| origin.make_item_vertex(item)),
                         )
                     });
@@ -213,10 +224,10 @@ pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
                             crate_vertex
                                 .pub_item_kind_index
                                 .decl_macros
-                                .iter()
+                                .values()
                                 .map(move |item| origin.make_item_vertex(item)),
                         )
-                    })
+                    });
                 }
                 "ProcMacro"
                 | "FunctionLikeProcMacro"
@@ -230,10 +241,10 @@ pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
                             crate_vertex
                                 .pub_item_kind_index
                                 .proc_macros
-                                .iter()
+                                .values()
                                 .map(move |item| origin.make_item_vertex(item)),
                         )
-                    })
+                    });
                 }
                 "Module" => {
                     return resolve_neighbors_with(contexts, move |vertex| {
@@ -244,10 +255,10 @@ pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
                             crate_vertex
                                 .pub_item_kind_index
                                 .modules
-                                .iter()
+                                .values()
                                 .map(move |item| origin.make_item_vertex(item)),
                         )
-                    })
+                    });
                 }
                 _ => {}
             }
@@ -264,15 +275,24 @@ pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
 fn resolve_items_by_importable_path<'a>(
     crate_vertex: &'a IndexedCrate,
     origin: Origin,
+    destination_type: Option<Arc<str>>,
     importable_path: CandidateValue<FieldValue>,
 ) -> VertexIterator<'a, Vertex<'a>> {
     match importable_path {
         CandidateValue::Impossible => Box::new(std::iter::empty()),
-        CandidateValue::Single(value) => {
-            resolve_items_by_importable_path_field_value(crate_vertex, origin, &value)
-        }
+        CandidateValue::Single(value) => resolve_items_by_importable_path_field_value(
+            crate_vertex,
+            origin,
+            destination_type,
+            &value,
+        ),
         CandidateValue::Multiple(values) => Box::new(values.into_iter().flat_map(move |value| {
-            resolve_items_by_importable_path_field_value(crate_vertex, origin, &value)
+            resolve_items_by_importable_path_field_value(
+                crate_vertex,
+                origin,
+                destination_type.clone(),
+                &value,
+            )
         })),
         _ => {
             // fall through to slow path
@@ -284,6 +304,7 @@ fn resolve_items_by_importable_path<'a>(
 fn resolve_items_by_importable_path_field_value<'a>(
     crate_vertex: &'a IndexedCrate,
     origin: Origin,
+    destination_type: Option<Arc<str>>,
     value: &FieldValue,
 ) -> VertexIterator<'a, Vertex<'a>> {
     let path_components: Vec<&str> = value
@@ -298,7 +319,18 @@ fn resolve_items_by_importable_path_field_value<'a>(
         .expect("crate's imports_index was never constructed")
         .get(path_components.as_slice())
     {
-        resolve_item_vertices(origin, items.iter().map(|(item, _)| item).copied())
+        resolve_item_vertices(
+            origin,
+            items
+                .iter()
+                .map(|(item, _)| item)
+                .copied()
+                .filter(move |item| {
+                    crate_vertex
+                        .pub_item_kind_index
+                        .contains(destination_type.clone(), item.id)
+                }),
+        )
     } else {
         // No such items found.
         Box::new(std::iter::empty())

--- a/src/adapter/optimizations/item_lookup.rs
+++ b/src/adapter/optimizations/item_lookup.rs
@@ -288,14 +288,14 @@ fn resolve_items_by_importable_path<'a>(
         CandidateValue::Single(value) => resolve_items_by_importable_path_field_value(
             crate_vertex,
             origin,
-            destination_type,
+            destination_type.as_deref(),
             &value,
         ),
         CandidateValue::Multiple(values) => Box::new(values.into_iter().flat_map(move |value| {
             resolve_items_by_importable_path_field_value(
                 crate_vertex,
                 origin,
-                destination_type.clone(),
+                destination_type.as_deref(),
                 &value,
             )
         })),
@@ -306,17 +306,20 @@ fn resolve_items_by_importable_path<'a>(
     }
 }
 
-/// Resolve public items with path `importable_path` and type `destination_type`.
+/// Resolve public items with importable path `path`, optionally of vertex type `destination_type`.
 ///
-/// If the destination is None or an unrecognised string, we conservatively return all
-/// paths that match the `value`.
+/// For example, "structs at path `foo::bar`" or "anything at `foo::bar`".
+/// The former has destination type `Some("Struct")`, while the latter has `None`.
+///
+/// When the destination is `None` or the name of a type that we don't have an index for,
+/// we conservatively return all paths that match the `value`.
 fn resolve_items_by_importable_path_field_value<'a>(
     crate_vertex: &'a IndexedCrate,
     origin: Origin,
-    destination_type: Option<Arc<str>>,
-    value: &FieldValue,
+    destination_type: Option<&str>,
+    path: &FieldValue,
 ) -> VertexIterator<'a, Vertex<'a>> {
-    let path_components: Vec<&str> = value
+    let path_components: Vec<&str> = path
         .as_slice()
         .expect("ImportablePath.path was not a list")
         .iter()
@@ -330,7 +333,7 @@ fn resolve_items_by_importable_path_field_value<'a>(
     {
         let base_iter = items.iter().map(|(item, _)| item).copied();
         if let Some(destination_type) = destination_type {
-            match destination_type.as_ref() {
+            match destination_type {
                 "Function" => resolve_item_vertices(
                     origin,
                     base_iter.filter(move |item| {
@@ -456,16 +459,20 @@ fn resolve_items_by_importable_path_field_value<'a>(
                     }),
                 ),
                 _ => {
+                    // No index is available for this type.
+                    //
                     // If this branch is reached inside time sensitive code, consider
                     // adding the destination type to an index.
                     resolve_item_vertices(origin, base_iter)
                 }
             }
         } else {
+            // This query doesn't apply a coercion on the resulting vertex,
+            // so we produce all vertices that matched the path lookup.
             resolve_item_vertices(origin, base_iter)
         }
     } else {
-        // No such items found.
+        // No items at found at the given path.
         Box::new(std::iter::empty())
     }
 }

--- a/src/adapter/optimizations/item_lookup.rs
+++ b/src/adapter/optimizations/item_lookup.rs
@@ -65,6 +65,195 @@ pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
         }
     }
 
+    // Is the `importable_path` edge being resolved in a subsequent step in a *mandatory* fashion?
+    // If so, we could only match on public items, so check which kinds of public items
+    // we're looking for and only return those from the index.
+    if destination
+        .first_mandatory_edge("importable_path")
+        .is_some()
+    {
+        if let Some(item_type) = destination.coerced_to_type().map(|x| x.as_ref()) {
+            match item_type {
+                "Function" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .free_functions
+                                .iter()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    })
+                }
+                "Struct" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .structs
+                                .iter()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    })
+                }
+                "Enum" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .enums
+                                .iter()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    })
+                }
+                "Union" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .unions
+                                .iter()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    })
+                }
+                "Trait" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .traits
+                                .iter()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    })
+                }
+                "ImplOwner" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .structs
+                                .iter()
+                                .chain(crate_vertex.pub_item_kind_index.enums.iter())
+                                .chain(crate_vertex.pub_item_kind_index.unions.iter())
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    })
+                }
+                "Constant" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .free_consts
+                                .iter()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    })
+                }
+                "Static" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .statics
+                                .iter()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    })
+                }
+                "GlobalValue" => {
+                    // const or static
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .free_consts
+                                .iter()
+                                .chain(crate_vertex.pub_item_kind_index.statics.iter())
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    });
+                }
+                "Macro" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .decl_macros
+                                .iter()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    })
+                }
+                "ProcMacro"
+                | "FunctionLikeProcMacro"
+                | "AttributeProcMacro"
+                | "DeriveProcMacro" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .proc_macros
+                                .iter()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    })
+                }
+                "Module" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .modules
+                                .iter()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    })
+                }
+                _ => {}
+            }
+        }
+    }
+
     resolve_neighbors_with(contexts, |vertex| {
         let crate_vertex = vertex.as_indexed_crate().expect("vertex was not a Crate");
         let origin = vertex.origin;

--- a/src/adapter/optimizations/item_lookup.rs
+++ b/src/adapter/optimizations/item_lookup.rs
@@ -273,6 +273,8 @@ pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
     })
 }
 
+/// Resolve items with the given value (ImportablePath), keeping only public
+/// items that match the destination_type.
 fn resolve_items_by_importable_path<'a>(
     crate_vertex: &'a IndexedCrate,
     origin: Origin,
@@ -302,6 +304,8 @@ fn resolve_items_by_importable_path<'a>(
     }
 }
 
+/// Resolve items with the given value (ImportablePath), keeping only public
+/// items that match the destination_type.
 fn resolve_items_by_importable_path_field_value<'a>(
     crate_vertex: &'a IndexedCrate,
     origin: Origin,
@@ -320,8 +324,8 @@ fn resolve_items_by_importable_path_field_value<'a>(
         .expect("crate's imports_index was never constructed")
         .get(path_components.as_slice())
     {
+        let base_iter = items.iter().map(|(item, _)| item).copied();
         if let Some(destination_type) = destination_type {
-            let base_iter = items.iter().map(|(item, _)| item).copied();
             match destination_type.as_ref() {
                 "Function" => resolve_item_vertices(
                     origin,
@@ -448,19 +452,13 @@ fn resolve_items_by_importable_path_field_value<'a>(
                     }),
                 ),
                 _ => {
-                    // Currently, this function is only called in the context of resolving
-                    // the coercion of a crate to an item. As there are no lints that coerce
-                    // an item to a type other than the ones listed above, this is unreachable.
-                    // If a lint is added that does coerce to a different type, consider adding
-                    // it to the index instead of making this branch reachable.
-                    unreachable!(
-                        "PubItemKindIndex does not contain type {}",
-                        destination_type
-                    )
+                    // If this branch is reached inside time sensitive code, consider
+                    // adding the destination type to an index.
+                    resolve_item_vertices(origin, base_iter)
                 }
             }
         } else {
-            resolve_item_vertices(origin, items.iter().map(|(item, _)| item).copied())
+            resolve_item_vertices(origin, base_iter)
         }
     } else {
         // No such items found.

--- a/src/adapter/optimizations/item_lookup.rs
+++ b/src/adapter/optimizations/item_lookup.rs
@@ -321,18 +321,144 @@ fn resolve_items_by_importable_path_field_value<'a>(
         .get(path_components.as_slice())
     {
         if let Some(destination_type) = destination_type {
-            resolve_item_vertices(
-                origin,
-                items
-                    .iter()
-                    .map(|(item, _)| item)
-                    .copied()
-                    .filter(move |item| {
+            let base_iter = items.iter().map(|(item, _)| item).copied();
+            match destination_type.as_ref() {
+                "Function" => resolve_item_vertices(
+                    origin,
+                    base_iter.filter(move |item| {
                         crate_vertex
                             .pub_item_kind_index
-                            .contains(destination_type.as_ref(), item.id)
+                            .free_functions
+                            .contains_key(&item.id)
                     }),
-            )
+                ),
+                "Struct" => resolve_item_vertices(
+                    origin,
+                    base_iter.filter(move |item| {
+                        crate_vertex
+                            .pub_item_kind_index
+                            .structs
+                            .contains_key(&item.id)
+                    }),
+                ),
+                "Enum" => resolve_item_vertices(
+                    origin,
+                    base_iter.filter(move |item| {
+                        crate_vertex
+                            .pub_item_kind_index
+                            .enums
+                            .contains_key(&item.id)
+                    }),
+                ),
+                "Union" => resolve_item_vertices(
+                    origin,
+                    base_iter.filter(move |item| {
+                        crate_vertex
+                            .pub_item_kind_index
+                            .unions
+                            .contains_key(&item.id)
+                    }),
+                ),
+                "Trait" => resolve_item_vertices(
+                    origin,
+                    base_iter.filter(move |item| {
+                        crate_vertex
+                            .pub_item_kind_index
+                            .traits
+                            .contains_key(&item.id)
+                    }),
+                ),
+                "ImplOwner" => resolve_item_vertices(
+                    origin,
+                    base_iter.filter(move |item| {
+                        crate_vertex
+                            .pub_item_kind_index
+                            .structs
+                            .contains_key(&item.id)
+                            || crate_vertex
+                                .pub_item_kind_index
+                                .enums
+                                .contains_key(&item.id)
+                            || crate_vertex
+                                .pub_item_kind_index
+                                .unions
+                                .contains_key(&item.id)
+                    }),
+                ),
+                "Constant" => resolve_item_vertices(
+                    origin,
+                    base_iter.filter(move |item| {
+                        crate_vertex
+                            .pub_item_kind_index
+                            .free_consts
+                            .contains_key(&item.id)
+                    }),
+                ),
+                "Static" => resolve_item_vertices(
+                    origin,
+                    base_iter.filter(move |item| {
+                        crate_vertex
+                            .pub_item_kind_index
+                            .statics
+                            .contains_key(&item.id)
+                    }),
+                ),
+                "GlobalValue" => resolve_item_vertices(
+                    origin,
+                    base_iter.filter(move |item| {
+                        // const or static
+                        crate_vertex
+                            .pub_item_kind_index
+                            .free_consts
+                            .contains_key(&item.id)
+                            || crate_vertex
+                                .pub_item_kind_index
+                                .statics
+                                .contains_key(&item.id)
+                    }),
+                ),
+                "Macro" => resolve_item_vertices(
+                    origin,
+                    base_iter.filter(move |item| {
+                        crate_vertex
+                            .pub_item_kind_index
+                            .decl_macros
+                            .contains_key(&item.id)
+                    }),
+                ),
+                "ProcMacro"
+                | "FunctionLikeProcMacro"
+                | "AttributeProcMacro"
+                | "DeriveProcMacro" => resolve_item_vertices(
+                    origin,
+                    base_iter.filter(move |item| {
+                        crate_vertex
+                            .pub_item_kind_index
+                            .proc_macros
+                            .contains_key(&item.id)
+                    }),
+                ),
+                "Module" => resolve_item_vertices(
+                    origin,
+                    base_iter.filter(move |item| {
+                        crate_vertex
+                            .pub_item_kind_index
+                            .modules
+                            .contains_key(&item.id)
+                    }),
+                ),
+                _ => {
+                    // Currently, this function is only called in the context of resolving
+                    // the coercion of a crate to an item. As there are no lints that coerce
+                    // an item to a type other than the ones listed above, this is unreachable.
+                    // If a lint is added that does coerce to a different type, consider adding
+                    // it to the index instead of making this branch reachable.
+                    unreachable!(
+                        "PubItemKindIndex does not contain type {}",
+                        destination_type
+                    )
+                }
+            }
         } else {
             resolve_item_vertices(origin, items.iter().map(|(item, _)| item).copied())
         }

--- a/src/adapter/optimizations/item_lookup.rs
+++ b/src/adapter/optimizations/item_lookup.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use rustdoc_types::Item;
 use trustfall::{
     FieldValue,
@@ -8,7 +10,6 @@ use trustfall::{
 };
 
 use super::super::{RustdocAdapter, origin::Origin, vertex::Vertex};
-use std::sync::Arc;
 
 use crate::IndexedCrate;
 
@@ -319,18 +320,22 @@ fn resolve_items_by_importable_path_field_value<'a>(
         .expect("crate's imports_index was never constructed")
         .get(path_components.as_slice())
     {
-        resolve_item_vertices(
-            origin,
-            items
-                .iter()
-                .map(|(item, _)| item)
-                .copied()
-                .filter(move |item| {
-                    crate_vertex
-                        .pub_item_kind_index
-                        .contains(destination_type.clone(), item.id)
-                }),
-        )
+        if let Some(destination_type) = destination_type {
+            resolve_item_vertices(
+                origin,
+                items
+                    .iter()
+                    .map(|(item, _)| item)
+                    .copied()
+                    .filter(move |item| {
+                        crate_vertex
+                            .pub_item_kind_index
+                            .contains(destination_type.as_ref(), item.id)
+                    }),
+            )
+        } else {
+            resolve_item_vertices(origin, items.iter().map(|(item, _)| item).copied())
+        }
     } else {
         // No such items found.
         Box::new(std::iter::empty())

--- a/src/adapter/optimizations/item_lookup.rs
+++ b/src/adapter/optimizations/item_lookup.rs
@@ -273,8 +273,10 @@ pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
     })
 }
 
-/// Resolve items with the given value (ImportablePath), keeping only public
-/// items that match the destination_type.
+/// Resolve public items with candidate value `importable_path` and type `destination_type`.
+///
+/// If the destination is None or an unrecognised string, we conservatively return all
+/// paths that match the candidate value.
 fn resolve_items_by_importable_path<'a>(
     crate_vertex: &'a IndexedCrate,
     origin: Origin,
@@ -304,8 +306,10 @@ fn resolve_items_by_importable_path<'a>(
     }
 }
 
-/// Resolve items with the given value (ImportablePath), keeping only public
-/// items that match the destination_type.
+/// Resolve public items with path `importable_path` and type `destination_type`.
+/// 
+/// If the destination is None or an unrecognised string, we conservatively return all
+/// paths that match the `value`.
 fn resolve_items_by_importable_path_field_value<'a>(
     crate_vertex: &'a IndexedCrate,
     origin: Origin,

--- a/src/adapter/optimizations/item_lookup.rs
+++ b/src/adapter/optimizations/item_lookup.rs
@@ -307,7 +307,7 @@ fn resolve_items_by_importable_path<'a>(
 }
 
 /// Resolve public items with path `importable_path` and type `destination_type`.
-/// 
+///
 /// If the destination is None or an unrecognised string, we conservatively return all
 /// paths that match the `value`.
 fn resolve_items_by_importable_path_field_value<'a>(

--- a/src/hashtables.rs
+++ b/src/hashtables.rs
@@ -3,3 +3,9 @@ pub(crate) use std::collections::{HashMap, HashSet};
 
 #[cfg(feature = "rustc-hash")]
 pub(crate) use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+
+#[cfg(feature = "rustc-hash")]
+pub(crate) type IndexMap<K, V> = indexmap::map::IndexMap<K, V, rustc_hash::FxBuildHasher>;
+
+#[cfg(not(feature = "rustc-hash"))]
+pub(crate) use indexmap::map::IndexMap;

--- a/src/hashtables.rs
+++ b/src/hashtables.rs
@@ -1,3 +1,6 @@
+use std::default::Default;
+use std::hash::{BuildHasher, Hash};
+
 #[cfg(not(feature = "rustc-hash"))]
 pub(crate) use std::collections::{HashMap, HashSet};
 
@@ -9,3 +12,46 @@ pub(crate) type IndexMap<K, V> = indexmap::map::IndexMap<K, V, rustc_hash::FxBui
 
 #[cfg(not(feature = "rustc-hash"))]
 pub(crate) use indexmap::map::IndexMap;
+
+/// Allow using new() and with_capacity() regardless of the hash algorithm.
+/// See https://github.com/tkaitchuck/aHash/issues/103 for more information.
+/// ```rust
+/// use hashtables::{HashMap, HashMapExt as _};
+/// fn foo() {
+/// 	// Will fail to compile if HashMapExt is not imported and rustc-hash is enabled.
+/// 	let bar = HashMap::new();
+/// }
+/// ```
+#[allow(dead_code)] // Used when rustc-hash is enabled.
+pub(crate) trait HashMapExt {
+    fn new() -> Self;
+    fn with_capacity(x: usize) -> Self;
+}
+
+impl<K, V, S> HashMapExt for std::collections::HashMap<K, V, S>
+where
+    K: Hash + Eq,
+    S: BuildHasher + Default,
+{
+    fn new() -> Self {
+        std::collections::HashMap::with_hasher(S::default())
+    }
+
+    fn with_capacity(capacity: usize) -> Self {
+        std::collections::HashMap::with_capacity_and_hasher(capacity, S::default())
+    }
+}
+
+impl<K, V, S> HashMapExt for indexmap::map::IndexMap<K, V, S>
+where
+    K: Hash + Eq,
+    S: BuildHasher + Default,
+{
+    fn new() -> Self {
+        indexmap::map::IndexMap::with_hasher(S::default())
+    }
+
+    fn with_capacity(capacity: usize) -> Self {
+        indexmap::map::IndexMap::with_capacity_and_hasher(capacity, S::default())
+    }
+}

--- a/src/hashtables.rs
+++ b/src/hashtables.rs
@@ -15,7 +15,7 @@ pub(crate) use indexmap::map::IndexMap;
 
 /// Allow using new() and with_capacity() regardless of the hash algorithm.
 /// See <https://github.com/tkaitchuck/aHash/issues/103> for more information.
-#[allow(dead_code)] // Used when rustc-hash is enabled.
+#[allow(dead_code, reason = "used when the `rustc-hash` feature is enabled")]
 pub(crate) trait HashMapExt {
     fn new() -> Self;
     fn with_capacity(x: usize) -> Self;

--- a/src/hashtables.rs
+++ b/src/hashtables.rs
@@ -7,8 +7,5 @@ pub(crate) use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 #[cfg(feature = "rustc-hash")]
 pub(crate) type IndexMap<K, V> = indexmap::map::IndexMap<K, V, rustc_hash::FxBuildHasher>;
 
-#[cfg(feature = "rustc-hash")]
-pub(crate) type IndexSet<T> = indexmap::map::IndexSet<T, rustc_hash::FxBuildHasher>;
-
 #[cfg(not(feature = "rustc-hash"))]
-pub(crate) use indexmap::{map::IndexMap, set::IndexSet};
+pub(crate) use indexmap::{map::IndexMap};

--- a/src/hashtables.rs
+++ b/src/hashtables.rs
@@ -14,7 +14,7 @@ pub(crate) type IndexMap<K, V> = indexmap::map::IndexMap<K, V, rustc_hash::FxBui
 pub(crate) use indexmap::map::IndexMap;
 
 /// Allow using new() and with_capacity() regardless of the hash algorithm.
-/// See https://github.com/tkaitchuck/aHash/issues/103 for more information.
+/// See <https://github.com/tkaitchuck/aHash/issues/103> for more information.
 #[allow(dead_code)] // Used when rustc-hash is enabled.
 pub(crate) trait HashMapExt {
     fn new() -> Self;

--- a/src/hashtables.rs
+++ b/src/hashtables.rs
@@ -15,13 +15,6 @@ pub(crate) use indexmap::map::IndexMap;
 
 /// Allow using new() and with_capacity() regardless of the hash algorithm.
 /// See https://github.com/tkaitchuck/aHash/issues/103 for more information.
-/// ```rust
-/// use crate::hashtables::{HashMap, HashMapExt as _};
-/// fn foo() {
-///     // Will fail to compile if HashMapExt is not imported and rustc-hash is enabled.
-///     let bar = HashMap::new();
-/// }
-/// ```
 #[allow(dead_code)] // Used when rustc-hash is enabled.
 pub(crate) trait HashMapExt {
     fn new() -> Self;

--- a/src/hashtables.rs
+++ b/src/hashtables.rs
@@ -7,5 +7,8 @@ pub(crate) use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 #[cfg(feature = "rustc-hash")]
 pub(crate) type IndexMap<K, V> = indexmap::map::IndexMap<K, V, rustc_hash::FxBuildHasher>;
 
+#[cfg(feature = "rustc-hash")]
+pub(crate) type IndexSet<T> = indexmap::map::IndexSet<T, rustc_hash::FxBuildHasher>;
+
 #[cfg(not(feature = "rustc-hash"))]
-pub(crate) use indexmap::map::IndexMap;
+pub(crate) use indexmap::{map::IndexMap, set::IndexSet};

--- a/src/hashtables.rs
+++ b/src/hashtables.rs
@@ -16,10 +16,10 @@ pub(crate) use indexmap::map::IndexMap;
 /// Allow using new() and with_capacity() regardless of the hash algorithm.
 /// See https://github.com/tkaitchuck/aHash/issues/103 for more information.
 /// ```rust
-/// use hashtables::{HashMap, HashMapExt as _};
+/// use crate::hashtables::{HashMap, HashMapExt as _};
 /// fn foo() {
-/// 	// Will fail to compile if HashMapExt is not imported and rustc-hash is enabled.
-/// 	let bar = HashMap::new();
+///     // Will fail to compile if HashMapExt is not imported and rustc-hash is enabled.
+///     let bar = HashMap::new();
 /// }
 /// ```
 #[allow(dead_code)] // Used when rustc-hash is enabled.

--- a/src/hashtables.rs
+++ b/src/hashtables.rs
@@ -8,4 +8,4 @@ pub(crate) use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 pub(crate) type IndexMap<K, V> = indexmap::map::IndexMap<K, V, rustc_hash::FxBuildHasher>;
 
 #[cfg(not(feature = "rustc-hash"))]
-pub(crate) use indexmap::{map::IndexMap};
+pub(crate) use indexmap::map::IndexMap;

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -203,7 +203,7 @@ pub struct IndexedCrate<'a> {
     /// -> function item with that export name; exported symbol names must be unique.
     pub(crate) export_name_index: Option<HashMap<&'a str, &'a Item>>,
 
-    /// index: kind of public top-level item -> `Vec<&'a Item>` of that kind
+    /// index: kind of public top-level item -> `HashMap<Id, &'a Item>` of that kind
     pub(crate) pub_item_kind_index: PubItemKindIndex<'a>,
 
     /// Trait items defined in external crates are not present in the `inner: &Crate` field,
@@ -229,156 +229,164 @@ pub struct IndexedCrate<'a> {
     pub(crate) target_features: HashMap<&'a str, &'a rustdoc_types::TargetFeature>,
 }
 
+
 #[derive(Debug, Clone)]
 pub(crate) struct PubItemKindIndex<'a> {
-    pub(crate) free_functions: Vec<&'a Item>,
-    pub(crate) structs: Vec<&'a Item>,
-    pub(crate) enums: Vec<&'a Item>,
-    pub(crate) unions: Vec<&'a Item>,
-    pub(crate) traits: Vec<&'a Item>,
-    pub(crate) modules: Vec<&'a Item>,
-    pub(crate) statics: Vec<&'a Item>,
-    pub(crate) free_consts: Vec<&'a Item>,
-    pub(crate) decl_macros: Vec<&'a Item>,
-    pub(crate) proc_macros: Vec<&'a Item>,
+    pub(crate) free_functions: HashMap<Id, &'a Item>,
+    pub(crate) structs: HashMap<Id, &'a Item>,
+    pub(crate) enums: HashMap<Id, &'a Item>,
+    pub(crate) unions: HashMap<Id, &'a Item>,
+    pub(crate) traits: HashMap<Id, &'a Item>,
+    pub(crate) modules: HashMap<Id, &'a Item>,
+    pub(crate) statics: HashMap<Id, &'a Item>,
+    pub(crate) free_consts: HashMap<Id, &'a Item>,
+    pub(crate) decl_macros: HashMap<Id, &'a Item>,
+    pub(crate) proc_macros: HashMap<Id, &'a Item>,
 }
 
+
 impl<'a> PubItemKindIndex<'a> {
+    #[cfg(feature = "rustc-hash")]
     fn with_capacity_hint(hint: usize) -> Self {
         let capacity = if hint < 128 * 128 { 128 } else { hint / 128 };
         Self {
             // Most top-level items in a crate are functions, structs, enums, or traits.
             // We want indexing to be fast, and it's okay if we waste a bit of memory.
-            free_functions: Vec::with_capacity(capacity),
-            structs: Vec::with_capacity(capacity),
-            enums: Vec::with_capacity(capacity),
-            traits: Vec::with_capacity(capacity),
-            unions: Vec::new(),
-            modules: Vec::with_capacity(64),
-            statics: Vec::new(),
-            free_consts: Vec::new(),
-            decl_macros: Vec::new(),
-            proc_macros: Vec::new(),
+            free_functions: HashMap::with_capacity_and_hasher(capacity, rustc_hash::FxBuildHasher),
+            structs: HashMap::with_capacity_and_hasher(capacity, rustc_hash::FxBuildHasher),
+            enums: HashMap::with_capacity_and_hasher(capacity, rustc_hash::FxBuildHasher),
+            traits: HashMap::with_capacity_and_hasher(capacity, rustc_hash::FxBuildHasher),
+            unions: HashMap::with_hasher(rustc_hash::FxBuildHasher),
+            modules: HashMap::with_capacity_and_hasher(64, rustc_hash::FxBuildHasher),
+            statics: HashMap::with_hasher(rustc_hash::FxBuildHasher),
+            free_consts: HashMap::with_hasher(rustc_hash::FxBuildHasher),
+            decl_macros: HashMap::with_hasher(rustc_hash::FxBuildHasher),
+            proc_macros: HashMap::with_hasher(rustc_hash::FxBuildHasher),
+        }
+    }
+
+    #[cfg(not(feature = "rustc-hash"))]
+    fn with_capacity_hint(hint: usize) -> Self {
+        let capacity = if hint < 128 * 128 { 128 } else { hint / 128 };
+        Self {
+            // Most top-level items in a crate are functions, structs, enums, or traits.
+            // We want indexing to be fast, and it's okay if we waste a bit of memory.
+            free_functions: HashMap::with_capacity(capacity),
+            structs: HashMap::with_capacity(capacity),
+            enums: HashMap::with_capacity(capacity),
+            traits: HashMap::with_capacity(capacity),
+            unions: HashMap::new(),
+            modules: HashMap::with_capacity(64),
+            statics: HashMap::new(),
+            free_consts: HashMap::new(),
+            decl_macros: HashMap::new(),
+            proc_macros: HashMap::new(),
         }
     }
 
     fn from_crate(crate_: &'a Crate, fn_owner_index: &HashMap<Id, &'a Item>) -> Self {
-        #[cfg(feature = "rayon")]
-        let iter = crate_.index.par_iter().map(|(_, value)| value);
-        #[cfg(not(feature = "rayon"))]
         let iter = crate_.index.values();
+        let init = PubItemKindIndex::with_capacity_hint(crate_.index.len());        
 
-        #[cfg(feature = "rayon")]
-        let init = || Self::with_capacity_hint(crate_.index.len());
-        #[cfg(not(feature = "rayon"))]
-        let init = Self::with_capacity_hint(crate_.index.len());
-
-        let folded = iter.fold(init, |mut acc, item| {
+        iter.fold(init, |mut acc, item| {
             if item.visibility == rustdoc_types::Visibility::Public {
                 match &item.inner {
                     rustdoc_types::ItemEnum::Module { .. } => {
-                        acc.modules.push(item);
+                        acc.modules.insert(item.id, item);
                     }
                     rustdoc_types::ItemEnum::Union { .. } => {
-                        acc.unions.push(item);
+                        acc.unions.insert(item.id, item);
                     }
                     rustdoc_types::ItemEnum::Struct { .. } => {
-                        acc.structs.push(item);
+                        acc.structs.insert(item.id, item);
                     }
                     rustdoc_types::ItemEnum::Enum { .. } => {
-                        acc.enums.push(item);
+                        acc.enums.insert(item.id, item);
                     }
                     rustdoc_types::ItemEnum::Function { .. } => {
                         if !fn_owner_index.contains_key(&item.id) {
                             // This is a free function.
-                            acc.free_functions.push(item);
+                            acc.free_functions.insert(item.id, item);
                         }
                     }
                     rustdoc_types::ItemEnum::Trait { .. } => {
-                        acc.traits.push(item);
+                        acc.traits.insert(item.id, item);
                     }
                     rustdoc_types::ItemEnum::Constant { .. } => {
-                        acc.free_consts.push(item);
+                        acc.free_consts.insert(item.id, item);
                     }
                     rustdoc_types::ItemEnum::Static { .. } => {
-                        acc.statics.push(item);
+                        acc.statics.insert(item.id, item);
                     }
                     rustdoc_types::ItemEnum::Macro { .. } => {
-                        acc.decl_macros.push(item);
+                        acc.decl_macros.insert(item.id, item);
                     }
                     rustdoc_types::ItemEnum::ProcMacro { .. } => {
-                        acc.proc_macros.push(item);
+                        acc.proc_macros.insert(item.id, item);
                     }
                     _ => {}
                 }
             }
 
             acc
-        });
+        })
+    }
 
-        #[cfg(feature = "rayon")]
-        let folded = {
-            let collected = folded
-                .map(|index| vec![index])
-                .reduce(Vec::new, |mut left, right| {
-                    left.extend(right);
-                    left
-                });
-
-            let mut fns_len = 0;
-            let mut structs_len = 0;
-            let mut enums_len = 0;
-            let mut unions_len = 0;
-            let mut traits_len = 0;
-            let mut modules_len = 0;
-            let mut statics_len = 0;
-            let mut consts_len = 0;
-            let mut decl_macros_len = 0;
-            let mut proc_macros_len = 0;
-
-            for c in &collected {
-                fns_len += c.free_functions.len();
-                structs_len += c.structs.len();
-                enums_len += c.enums.len();
-                unions_len += c.unions.len();
-                traits_len += c.traits.len();
-                modules_len += c.modules.len();
-                statics_len += c.statics.len();
-                consts_len += c.free_consts.len();
-                decl_macros_len += c.decl_macros.len();
-                proc_macros_len += c.proc_macros.len();
+    /// Returns true if the index corresponding to the type given by
+    /// `destination_type` contains an element with the id `item_id`.
+    /// Conservatively, returns true if the destination is None or of a type
+    /// that isn't contained in the indexes.
+    pub fn contains(&self, destination_type: Option<Arc<str>>, item_id: Id) -> bool {
+        if let Some(destination_type) = destination_type {
+            match destination_type.as_ref() {
+                "Function" => {
+                    self.free_functions.contains_key(&item_id)
+                }
+                "Struct" => {
+                    self.structs.contains_key(&item_id)
+                }
+                "Enum" => {
+                    self.enums.contains_key(&item_id)
+                }
+                "Union" => {
+                    self.unions.contains_key(&item_id)
+                }
+                "Trait" => {
+                    self.traits.contains_key(&item_id)
+                }
+                "ImplOwner" => {
+                    self.structs.contains_key(&item_id)
+                        || self.enums.contains_key(&item_id)
+                        || self.unions.contains_key(&item_id)
+                }
+                "Constant" => {
+                    self.free_consts.contains_key(&item_id)
+                }
+                "Static" => {
+                    self.statics.contains_key(&item_id)
+                }
+                "GlobalValue" => {
+                    // const or static
+                    self.free_consts.contains_key(&item_id)
+                        || self.statics.contains_key(&item_id)
+                }
+                "Macro" => {
+                    self.decl_macros.contains_key(&item_id)
+                }
+                "ProcMacro"
+                | "FunctionLikeProcMacro"
+                | "AttributeProcMacro"
+                | "DeriveProcMacro" => {
+                    self.proc_macros.contains_key(&item_id)
+                }
+                "Module" => {
+                    self.modules.contains_key(&item_id)
+                }
+                _ => true,
             }
-
-            let mut value = Self {
-                free_functions: Vec::with_capacity(fns_len),
-                structs: Vec::with_capacity(structs_len),
-                enums: Vec::with_capacity(enums_len),
-                unions: Vec::with_capacity(unions_len),
-                traits: Vec::with_capacity(traits_len),
-                modules: Vec::with_capacity(modules_len),
-                statics: Vec::with_capacity(statics_len),
-                free_consts: Vec::with_capacity(consts_len),
-                decl_macros: Vec::with_capacity(decl_macros_len),
-                proc_macros: Vec::with_capacity(proc_macros_len),
-            };
-
-            for c in collected {
-                value.free_functions.extend(c.free_functions);
-                value.structs.extend(c.structs);
-                value.enums.extend(c.enums);
-                value.unions.extend(c.unions);
-                value.traits.extend(c.traits);
-                value.modules.extend(c.modules);
-                value.statics.extend(c.statics);
-                value.free_consts.extend(c.free_consts);
-                value.decl_macros.extend(c.decl_macros);
-                value.proc_macros.extend(c.proc_macros);
-            }
-
-            value
-        };
-
-        folded
+        } else {
+            true
+        }
     }
 }
 
@@ -598,6 +606,9 @@ fn build_impl_index(index: &HashMap<Id, Item>) -> MapList<ImplEntry<'_>, (&Item,
 
 impl<'a> IndexedCrate<'a> {
     pub fn new(crate_: &'a Crate) -> Self {
+        let fn_owner_index = build_fn_owner_index(&crate_.index);
+        let pub_item_kind_index = PubItemKindIndex::from_crate(crate_, &fn_owner_index);
+
         let (manually_inlined_builtin_traits, sized_trait) =
             create_manually_inlined_builtin_traits(crate_);
 
@@ -659,7 +670,7 @@ impl<'a> IndexedCrate<'a> {
         value.imports_index = Some(imports_index);
 
         value.impl_method_index = Some(build_impl_index(&crate_.index).into_inner());
-        value.fn_owner_index = Some(build_fn_owner_index(&crate_.index));
+        value.fn_owner_index = Some(fn_owner_index);
         value.export_name_index = Some(build_export_name_index(&crate_.index));
 
         value

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -330,7 +330,6 @@ impl<'a> PubItemKindIndex<'a> {
         })
     }
 
-
     // A duplicate of from_crate that generates the index in parallel. It exists
     // only for benchmarking purposes.
     #[cfg(feature = "rustc-hash")]
@@ -423,16 +422,28 @@ impl<'a> PubItemKindIndex<'a> {
 
             // For the purposes of benchmarking.
             let mut value = Self {
-                free_functions: HashMap::with_capacity_and_hasher(fns_len, rustc_hash::FxBuildHasher),
+                free_functions: HashMap::with_capacity_and_hasher(
+                    fns_len,
+                    rustc_hash::FxBuildHasher,
+                ),
                 structs: HashMap::with_capacity_and_hasher(structs_len, rustc_hash::FxBuildHasher),
                 enums: HashMap::with_capacity_and_hasher(enums_len, rustc_hash::FxBuildHasher),
                 unions: HashMap::with_capacity_and_hasher(unions_len, rustc_hash::FxBuildHasher),
                 traits: HashMap::with_capacity_and_hasher(traits_len, rustc_hash::FxBuildHasher),
                 modules: HashMap::with_capacity_and_hasher(modules_len, rustc_hash::FxBuildHasher),
                 statics: HashMap::with_capacity_and_hasher(statics_len, rustc_hash::FxBuildHasher),
-                free_consts: HashMap::with_capacity_and_hasher(consts_len, rustc_hash::FxBuildHasher),
-                decl_macros: HashMap::with_capacity_and_hasher(decl_macros_len, rustc_hash::FxBuildHasher),
-                proc_macros: HashMap::with_capacity_and_hasher(proc_macros_len, rustc_hash::FxBuildHasher),
+                free_consts: HashMap::with_capacity_and_hasher(
+                    consts_len,
+                    rustc_hash::FxBuildHasher,
+                ),
+                decl_macros: HashMap::with_capacity_and_hasher(
+                    decl_macros_len,
+                    rustc_hash::FxBuildHasher,
+                ),
+                proc_macros: HashMap::with_capacity_and_hasher(
+                    proc_macros_len,
+                    rustc_hash::FxBuildHasher,
+                ),
             };
 
             for c in collected {
@@ -458,35 +469,30 @@ impl<'a> PubItemKindIndex<'a> {
     /// `destination_type` contains an element with the id `item_id`.
     /// Conservatively, returns true if the destination is None or of a type
     /// that isn't contained in the indexes.
-    pub fn contains(&self, destination_type: Option<Arc<str>>, item_id: Id) -> bool {
-        if let Some(destination_type) = destination_type {
-            match destination_type.as_ref() {
-                "Function" => self.free_functions.contains_key(&item_id),
-                "Struct" => self.structs.contains_key(&item_id),
-                "Enum" => self.enums.contains_key(&item_id),
-                "Union" => self.unions.contains_key(&item_id),
-                "Trait" => self.traits.contains_key(&item_id),
-                "ImplOwner" => {
-                    self.structs.contains_key(&item_id)
-                        || self.enums.contains_key(&item_id)
-                        || self.unions.contains_key(&item_id)
-                }
-                "Constant" => self.free_consts.contains_key(&item_id),
-                "Static" => self.statics.contains_key(&item_id),
-                "GlobalValue" => {
-                    // const or static
-                    self.free_consts.contains_key(&item_id) || self.statics.contains_key(&item_id)
-                }
-                "Macro" => self.decl_macros.contains_key(&item_id),
-                "ProcMacro"
-                | "FunctionLikeProcMacro"
-                | "AttributeProcMacro"
-                | "DeriveProcMacro" => self.proc_macros.contains_key(&item_id),
-                "Module" => self.modules.contains_key(&item_id),
-                _ => true,
+    pub fn contains(&self, destination_type: &str, item_id: Id) -> bool {
+        match destination_type {
+            "Function" => self.free_functions.contains_key(&item_id),
+            "Struct" => self.structs.contains_key(&item_id),
+            "Enum" => self.enums.contains_key(&item_id),
+            "Union" => self.unions.contains_key(&item_id),
+            "Trait" => self.traits.contains_key(&item_id),
+            "ImplOwner" => {
+                self.structs.contains_key(&item_id)
+                    || self.enums.contains_key(&item_id)
+                    || self.unions.contains_key(&item_id)
             }
-        } else {
-            true
+            "Constant" => self.free_consts.contains_key(&item_id),
+            "Static" => self.statics.contains_key(&item_id),
+            "GlobalValue" => {
+                // const or static
+                self.free_consts.contains_key(&item_id) || self.statics.contains_key(&item_id)
+            }
+            "Macro" => self.decl_macros.contains_key(&item_id),
+            "ProcMacro" | "FunctionLikeProcMacro" | "AttributeProcMacro" | "DeriveProcMacro" => {
+                self.proc_macros.contains_key(&item_id)
+            }
+            "Module" => self.modules.contains_key(&item_id),
+            _ => true,
         }
     }
 }
@@ -849,8 +855,6 @@ impl<'a> IndexedCrate<'a> {
 
         value
     }
-
-
 
     /// Return all the paths with which the given item can be imported from this crate.
     pub fn publicly_importable_names(&self, id: &'a Id) -> Vec<ImportablePath<'a>> {

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -283,6 +283,9 @@ impl<'a> PubItemKindIndex<'a> {
     }
 
     fn from_crate(crate_: &'a Crate, fn_owner_index: &HashMap<Id, &'a Item>) -> Self {
+        // Parallel construction takes significantly longer than single-threaded.
+        // See https://github.com/obi1kenobi/trustfall-rustdoc-adapter/pull/902#issuecomment-3054606032
+        // for a comparison of the runtimes.
         let iter = crate_.index.values();
         let init = PubItemKindIndex::with_capacity_hint(crate_.index.len());
 
@@ -328,141 +331,6 @@ impl<'a> PubItemKindIndex<'a> {
 
             acc
         })
-    }
-
-    // A duplicate of from_crate that generates the index in parallel. It exists
-    // only for benchmarking purposes.
-    #[cfg(feature = "rustc-hash")]
-    fn from_crate_parallel(crate_: &'a Crate, fn_owner_index: &HashMap<Id, &'a Item>) -> Self {
-        #[cfg(feature = "rayon")]
-        let iter = crate_.index.par_iter().map(|(_, value)| value);
-        #[cfg(not(feature = "rayon"))]
-        let iter = crate_.index.values();
-
-        #[cfg(feature = "rayon")]
-        let init = || Self::with_capacity_hint(crate_.index.len());
-        #[cfg(not(feature = "rayon"))]
-        let init = Self::with_capacity_hint(crate_.index.len());
-
-        let folded = iter.fold(init, |mut acc, item| {
-            if item.visibility == rustdoc_types::Visibility::Public {
-                match &item.inner {
-                    rustdoc_types::ItemEnum::Module { .. } => {
-                        acc.modules.insert(item.id, item);
-                    }
-                    rustdoc_types::ItemEnum::Union { .. } => {
-                        acc.unions.insert(item.id, item);
-                    }
-                    rustdoc_types::ItemEnum::Struct { .. } => {
-                        acc.structs.insert(item.id, item);
-                    }
-                    rustdoc_types::ItemEnum::Enum { .. } => {
-                        acc.enums.insert(item.id, item);
-                    }
-                    rustdoc_types::ItemEnum::Function { .. } => {
-                        if !fn_owner_index.contains_key(&item.id) {
-                            // This is a free function.
-                            acc.free_functions.insert(item.id, item);
-                        }
-                    }
-                    rustdoc_types::ItemEnum::Trait { .. } => {
-                        acc.traits.insert(item.id, item);
-                    }
-                    rustdoc_types::ItemEnum::Constant { .. } => {
-                        acc.free_consts.insert(item.id, item);
-                    }
-                    rustdoc_types::ItemEnum::Static { .. } => {
-                        acc.statics.insert(item.id, item);
-                    }
-                    rustdoc_types::ItemEnum::Macro { .. } => {
-                        acc.decl_macros.insert(item.id, item);
-                    }
-                    rustdoc_types::ItemEnum::ProcMacro { .. } => {
-                        acc.proc_macros.insert(item.id, item);
-                    }
-                    _ => {}
-                }
-            }
-
-            acc
-        });
-
-        #[cfg(feature = "rayon")]
-        let folded = {
-            let collected = folded
-                .map(|index| vec![index])
-                .reduce(Vec::new, |mut left, right| {
-                    left.extend(right);
-                    left
-                });
-
-            let mut fns_len = 0;
-            let mut structs_len = 0;
-            let mut enums_len = 0;
-            let mut unions_len = 0;
-            let mut traits_len = 0;
-            let mut modules_len = 0;
-            let mut statics_len = 0;
-            let mut consts_len = 0;
-            let mut decl_macros_len = 0;
-            let mut proc_macros_len = 0;
-
-            for c in &collected {
-                fns_len += c.free_functions.len();
-                structs_len += c.structs.len();
-                enums_len += c.enums.len();
-                unions_len += c.unions.len();
-                traits_len += c.traits.len();
-                modules_len += c.modules.len();
-                statics_len += c.statics.len();
-                consts_len += c.free_consts.len();
-                decl_macros_len += c.decl_macros.len();
-                proc_macros_len += c.proc_macros.len();
-            }
-
-            // For the purposes of benchmarking.
-            let mut value = Self {
-                free_functions: HashMap::with_capacity_and_hasher(
-                    fns_len,
-                    rustc_hash::FxBuildHasher,
-                ),
-                structs: HashMap::with_capacity_and_hasher(structs_len, rustc_hash::FxBuildHasher),
-                enums: HashMap::with_capacity_and_hasher(enums_len, rustc_hash::FxBuildHasher),
-                unions: HashMap::with_capacity_and_hasher(unions_len, rustc_hash::FxBuildHasher),
-                traits: HashMap::with_capacity_and_hasher(traits_len, rustc_hash::FxBuildHasher),
-                modules: HashMap::with_capacity_and_hasher(modules_len, rustc_hash::FxBuildHasher),
-                statics: HashMap::with_capacity_and_hasher(statics_len, rustc_hash::FxBuildHasher),
-                free_consts: HashMap::with_capacity_and_hasher(
-                    consts_len,
-                    rustc_hash::FxBuildHasher,
-                ),
-                decl_macros: HashMap::with_capacity_and_hasher(
-                    decl_macros_len,
-                    rustc_hash::FxBuildHasher,
-                ),
-                proc_macros: HashMap::with_capacity_and_hasher(
-                    proc_macros_len,
-                    rustc_hash::FxBuildHasher,
-                ),
-            };
-
-            for c in collected {
-                value.free_functions.extend(c.free_functions);
-                value.structs.extend(c.structs);
-                value.enums.extend(c.enums);
-                value.unions.extend(c.unions);
-                value.traits.extend(c.traits);
-                value.modules.extend(c.modules);
-                value.statics.extend(c.statics);
-                value.free_consts.extend(c.free_consts);
-                value.decl_macros.extend(c.decl_macros);
-                value.proc_macros.extend(c.proc_macros);
-            }
-
-            value
-        };
-
-        folded
     }
 
     /// Returns true if the index corresponding to the type given by
@@ -715,79 +583,6 @@ impl<'a> IndexedCrate<'a> {
     pub fn new(crate_: &'a Crate) -> Self {
         let fn_owner_index = build_fn_owner_index(&crate_.index);
         let pub_item_kind_index = PubItemKindIndex::from_crate(crate_, &fn_owner_index);
-
-        let (manually_inlined_builtin_traits, sized_trait) =
-            create_manually_inlined_builtin_traits(crate_);
-
-        let target_features = crate_
-            .target
-            .target_features
-            .iter()
-            .map(|feat| (feat.name.as_str(), feat))
-            .collect();
-
-        let mut value = Self {
-            inner: crate_,
-            visibility_tracker: VisibilityTracker::from_crate(crate_),
-            manually_inlined_builtin_traits,
-            sized_trait,
-            flags: None,
-            imports_index: None,
-            impl_method_index: None,
-            fn_owner_index: None,
-            export_name_index: None,
-            target_features,
-            pub_item_kind_index,
-        };
-
-        debug_assert!(
-            !value.manually_inlined_builtin_traits.is_empty(),
-            "failed to find any traits to manually inline",
-        );
-
-        // Build the imports index
-        //
-        // This is inlined because we need access to `value`, but `value` is not a valid
-        // `IndexedCrate` yet. Do not extract into a separate function.
-        #[cfg(feature = "rayon")]
-        let iter = crate_.index.par_iter();
-        #[cfg(not(feature = "rayon"))]
-        let iter = crate_.index.iter();
-
-        let imports_index = iter
-            .filter_map(|(_id, item)| {
-                if !supported_item_kind(item) {
-                    return None;
-                }
-                let importable_paths = value.publicly_importable_names(&item.id);
-
-                #[cfg(feature = "rayon")]
-                let iter = importable_paths.into_par_iter();
-                #[cfg(not(feature = "rayon"))]
-                let iter = importable_paths.into_iter();
-
-                Some(iter.map(move |importable_path| {
-                    (importable_path.path, (item, importable_path.modifiers))
-                }))
-            })
-            .flatten()
-            .collect::<MapList<_, _>>()
-            .into_inner();
-        value.flags = Some(build_flags_index(&crate_.index, &imports_index));
-        value.imports_index = Some(imports_index);
-
-        value.impl_method_index = Some(build_impl_index(&crate_.index).into_inner());
-        value.fn_owner_index = Some(fn_owner_index);
-        value.export_name_index = Some(build_export_name_index(&crate_.index));
-
-        value
-    }
-
-    // Only exists for temporary benchmarking purposes. Exactly the same as new
-    // but creates the PubItemKindIndex in parallel.
-    pub fn new_parallel(crate_: &'a Crate) -> Self {
-        let fn_owner_index = build_fn_owner_index(&crate_.index);
-        let pub_item_kind_index = PubItemKindIndex::from_crate_parallel(crate_, &fn_owner_index);
 
         let (manually_inlined_builtin_traits, sized_trait) =
             create_manually_inlined_builtin_traits(crate_);

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -229,7 +229,6 @@ pub struct IndexedCrate<'a> {
     pub(crate) target_features: HashMap<&'a str, &'a rustdoc_types::TargetFeature>,
 }
 
-
 #[derive(Debug, Clone)]
 pub(crate) struct PubItemKindIndex<'a> {
     pub(crate) free_functions: HashMap<Id, &'a Item>,
@@ -243,7 +242,6 @@ pub(crate) struct PubItemKindIndex<'a> {
     pub(crate) decl_macros: HashMap<Id, &'a Item>,
     pub(crate) proc_macros: HashMap<Id, &'a Item>,
 }
-
 
 impl<'a> PubItemKindIndex<'a> {
     #[cfg(feature = "rustc-hash")]
@@ -286,7 +284,7 @@ impl<'a> PubItemKindIndex<'a> {
 
     fn from_crate(crate_: &'a Crate, fn_owner_index: &HashMap<Id, &'a Item>) -> Self {
         let iter = crate_.index.values();
-        let init = PubItemKindIndex::with_capacity_hint(crate_.index.len());        
+        let init = PubItemKindIndex::with_capacity_hint(crate_.index.len());
 
         iter.fold(init, |mut acc, item| {
             if item.visibility == rustdoc_types::Visibility::Public {
@@ -339,49 +337,28 @@ impl<'a> PubItemKindIndex<'a> {
     pub fn contains(&self, destination_type: Option<Arc<str>>, item_id: Id) -> bool {
         if let Some(destination_type) = destination_type {
             match destination_type.as_ref() {
-                "Function" => {
-                    self.free_functions.contains_key(&item_id)
-                }
-                "Struct" => {
-                    self.structs.contains_key(&item_id)
-                }
-                "Enum" => {
-                    self.enums.contains_key(&item_id)
-                }
-                "Union" => {
-                    self.unions.contains_key(&item_id)
-                }
-                "Trait" => {
-                    self.traits.contains_key(&item_id)
-                }
+                "Function" => self.free_functions.contains_key(&item_id),
+                "Struct" => self.structs.contains_key(&item_id),
+                "Enum" => self.enums.contains_key(&item_id),
+                "Union" => self.unions.contains_key(&item_id),
+                "Trait" => self.traits.contains_key(&item_id),
                 "ImplOwner" => {
                     self.structs.contains_key(&item_id)
                         || self.enums.contains_key(&item_id)
                         || self.unions.contains_key(&item_id)
                 }
-                "Constant" => {
-                    self.free_consts.contains_key(&item_id)
-                }
-                "Static" => {
-                    self.statics.contains_key(&item_id)
-                }
+                "Constant" => self.free_consts.contains_key(&item_id),
+                "Static" => self.statics.contains_key(&item_id),
                 "GlobalValue" => {
                     // const or static
-                    self.free_consts.contains_key(&item_id)
-                        || self.statics.contains_key(&item_id)
+                    self.free_consts.contains_key(&item_id) || self.statics.contains_key(&item_id)
                 }
-                "Macro" => {
-                    self.decl_macros.contains_key(&item_id)
-                }
+                "Macro" => self.decl_macros.contains_key(&item_id),
                 "ProcMacro"
                 | "FunctionLikeProcMacro"
                 | "AttributeProcMacro"
-                | "DeriveProcMacro" => {
-                    self.proc_macros.contains_key(&item_id)
-                }
-                "Module" => {
-                    self.modules.contains_key(&item_id)
-                }
+                | "DeriveProcMacro" => self.proc_macros.contains_key(&item_id),
+                "Module" => self.modules.contains_key(&item_id),
                 _ => true,
             }
         } else {

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -6,7 +6,7 @@ use rustdoc_types::{Crate, Id, Item};
 
 use crate::{
     adapter::supported_item_kind,
-    hashtables::{HashMap, HashSet},
+    hashtables::{HashMap, HashSet, IndexMap},
     item_flags::{ItemFlag, build_flags_index},
     visibility_tracker::VisibilityTracker,
 };
@@ -203,7 +203,7 @@ pub struct IndexedCrate<'a> {
     /// -> function item with that export name; exported symbol names must be unique.
     pub(crate) export_name_index: Option<HashMap<&'a str, &'a Item>>,
 
-    /// index: kind of public top-level item -> `HashMap<Id, &'a Item>` of that kind
+    /// index: kind of public top-level item -> `IndexMap<Id, &'a Item>` of that kind
     pub(crate) pub_item_kind_index: PubItemKindIndex<'a>,
 
     /// Trait items defined in external crates are not present in the `inner: &Crate` field,
@@ -231,16 +231,16 @@ pub struct IndexedCrate<'a> {
 
 #[derive(Debug, Clone)]
 pub(crate) struct PubItemKindIndex<'a> {
-    pub(crate) free_functions: HashMap<Id, &'a Item>,
-    pub(crate) structs: HashMap<Id, &'a Item>,
-    pub(crate) enums: HashMap<Id, &'a Item>,
-    pub(crate) unions: HashMap<Id, &'a Item>,
-    pub(crate) traits: HashMap<Id, &'a Item>,
-    pub(crate) modules: HashMap<Id, &'a Item>,
-    pub(crate) statics: HashMap<Id, &'a Item>,
-    pub(crate) free_consts: HashMap<Id, &'a Item>,
-    pub(crate) decl_macros: HashMap<Id, &'a Item>,
-    pub(crate) proc_macros: HashMap<Id, &'a Item>,
+    pub(crate) free_functions: IndexMap<Id, &'a Item>,
+    pub(crate) structs: IndexMap<Id, &'a Item>,
+    pub(crate) enums: IndexMap<Id, &'a Item>,
+    pub(crate) unions: IndexMap<Id, &'a Item>,
+    pub(crate) traits: IndexMap<Id, &'a Item>,
+    pub(crate) modules: IndexMap<Id, &'a Item>,
+    pub(crate) statics: IndexMap<Id, &'a Item>,
+    pub(crate) free_consts: IndexMap<Id, &'a Item>,
+    pub(crate) decl_macros: IndexMap<Id, &'a Item>,
+    pub(crate) proc_macros: IndexMap<Id, &'a Item>,
 }
 
 impl<'a> PubItemKindIndex<'a> {
@@ -250,16 +250,16 @@ impl<'a> PubItemKindIndex<'a> {
         Self {
             // Most top-level items in a crate are functions, structs, enums, or traits.
             // We want indexing to be fast, and it's okay if we waste a bit of memory.
-            free_functions: HashMap::with_capacity_and_hasher(capacity, rustc_hash::FxBuildHasher),
-            structs: HashMap::with_capacity_and_hasher(capacity, rustc_hash::FxBuildHasher),
-            enums: HashMap::with_capacity_and_hasher(capacity, rustc_hash::FxBuildHasher),
-            traits: HashMap::with_capacity_and_hasher(capacity, rustc_hash::FxBuildHasher),
-            unions: HashMap::default(),
-            modules: HashMap::with_capacity_and_hasher(64, rustc_hash::FxBuildHasher),
-            statics: HashMap::default(),
-            free_consts: HashMap::default(),
-            decl_macros: HashMap::default(),
-            proc_macros: HashMap::default(),
+            free_functions: IndexMap::with_capacity_and_hasher(capacity, rustc_hash::FxBuildHasher),
+            structs: IndexMap::with_capacity_and_hasher(capacity, rustc_hash::FxBuildHasher),
+            enums: IndexMap::with_capacity_and_hasher(capacity, rustc_hash::FxBuildHasher),
+            traits: IndexMap::with_capacity_and_hasher(capacity, rustc_hash::FxBuildHasher),
+            unions: IndexMap::default(),
+            modules: IndexMap::with_capacity_and_hasher(64, rustc_hash::FxBuildHasher),
+            statics: IndexMap::default(),
+            free_consts: IndexMap::default(),
+            decl_macros: IndexMap::default(),
+            proc_macros: IndexMap::default(),
         }
     }
 
@@ -269,16 +269,16 @@ impl<'a> PubItemKindIndex<'a> {
         Self {
             // Most top-level items in a crate are functions, structs, enums, or traits.
             // We want indexing to be fast, and it's okay if we waste a bit of memory.
-            free_functions: HashMap::with_capacity(capacity),
-            structs: HashMap::with_capacity(capacity),
-            enums: HashMap::with_capacity(capacity),
-            traits: HashMap::with_capacity(capacity),
-            unions: HashMap::new(),
-            modules: HashMap::with_capacity(64),
-            statics: HashMap::new(),
-            free_consts: HashMap::new(),
-            decl_macros: HashMap::new(),
-            proc_macros: HashMap::new(),
+            free_functions: IndexMap::with_capacity(capacity),
+            structs: IndexMap::with_capacity(capacity),
+            enums: IndexMap::with_capacity(capacity),
+            traits: IndexMap::with_capacity(capacity),
+            unions: IndexMap::new(),
+            modules: IndexMap::with_capacity(64),
+            statics: IndexMap::new(),
+            free_consts: IndexMap::new(),
+            decl_macros: IndexMap::new(),
+            proc_macros: IndexMap::new(),
         }
     }
 

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -318,7 +318,7 @@ impl<'a> PubItemKindIndex<'a> {
     /// Returns true if the index corresponding to the type given by
     /// `destination_type` contains an element with the id `item_id`.
     // Currently unused, but might be used in the future so it stays.
-    #[allow(unused)]  
+    #[allow(unused)]
     pub fn contains(&self, destination_type: &str, item_id: Id) -> bool {
         match destination_type {
             "Function" => self.free_functions.contains_key(&item_id),

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -335,7 +335,6 @@ impl<'a> PubItemKindIndex<'a> {
 
     /// Returns true if the index corresponding to the type given by
     /// `destination_type` contains an element with the id `item_id`.
-    /// Conservatively, returns true if passed a type that isn't contained in the indexes.
     pub fn contains(&self, destination_type: &str, item_id: Id) -> bool {
         match destination_type {
             "Function" => self.free_functions.contains_key(&item_id),
@@ -359,7 +358,17 @@ impl<'a> PubItemKindIndex<'a> {
                 self.proc_macros.contains_key(&item_id)
             }
             "Module" => self.modules.contains_key(&item_id),
-            _ => true,
+            _ => {
+                // Currently, this function is only called in the context of resolving
+                // the coercion of a crate to an item. As there are no lints that coerce
+                // an item to a type other than the ones listed above, this is unreachable.
+                // If a lint is added that does coerce to a different type, consider adding
+                // it to the index instead of making this branch reachable.
+                unreachable!(
+                    "PubItemKindIndex does not contain type {}",
+                    destination_type
+                )
+            }
         }
     }
 }

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -254,12 +254,12 @@ impl<'a> PubItemKindIndex<'a> {
             structs: HashMap::with_capacity_and_hasher(capacity, rustc_hash::FxBuildHasher),
             enums: HashMap::with_capacity_and_hasher(capacity, rustc_hash::FxBuildHasher),
             traits: HashMap::with_capacity_and_hasher(capacity, rustc_hash::FxBuildHasher),
-            unions: HashMap::with_hasher(rustc_hash::FxBuildHasher),
+            unions: HashMap::default(),
             modules: HashMap::with_capacity_and_hasher(64, rustc_hash::FxBuildHasher),
-            statics: HashMap::with_hasher(rustc_hash::FxBuildHasher),
-            free_consts: HashMap::with_hasher(rustc_hash::FxBuildHasher),
-            decl_macros: HashMap::with_hasher(rustc_hash::FxBuildHasher),
-            proc_macros: HashMap::with_hasher(rustc_hash::FxBuildHasher),
+            statics: HashMap::default(),
+            free_consts: HashMap::default(),
+            decl_macros: HashMap::default(),
+            proc_macros: HashMap::default(),
         }
     }
 

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -335,6 +335,8 @@ impl<'a> PubItemKindIndex<'a> {
 
     /// Returns true if the index corresponding to the type given by
     /// `destination_type` contains an element with the id `item_id`.
+    // Currently unused, but might be used in the future so it stays.
+    #[allow(unused)]  
     pub fn contains(&self, destination_type: &str, item_id: Id) -> bool {
         match destination_type {
             "Function" => self.free_functions.contains_key(&item_id),

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -203,6 +203,9 @@ pub struct IndexedCrate<'a> {
     /// -> function item with that export name; exported symbol names must be unique.
     pub(crate) export_name_index: Option<HashMap<&'a str, &'a Item>>,
 
+    /// index: kind of public top-level item -> `Vec<&'a Item>` of that kind
+    pub(crate) pub_item_kind_index: PubItemKindIndex<'a>,
+
     /// Trait items defined in external crates are not present in the `inner: &Crate` field,
     /// even if they are implemented by a type in that crate. This also includes
     /// Rust's built-in traits like `Debug, Send, Eq` etc.
@@ -224,6 +227,159 @@ pub struct IndexedCrate<'a> {
 
     /// Target feature information about our current target triple.
     pub(crate) target_features: HashMap<&'a str, &'a rustdoc_types::TargetFeature>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PubItemKindIndex<'a> {
+    pub(crate) free_functions: Vec<&'a Item>,
+    pub(crate) structs: Vec<&'a Item>,
+    pub(crate) enums: Vec<&'a Item>,
+    pub(crate) unions: Vec<&'a Item>,
+    pub(crate) traits: Vec<&'a Item>,
+    pub(crate) modules: Vec<&'a Item>,
+    pub(crate) statics: Vec<&'a Item>,
+    pub(crate) free_consts: Vec<&'a Item>,
+    pub(crate) decl_macros: Vec<&'a Item>,
+    pub(crate) proc_macros: Vec<&'a Item>,
+}
+
+impl<'a> PubItemKindIndex<'a> {
+    fn with_capacity_hint(hint: usize) -> Self {
+        let capacity = if hint < 128 * 128 { 128 } else { hint / 128 };
+        Self {
+            // Most top-level items in a crate are functions, structs, enums, or traits.
+            // We want indexing to be fast, and it's okay if we waste a bit of memory.
+            free_functions: Vec::with_capacity(capacity),
+            structs: Vec::with_capacity(capacity),
+            enums: Vec::with_capacity(capacity),
+            traits: Vec::with_capacity(capacity),
+            unions: Vec::new(),
+            modules: Vec::with_capacity(64),
+            statics: Vec::new(),
+            free_consts: Vec::new(),
+            decl_macros: Vec::new(),
+            proc_macros: Vec::new(),
+        }
+    }
+
+    fn from_crate(crate_: &'a Crate, fn_owner_index: &HashMap<Id, &'a Item>) -> Self {
+        #[cfg(feature = "rayon")]
+        let iter = crate_.index.par_iter().map(|(_, value)| value);
+        #[cfg(not(feature = "rayon"))]
+        let iter = crate_.index.values();
+
+        #[cfg(feature = "rayon")]
+        let init = || Self::with_capacity_hint(crate_.index.len());
+        #[cfg(not(feature = "rayon"))]
+        let init = Self::with_capacity_hint(crate_.index.len());
+
+        let folded = iter.fold(init, |mut acc, item| {
+            if item.visibility == rustdoc_types::Visibility::Public {
+                match &item.inner {
+                    rustdoc_types::ItemEnum::Module { .. } => {
+                        acc.modules.push(item);
+                    }
+                    rustdoc_types::ItemEnum::Union { .. } => {
+                        acc.unions.push(item);
+                    }
+                    rustdoc_types::ItemEnum::Struct { .. } => {
+                        acc.structs.push(item);
+                    }
+                    rustdoc_types::ItemEnum::Enum { .. } => {
+                        acc.enums.push(item);
+                    }
+                    rustdoc_types::ItemEnum::Function { .. } => {
+                        if !fn_owner_index.contains_key(&item.id) {
+                            // This is a free function.
+                            acc.free_functions.push(item);
+                        }
+                    }
+                    rustdoc_types::ItemEnum::Trait { .. } => {
+                        acc.traits.push(item);
+                    }
+                    rustdoc_types::ItemEnum::Constant { .. } => {
+                        acc.free_consts.push(item);
+                    }
+                    rustdoc_types::ItemEnum::Static { .. } => {
+                        acc.statics.push(item);
+                    }
+                    rustdoc_types::ItemEnum::Macro { .. } => {
+                        acc.decl_macros.push(item);
+                    }
+                    rustdoc_types::ItemEnum::ProcMacro { .. } => {
+                        acc.proc_macros.push(item);
+                    }
+                    _ => {}
+                }
+            }
+
+            acc
+        });
+
+        #[cfg(feature = "rayon")]
+        let folded = {
+            let collected = folded
+                .map(|index| vec![index])
+                .reduce(Vec::new, |mut left, right| {
+                    left.extend(right);
+                    left
+                });
+
+            let mut fns_len = 0;
+            let mut structs_len = 0;
+            let mut enums_len = 0;
+            let mut unions_len = 0;
+            let mut traits_len = 0;
+            let mut modules_len = 0;
+            let mut statics_len = 0;
+            let mut consts_len = 0;
+            let mut decl_macros_len = 0;
+            let mut proc_macros_len = 0;
+
+            for c in &collected {
+                fns_len += c.free_functions.len();
+                structs_len += c.structs.len();
+                enums_len += c.enums.len();
+                unions_len += c.unions.len();
+                traits_len += c.traits.len();
+                modules_len += c.modules.len();
+                statics_len += c.statics.len();
+                consts_len += c.free_consts.len();
+                decl_macros_len += c.decl_macros.len();
+                proc_macros_len += c.proc_macros.len();
+            }
+
+            let mut value = Self {
+                free_functions: Vec::with_capacity(fns_len),
+                structs: Vec::with_capacity(structs_len),
+                enums: Vec::with_capacity(enums_len),
+                unions: Vec::with_capacity(unions_len),
+                traits: Vec::with_capacity(traits_len),
+                modules: Vec::with_capacity(modules_len),
+                statics: Vec::with_capacity(statics_len),
+                free_consts: Vec::with_capacity(consts_len),
+                decl_macros: Vec::with_capacity(decl_macros_len),
+                proc_macros: Vec::with_capacity(proc_macros_len),
+            };
+
+            for c in collected {
+                value.free_functions.extend(c.free_functions);
+                value.structs.extend(c.structs);
+                value.enums.extend(c.enums);
+                value.unions.extend(c.unions);
+                value.traits.extend(c.traits);
+                value.modules.extend(c.modules);
+                value.statics.extend(c.statics);
+                value.free_consts.extend(c.free_consts);
+                value.decl_macros.extend(c.decl_macros);
+                value.proc_macros.extend(c.proc_macros);
+            }
+
+            value
+        };
+
+        folded
+    }
 }
 
 /// Map a Key to a List (Vec) of values
@@ -463,6 +619,7 @@ impl<'a> IndexedCrate<'a> {
             fn_owner_index: None,
             export_name_index: None,
             target_features,
+            pub_item_kind_index,
         };
 
         debug_assert!(

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -335,8 +335,7 @@ impl<'a> PubItemKindIndex<'a> {
 
     /// Returns true if the index corresponding to the type given by
     /// `destination_type` contains an element with the id `item_id`.
-    /// Conservatively, returns true if the destination is None or of a type
-    /// that isn't contained in the indexes.
+    /// Conservatively, returns true if passed a type that isn't contained in the indexes.
     pub fn contains(&self, destination_type: &str, item_id: Id) -> bool {
         match destination_type {
             "Function" => self.free_functions.contains_key(&item_id),

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -4,6 +4,8 @@ use std::{borrow::Borrow, collections::hash_map::Entry, sync::Arc};
 use rayon::prelude::*;
 use rustdoc_types::{Crate, Id, Item};
 
+#[allow(unused_imports)]
+use crate::hashtables::HashMapExt as _;
 use crate::{
     adapter::supported_item_kind,
     hashtables::{HashMap, HashSet, IndexMap},
@@ -244,26 +246,6 @@ pub(crate) struct PubItemKindIndex<'a> {
 }
 
 impl<'a> PubItemKindIndex<'a> {
-    #[cfg(feature = "rustc-hash")]
-    fn with_capacity_hint(hint: usize) -> Self {
-        let capacity = if hint < 128 * 128 { 128 } else { hint / 128 };
-        Self {
-            // Most top-level items in a crate are functions, structs, enums, or traits.
-            // We want indexing to be fast, and it's okay if we waste a bit of memory.
-            free_functions: IndexMap::with_capacity_and_hasher(capacity, rustc_hash::FxBuildHasher),
-            structs: IndexMap::with_capacity_and_hasher(capacity, rustc_hash::FxBuildHasher),
-            enums: IndexMap::with_capacity_and_hasher(capacity, rustc_hash::FxBuildHasher),
-            traits: IndexMap::with_capacity_and_hasher(capacity, rustc_hash::FxBuildHasher),
-            unions: IndexMap::default(),
-            modules: IndexMap::with_capacity_and_hasher(64, rustc_hash::FxBuildHasher),
-            statics: IndexMap::default(),
-            free_consts: IndexMap::default(),
-            decl_macros: IndexMap::default(),
-            proc_macros: IndexMap::default(),
-        }
-    }
-
-    #[cfg(not(feature = "rustc-hash"))]
     fn with_capacity_hint(hint: usize) -> Self {
         let capacity = if hint < 128 * 128 { 128 } else { hint / 128 };
         Self {

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -4,7 +4,10 @@ use std::{borrow::Borrow, collections::hash_map::Entry, sync::Arc};
 use rayon::prelude::*;
 use rustdoc_types::{Crate, Id, Item};
 
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    reason = "used when the `rustc-hash` feature is enabled"
+)]
 use crate::hashtables::HashMapExt as _;
 use crate::{
     adapter::supported_item_kind,
@@ -313,47 +316,6 @@ impl<'a> PubItemKindIndex<'a> {
 
             acc
         })
-    }
-
-    /// Returns true if the index corresponding to the type given by
-    /// `destination_type` contains an element with the id `item_id`.
-    // Currently unused, but might be used in the future so it stays.
-    #[allow(unused)]
-    pub fn contains(&self, destination_type: &str, item_id: Id) -> bool {
-        match destination_type {
-            "Function" => self.free_functions.contains_key(&item_id),
-            "Struct" => self.structs.contains_key(&item_id),
-            "Enum" => self.enums.contains_key(&item_id),
-            "Union" => self.unions.contains_key(&item_id),
-            "Trait" => self.traits.contains_key(&item_id),
-            "ImplOwner" => {
-                self.structs.contains_key(&item_id)
-                    || self.enums.contains_key(&item_id)
-                    || self.unions.contains_key(&item_id)
-            }
-            "Constant" => self.free_consts.contains_key(&item_id),
-            "Static" => self.statics.contains_key(&item_id),
-            "GlobalValue" => {
-                // const or static
-                self.free_consts.contains_key(&item_id) || self.statics.contains_key(&item_id)
-            }
-            "Macro" => self.decl_macros.contains_key(&item_id),
-            "ProcMacro" | "FunctionLikeProcMacro" | "AttributeProcMacro" | "DeriveProcMacro" => {
-                self.proc_macros.contains_key(&item_id)
-            }
-            "Module" => self.modules.contains_key(&item_id),
-            _ => {
-                // Currently, this function is only called in the context of resolving
-                // the coercion of a crate to an item. As there are no lints that coerce
-                // an item to a type other than the ones listed above, this is unreachable.
-                // If a lint is added that does coerce to a different type, consider adding
-                // it to the index instead of making this branch reachable.
-                unreachable!(
-                    "PubItemKindIndex does not contain type {}",
-                    destination_type
-                )
-            }
-        }
     }
 }
 

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -330,6 +330,130 @@ impl<'a> PubItemKindIndex<'a> {
         })
     }
 
+
+    // A duplicate of from_crate that generates the index in parallel. It exists
+    // only for benchmarking purposes.
+    #[cfg(feature = "rustc-hash")]
+    fn from_crate_parallel(crate_: &'a Crate, fn_owner_index: &HashMap<Id, &'a Item>) -> Self {
+        #[cfg(feature = "rayon")]
+        let iter = crate_.index.par_iter().map(|(_, value)| value);
+        #[cfg(not(feature = "rayon"))]
+        let iter = crate_.index.values();
+
+        #[cfg(feature = "rayon")]
+        let init = || Self::with_capacity_hint(crate_.index.len());
+        #[cfg(not(feature = "rayon"))]
+        let init = Self::with_capacity_hint(crate_.index.len());
+
+        let folded = iter.fold(init, |mut acc, item| {
+            if item.visibility == rustdoc_types::Visibility::Public {
+                match &item.inner {
+                    rustdoc_types::ItemEnum::Module { .. } => {
+                        acc.modules.insert(item.id, item);
+                    }
+                    rustdoc_types::ItemEnum::Union { .. } => {
+                        acc.unions.insert(item.id, item);
+                    }
+                    rustdoc_types::ItemEnum::Struct { .. } => {
+                        acc.structs.insert(item.id, item);
+                    }
+                    rustdoc_types::ItemEnum::Enum { .. } => {
+                        acc.enums.insert(item.id, item);
+                    }
+                    rustdoc_types::ItemEnum::Function { .. } => {
+                        if !fn_owner_index.contains_key(&item.id) {
+                            // This is a free function.
+                            acc.free_functions.insert(item.id, item);
+                        }
+                    }
+                    rustdoc_types::ItemEnum::Trait { .. } => {
+                        acc.traits.insert(item.id, item);
+                    }
+                    rustdoc_types::ItemEnum::Constant { .. } => {
+                        acc.free_consts.insert(item.id, item);
+                    }
+                    rustdoc_types::ItemEnum::Static { .. } => {
+                        acc.statics.insert(item.id, item);
+                    }
+                    rustdoc_types::ItemEnum::Macro { .. } => {
+                        acc.decl_macros.insert(item.id, item);
+                    }
+                    rustdoc_types::ItemEnum::ProcMacro { .. } => {
+                        acc.proc_macros.insert(item.id, item);
+                    }
+                    _ => {}
+                }
+            }
+
+            acc
+        });
+
+        #[cfg(feature = "rayon")]
+        let folded = {
+            let collected = folded
+                .map(|index| vec![index])
+                .reduce(Vec::new, |mut left, right| {
+                    left.extend(right);
+                    left
+                });
+
+            let mut fns_len = 0;
+            let mut structs_len = 0;
+            let mut enums_len = 0;
+            let mut unions_len = 0;
+            let mut traits_len = 0;
+            let mut modules_len = 0;
+            let mut statics_len = 0;
+            let mut consts_len = 0;
+            let mut decl_macros_len = 0;
+            let mut proc_macros_len = 0;
+
+            for c in &collected {
+                fns_len += c.free_functions.len();
+                structs_len += c.structs.len();
+                enums_len += c.enums.len();
+                unions_len += c.unions.len();
+                traits_len += c.traits.len();
+                modules_len += c.modules.len();
+                statics_len += c.statics.len();
+                consts_len += c.free_consts.len();
+                decl_macros_len += c.decl_macros.len();
+                proc_macros_len += c.proc_macros.len();
+            }
+
+            // For the purposes of benchmarking.
+            let mut value = Self {
+                free_functions: HashMap::with_capacity_and_hasher(fns_len, rustc_hash::FxBuildHasher),
+                structs: HashMap::with_capacity_and_hasher(structs_len, rustc_hash::FxBuildHasher),
+                enums: HashMap::with_capacity_and_hasher(enums_len, rustc_hash::FxBuildHasher),
+                unions: HashMap::with_capacity_and_hasher(unions_len, rustc_hash::FxBuildHasher),
+                traits: HashMap::with_capacity_and_hasher(traits_len, rustc_hash::FxBuildHasher),
+                modules: HashMap::with_capacity_and_hasher(modules_len, rustc_hash::FxBuildHasher),
+                statics: HashMap::with_capacity_and_hasher(statics_len, rustc_hash::FxBuildHasher),
+                free_consts: HashMap::with_capacity_and_hasher(consts_len, rustc_hash::FxBuildHasher),
+                decl_macros: HashMap::with_capacity_and_hasher(decl_macros_len, rustc_hash::FxBuildHasher),
+                proc_macros: HashMap::with_capacity_and_hasher(proc_macros_len, rustc_hash::FxBuildHasher),
+            };
+
+            for c in collected {
+                value.free_functions.extend(c.free_functions);
+                value.structs.extend(c.structs);
+                value.enums.extend(c.enums);
+                value.unions.extend(c.unions);
+                value.traits.extend(c.traits);
+                value.modules.extend(c.modules);
+                value.statics.extend(c.statics);
+                value.free_consts.extend(c.free_consts);
+                value.decl_macros.extend(c.decl_macros);
+                value.proc_macros.extend(c.proc_macros);
+            }
+
+            value
+        };
+
+        folded
+    }
+
     /// Returns true if the index corresponding to the type given by
     /// `destination_type` contains an element with the id `item_id`.
     /// Conservatively, returns true if the destination is None or of a type
@@ -652,6 +776,81 @@ impl<'a> IndexedCrate<'a> {
 
         value
     }
+
+    // Only exists for temporary benchmarking purposes. Exactly the same as new
+    // but creates the PubItemKindIndex in parallel.
+    pub fn new_parallel(crate_: &'a Crate) -> Self {
+        let fn_owner_index = build_fn_owner_index(&crate_.index);
+        let pub_item_kind_index = PubItemKindIndex::from_crate_parallel(crate_, &fn_owner_index);
+
+        let (manually_inlined_builtin_traits, sized_trait) =
+            create_manually_inlined_builtin_traits(crate_);
+
+        let target_features = crate_
+            .target
+            .target_features
+            .iter()
+            .map(|feat| (feat.name.as_str(), feat))
+            .collect();
+
+        let mut value = Self {
+            inner: crate_,
+            visibility_tracker: VisibilityTracker::from_crate(crate_),
+            manually_inlined_builtin_traits,
+            sized_trait,
+            flags: None,
+            imports_index: None,
+            impl_method_index: None,
+            fn_owner_index: None,
+            export_name_index: None,
+            target_features,
+            pub_item_kind_index,
+        };
+
+        debug_assert!(
+            !value.manually_inlined_builtin_traits.is_empty(),
+            "failed to find any traits to manually inline",
+        );
+
+        // Build the imports index
+        //
+        // This is inlined because we need access to `value`, but `value` is not a valid
+        // `IndexedCrate` yet. Do not extract into a separate function.
+        #[cfg(feature = "rayon")]
+        let iter = crate_.index.par_iter();
+        #[cfg(not(feature = "rayon"))]
+        let iter = crate_.index.iter();
+
+        let imports_index = iter
+            .filter_map(|(_id, item)| {
+                if !supported_item_kind(item) {
+                    return None;
+                }
+                let importable_paths = value.publicly_importable_names(&item.id);
+
+                #[cfg(feature = "rayon")]
+                let iter = importable_paths.into_par_iter();
+                #[cfg(not(feature = "rayon"))]
+                let iter = importable_paths.into_iter();
+
+                Some(iter.map(move |importable_path| {
+                    (importable_path.path, (item, importable_path.modifiers))
+                }))
+            })
+            .flatten()
+            .collect::<MapList<_, _>>()
+            .into_inner();
+        value.flags = Some(build_flags_index(&crate_.index, &imports_index));
+        value.imports_index = Some(imports_index);
+
+        value.impl_method_index = Some(build_impl_index(&crate_.index).into_inner());
+        value.fn_owner_index = Some(fn_owner_index);
+        value.export_name_index = Some(build_export_name_index(&crate_.index));
+
+        value
+    }
+
+
 
     /// Return all the paths with which the given item can be imported from this crate.
     pub fn publicly_importable_names(&self, id: &'a Id) -> Vec<ImportablePath<'a>> {


### PR DESCRIPTION
This PR is based on #676. Due to merge conflicts it was easier to create a new PR than attempt to build on that one, but all the points made in that PR remain current.

**Purpose of Change**
From @obi1kenobi in #676:
> Most items we'll see in the crate either aren't public, or aren't top-level items that would be returned by the `Crate -[item]-> Item` edge. For example, many of those items are methods, impls, trait associated types, associated constants, etc.
> 
> In this PR, we ensure we don't bother iterating over such items in queries where they can't possibly match. Queries that look at public structs should only iterate over structs, ones that look at enums should only iterate over enums, etc.
> 
> This has a substantial performance effect: it speeds up the median `cargo-semver-checks` lint by ~100x, and makes it so that a tiny handful (~5) of lints dominate all linting runtime — the combined runtime of all other lints becomes negligible. In end-to-end terms, `cargo-semver-checks` becomes about ~35% faster on our largest workload, but this number is misleadingly small w.r.t. the impact of this optimization: the new runtime is now equal to ~101% of the slowest lint, whereas that number was ~140% previously. If we can now optimize that slow lint in particular, we'll get tens of percent of additional speedup from the optimization in this PR.

On top of that, when calling `resolve_crate_items` and resolving a path, all items matching that path are returned from `imports_index`. However, a single path might have dozens of imports, and only some of these items will be of the right type (e.g. a Trait or Enum). 

**Describe the Solution**
In order to return only the items of the right type, we can take the intersection of `imports_index` and `pub_item_kind_index`. However, as both of these were vectors, it was very inefficient to find their intersection. Replacing the vectors inside `pub_item_kind_index` with maps allows efficiently taking the intersection of indices.

As noted in https://github.com/obi1kenobi/trustfall-rustdoc-adapter/pull/676#issuecomment-3051767440, there is a decent improvement in performance thanks to this change (roughly a 40% improvement in total time spent in queries). Additionally, since the indices are generally quite small there is a negligible effect on indexed crate creation time.

**Describe alternatives you've considered**
- Use an `Rc<str>` instead of `Arc<str>`. I think it would be safe, but I don't know enough about trustfall's internals to be sure.
- ~~Inline `PubItemKindIndex::contains` into `resolve_items_by_importable_path_field_value`~~. This was done.
- Create the index in parallel. Benchmarks showed parallel construction used in the original commit was significantly slower than the single-threaded version, taking over a second compared to the single-threaded version resolving in milliseconds.