### PR TITLE
Use hashtables.rs instead of cfg attributes.

### DIFF
--- a/src/sealed_trait.rs
+++ b/src/sealed_trait.rs
@@ -1,12 +1,9 @@
-#[cfg(not(feature = "rustc-hash"))]
-use std::collections::{HashMap, HashSet};
-
-#[cfg(feature = "rustc-hash")]
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-
 use rustdoc_types::{GenericBound, Id, Item, Trait};
 
-use crate::item_flags::ItemFlag;
+use crate::{
+    hashtables::{HashMap, HashSet},
+    item_flags::ItemFlag,
+};
 
 /// Update the `flags` with trait sealing and blanket impls information.
 ///

--- a/src/visibility_tracker.rs
+++ b/src/visibility_tracker.rs
@@ -1,15 +1,13 @@
-#[cfg(not(feature = "rustc-hash"))]
-use std::collections::{HashMap, HashSet};
-
-#[cfg(feature = "rustc-hash")]
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-
 use rustdoc_types::{Crate, GenericArgs, Id, Item, ItemEnum, TypeAlias, Visibility};
 
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
 
-use crate::{ImportablePath, attributes::Attribute};
+use crate::{
+    ImportablePath,
+    attributes::Attribute,
+    hashtables::{HashMap, HashSet},
+};
 
 #[derive(Debug, Clone)]
 pub(crate) struct VisibilityTracker<'a> {


### PR DESCRIPTION
While working on #902, I came across these two files which don't use `hashtables.rs`.

**Purpose of Change**
Makes code slightly cleaner.