### PR TITLE
Add a per-item-kind index of public items (#902)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,9 +312,9 @@ checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -748,6 +748,7 @@ dependencies = [
  "cargo_metadata",
  "cargo_toml",
  "criterion",
+ "indexmap",
  "itertools 0.13.0",
  "maplit",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ cargo_toml = { version = "0.21.0", features = ["features"] }
 #
 trustfall = "0.8.0"
 cargo_metadata = "0.19.1"
+indexmap = "2.10.0"
 
 #
 # Keep this dependency last, its own block, since we change it often via automated means
@@ -45,6 +46,7 @@ harness = false
 
 [profile.bench]
 debug = 1 # We only need function name information (for flamegraphs)
+lto = "thin"
 
 [dev-dependencies]
 anyhow = "1.0.89"

--- a/src/adapter/optimizations/item_lookup.rs
+++ b/src/adapter/optimizations/item_lookup.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use rustdoc_types::Item;
 use trustfall::{
     FieldValue,
@@ -31,16 +33,26 @@ pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
         // statically vs dynamically, so we check the dynamic case first since
         // it might be more specific.
         if let Some(dynamic_value) = neighbor_info.dynamically_required_property("path") {
-            return dynamic_value.resolve_with(&adapter, contexts, |vertex, candidate| {
+            return dynamic_value.resolve_with(&adapter, contexts, move |vertex, candidate| {
                 let crate_vertex = vertex.as_indexed_crate().expect("vertex was not a Crate");
                 let origin = vertex.origin;
-                resolve_items_by_importable_path(crate_vertex, origin, candidate)
+                resolve_items_by_importable_path(
+                    crate_vertex,
+                    origin,
+                    destination.coerced_to_type().cloned(),
+                    candidate,
+                )
             });
         } else if let Some(path_value) = neighbor_info.statically_required_property("path") {
             return resolve_neighbors_with(contexts, move |vertex| {
                 let crate_vertex = vertex.as_indexed_crate().expect("vertex was not a Crate");
                 let origin = vertex.origin;
-                resolve_items_by_importable_path(crate_vertex, origin, path_value.clone())
+                resolve_items_by_importable_path(
+                    crate_vertex,
+                    origin,
+                    destination.coerced_to_type().cloned(),
+                    path_value.clone(),
+                )
             });
         }
     }
@@ -65,6 +77,195 @@ pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
         }
     }
 
+    // Is the `importable_path` edge being resolved in a subsequent step in a *mandatory* fashion?
+    // If so, we could only match on public items, so check which kinds of public items
+    // we're looking for and only return those from the index.
+    if destination
+        .first_mandatory_edge("importable_path")
+        .is_some()
+    {
+        if let Some(item_type) = destination.coerced_to_type().map(|x| x.as_ref()) {
+            match item_type {
+                "Function" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .free_functions
+                                .values()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    });
+                }
+                "Struct" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .structs
+                                .values()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    });
+                }
+                "Enum" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .enums
+                                .values()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    });
+                }
+                "Union" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .unions
+                                .values()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    });
+                }
+                "Trait" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .traits
+                                .values()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    });
+                }
+                "ImplOwner" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .structs
+                                .values()
+                                .chain(crate_vertex.pub_item_kind_index.enums.values())
+                                .chain(crate_vertex.pub_item_kind_index.unions.values())
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    });
+                }
+                "Constant" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .free_consts
+                                .values()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    });
+                }
+                "Static" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .statics
+                                .values()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    });
+                }
+                "GlobalValue" => {
+                    // const or static
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .free_consts
+                                .values()
+                                .chain(crate_vertex.pub_item_kind_index.statics.values())
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    });
+                }
+                "Macro" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .decl_macros
+                                .values()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    });
+                }
+                "ProcMacro"
+                | "FunctionLikeProcMacro"
+                | "AttributeProcMacro"
+                | "DeriveProcMacro" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .proc_macros
+                                .values()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    });
+                }
+                "Module" => {
+                    return resolve_neighbors_with(contexts, move |vertex| {
+                        let crate_vertex =
+                            vertex.as_indexed_crate().expect("vertex was not a Crate");
+                        let origin = vertex.origin;
+                        Box::new(
+                            crate_vertex
+                                .pub_item_kind_index
+                                .modules
+                                .values()
+                                .map(move |item| origin.make_item_vertex(item)),
+                        )
+                    });
+                }
+                _ => {}
+            }
+        }
+    }
+
     resolve_neighbors_with(contexts, |vertex| {
         let crate_vertex = vertex.as_indexed_crate().expect("vertex was not a Crate");
         let origin = vertex.origin;
@@ -72,18 +273,31 @@ pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
     })
 }
 
+/// Resolve public items with candidate value `importable_path` and type `destination_type`.
+///
+/// If the destination is None or an unrecognised string, we conservatively return all
+/// paths that match the candidate value.
 fn resolve_items_by_importable_path<'a>(
     crate_vertex: &'a IndexedCrate,
     origin: Origin,
+    destination_type: Option<Arc<str>>,
     importable_path: CandidateValue<FieldValue>,
 ) -> VertexIterator<'a, Vertex<'a>> {
     match importable_path {
         CandidateValue::Impossible => Box::new(std::iter::empty()),
-        CandidateValue::Single(value) => {
-            resolve_items_by_importable_path_field_value(crate_vertex, origin, &value)
-        }
+        CandidateValue::Single(value) => resolve_items_by_importable_path_field_value(
+            crate_vertex,
+            origin,
+            destination_type.as_deref(),
+            &value,
+        ),
         CandidateValue::Multiple(values) => Box::new(values.into_iter().flat_map(move |value| {
-            resolve_items_by_importable_path_field_value(crate_vertex, origin, &value)
+            resolve_items_by_importable_path_field_value(
+                crate_vertex,
+                origin,
+                destination_type.as_deref(),
+                &value,
+            )
         })),
         _ => {
             // fall through to slow path
@@ -92,12 +306,20 @@ fn resolve_items_by_importable_path<'a>(
     }
 }
 
+/// Resolve public items with importable path `path`, optionally of vertex type `destination_type`.
+///
+/// For example, "structs at path `foo::bar`" or "anything at `foo::bar`".
+/// The former has destination type `Some("Struct")`, while the latter has `None`.
+///
+/// When the destination is `None` or the name of a type that we don't have an index for,
+/// we conservatively return all paths that match the `value`.
 fn resolve_items_by_importable_path_field_value<'a>(
     crate_vertex: &'a IndexedCrate,
     origin: Origin,
-    value: &FieldValue,
+    destination_type: Option<&str>,
+    path: &FieldValue,
 ) -> VertexIterator<'a, Vertex<'a>> {
-    let path_components: Vec<&str> = value
+    let path_components: Vec<&str> = path
         .as_slice()
         .expect("ImportablePath.path was not a list")
         .iter()
@@ -109,9 +331,148 @@ fn resolve_items_by_importable_path_field_value<'a>(
         .expect("crate's imports_index was never constructed")
         .get(path_components.as_slice())
     {
-        resolve_item_vertices(origin, items.iter().map(|(item, _)| item).copied())
+        let base_iter = items.iter().map(|(item, _)| item).copied();
+        if let Some(destination_type) = destination_type {
+            match destination_type {
+                "Function" => resolve_item_vertices(
+                    origin,
+                    base_iter.filter(move |item| {
+                        crate_vertex
+                            .pub_item_kind_index
+                            .free_functions
+                            .contains_key(&item.id)
+                    }),
+                ),
+                "Struct" => resolve_item_vertices(
+                    origin,
+                    base_iter.filter(move |item| {
+                        crate_vertex
+                            .pub_item_kind_index
+                            .structs
+                            .contains_key(&item.id)
+                    }),
+                ),
+                "Enum" => resolve_item_vertices(
+                    origin,
+                    base_iter.filter(move |item| {
+                        crate_vertex
+                            .pub_item_kind_index
+                            .enums
+                            .contains_key(&item.id)
+                    }),
+                ),
+                "Union" => resolve_item_vertices(
+                    origin,
+                    base_iter.filter(move |item| {
+                        crate_vertex
+                            .pub_item_kind_index
+                            .unions
+                            .contains_key(&item.id)
+                    }),
+                ),
+                "Trait" => resolve_item_vertices(
+                    origin,
+                    base_iter.filter(move |item| {
+                        crate_vertex
+                            .pub_item_kind_index
+                            .traits
+                            .contains_key(&item.id)
+                    }),
+                ),
+                "ImplOwner" => resolve_item_vertices(
+                    origin,
+                    base_iter.filter(move |item| {
+                        crate_vertex
+                            .pub_item_kind_index
+                            .structs
+                            .contains_key(&item.id)
+                            || crate_vertex
+                                .pub_item_kind_index
+                                .enums
+                                .contains_key(&item.id)
+                            || crate_vertex
+                                .pub_item_kind_index
+                                .unions
+                                .contains_key(&item.id)
+                    }),
+                ),
+                "Constant" => resolve_item_vertices(
+                    origin,
+                    base_iter.filter(move |item| {
+                        crate_vertex
+                            .pub_item_kind_index
+                            .free_consts
+                            .contains_key(&item.id)
+                    }),
+                ),
+                "Static" => resolve_item_vertices(
+                    origin,
+                    base_iter.filter(move |item| {
+                        crate_vertex
+                            .pub_item_kind_index
+                            .statics
+                            .contains_key(&item.id)
+                    }),
+                ),
+                "GlobalValue" => resolve_item_vertices(
+                    origin,
+                    base_iter.filter(move |item| {
+                        // const or static
+                        crate_vertex
+                            .pub_item_kind_index
+                            .free_consts
+                            .contains_key(&item.id)
+                            || crate_vertex
+                                .pub_item_kind_index
+                                .statics
+                                .contains_key(&item.id)
+                    }),
+                ),
+                "Macro" => resolve_item_vertices(
+                    origin,
+                    base_iter.filter(move |item| {
+                        crate_vertex
+                            .pub_item_kind_index
+                            .decl_macros
+                            .contains_key(&item.id)
+                    }),
+                ),
+                "ProcMacro"
+                | "FunctionLikeProcMacro"
+                | "AttributeProcMacro"
+                | "DeriveProcMacro" => resolve_item_vertices(
+                    origin,
+                    base_iter.filter(move |item| {
+                        crate_vertex
+                            .pub_item_kind_index
+                            .proc_macros
+                            .contains_key(&item.id)
+                    }),
+                ),
+                "Module" => resolve_item_vertices(
+                    origin,
+                    base_iter.filter(move |item| {
+                        crate_vertex
+                            .pub_item_kind_index
+                            .modules
+                            .contains_key(&item.id)
+                    }),
+                ),
+                _ => {
+                    // No index is available for this type.
+                    //
+                    // If this branch is reached inside time sensitive code, consider
+                    // adding the destination type to an index.
+                    resolve_item_vertices(origin, base_iter)
+                }
+            }
+        } else {
+            // This query doesn't apply a coercion on the resulting vertex,
+            // so we produce all vertices that matched the path lookup.
+            resolve_item_vertices(origin, base_iter)
+        }
     } else {
-        // No such items found.
+        // No items at found at the given path.
         Box::new(std::iter::empty())
     }
 }

--- a/src/hashtables.rs
+++ b/src/hashtables.rs
@@ -1,5 +1,50 @@
+use std::default::Default;
+use std::hash::{BuildHasher, Hash};
+
 #[cfg(not(feature = "rustc-hash"))]
 pub(crate) use std::collections::{HashMap, HashSet};
 
 #[cfg(feature = "rustc-hash")]
 pub(crate) use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+
+#[cfg(feature = "rustc-hash")]
+pub(crate) type IndexMap<K, V> = indexmap::map::IndexMap<K, V, rustc_hash::FxBuildHasher>;
+
+#[cfg(not(feature = "rustc-hash"))]
+pub(crate) use indexmap::map::IndexMap;
+
+/// Allow using new() and with_capacity() regardless of the hash algorithm.
+/// See <https://github.com/tkaitchuck/aHash/issues/103> for more information.
+#[allow(dead_code, reason = "used when the `rustc-hash` feature is enabled")]
+pub(crate) trait HashMapExt {
+    fn new() -> Self;
+    fn with_capacity(x: usize) -> Self;
+}
+
+impl<K, V, S> HashMapExt for std::collections::HashMap<K, V, S>
+where
+    K: Hash + Eq,
+    S: BuildHasher + Default,
+{
+    fn new() -> Self {
+        std::collections::HashMap::with_hasher(S::default())
+    }
+
+    fn with_capacity(capacity: usize) -> Self {
+        std::collections::HashMap::with_capacity_and_hasher(capacity, S::default())
+    }
+}
+
+impl<K, V, S> HashMapExt for indexmap::map::IndexMap<K, V, S>
+where
+    K: Hash + Eq,
+    S: BuildHasher + Default,
+{
+    fn new() -> Self {
+        indexmap::map::IndexMap::with_hasher(S::default())
+    }
+
+    fn with_capacity(capacity: usize) -> Self {
+        indexmap::map::IndexMap::with_capacity_and_hasher(capacity, S::default())
+    }
+}

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -4,9 +4,14 @@ use std::{borrow::Borrow, collections::hash_map::Entry, sync::Arc};
 use rayon::prelude::*;
 use rustdoc_types::{Crate, Id, Item};
 
+#[allow(
+    unused_imports,
+    reason = "used when the `rustc-hash` feature is enabled"
+)]
+use crate::hashtables::HashMapExt as _;
 use crate::{
     adapter::supported_item_kind,
-    hashtables::{HashMap, HashSet},
+    hashtables::{HashMap, HashSet, IndexMap},
     item_flags::{ItemFlag, build_flags_index},
     visibility_tracker::VisibilityTracker,
 };
@@ -203,6 +208,9 @@ pub struct IndexedCrate<'a> {
     /// -> function item with that export name; exported symbol names must be unique.
     pub(crate) export_name_index: Option<HashMap<&'a str, &'a Item>>,
 
+    /// index: kind of public top-level item -> `IndexMap<Id, &'a Item>` of that kind
+    pub(crate) pub_item_kind_index: PubItemKindIndex<'a>,
+
     /// Trait items defined in external crates are not present in the `inner: &Crate` field,
     /// even if they are implemented by a type in that crate. This also includes
     /// Rust's built-in traits like `Debug, Send, Eq` etc.
@@ -224,6 +232,91 @@ pub struct IndexedCrate<'a> {
 
     /// Target feature information about our current target triple.
     pub(crate) target_features: HashMap<&'a str, &'a rustdoc_types::TargetFeature>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PubItemKindIndex<'a> {
+    pub(crate) free_functions: IndexMap<Id, &'a Item>,
+    pub(crate) structs: IndexMap<Id, &'a Item>,
+    pub(crate) enums: IndexMap<Id, &'a Item>,
+    pub(crate) unions: IndexMap<Id, &'a Item>,
+    pub(crate) traits: IndexMap<Id, &'a Item>,
+    pub(crate) modules: IndexMap<Id, &'a Item>,
+    pub(crate) statics: IndexMap<Id, &'a Item>,
+    pub(crate) free_consts: IndexMap<Id, &'a Item>,
+    pub(crate) decl_macros: IndexMap<Id, &'a Item>,
+    pub(crate) proc_macros: IndexMap<Id, &'a Item>,
+}
+
+impl<'a> PubItemKindIndex<'a> {
+    fn with_capacity_hint(hint: usize) -> Self {
+        let capacity = if hint < 128 * 128 { 128 } else { hint / 128 };
+        Self {
+            // Most top-level items in a crate are functions, structs, enums, or traits.
+            // We want indexing to be fast, and it's okay if we waste a bit of memory.
+            free_functions: IndexMap::with_capacity(capacity),
+            structs: IndexMap::with_capacity(capacity),
+            enums: IndexMap::with_capacity(capacity),
+            traits: IndexMap::with_capacity(capacity),
+            unions: IndexMap::new(),
+            modules: IndexMap::with_capacity(64),
+            statics: IndexMap::new(),
+            free_consts: IndexMap::new(),
+            decl_macros: IndexMap::new(),
+            proc_macros: IndexMap::new(),
+        }
+    }
+
+    fn from_crate(crate_: &'a Crate, fn_owner_index: &HashMap<Id, &'a Item>) -> Self {
+        // Parallel construction takes significantly longer than single-threaded.
+        // See https://github.com/obi1kenobi/trustfall-rustdoc-adapter/pull/902#issuecomment-3054606032
+        // for a comparison of the runtimes.
+        let iter = crate_.index.values();
+        let init = PubItemKindIndex::with_capacity_hint(crate_.index.len());
+
+        iter.fold(init, |mut acc, item| {
+            if item.visibility == rustdoc_types::Visibility::Public {
+                match &item.inner {
+                    rustdoc_types::ItemEnum::Module { .. } => {
+                        acc.modules.insert(item.id, item);
+                    }
+                    rustdoc_types::ItemEnum::Union { .. } => {
+                        acc.unions.insert(item.id, item);
+                    }
+                    rustdoc_types::ItemEnum::Struct { .. } => {
+                        acc.structs.insert(item.id, item);
+                    }
+                    rustdoc_types::ItemEnum::Enum { .. } => {
+                        acc.enums.insert(item.id, item);
+                    }
+                    rustdoc_types::ItemEnum::Function { .. } => {
+                        if !fn_owner_index.contains_key(&item.id) {
+                            // This is a free function.
+                            acc.free_functions.insert(item.id, item);
+                        }
+                    }
+                    rustdoc_types::ItemEnum::Trait { .. } => {
+                        acc.traits.insert(item.id, item);
+                    }
+                    rustdoc_types::ItemEnum::Constant { .. } => {
+                        acc.free_consts.insert(item.id, item);
+                    }
+                    rustdoc_types::ItemEnum::Static { .. } => {
+                        acc.statics.insert(item.id, item);
+                    }
+                    rustdoc_types::ItemEnum::Macro { .. } => {
+                        acc.decl_macros.insert(item.id, item);
+                    }
+                    rustdoc_types::ItemEnum::ProcMacro { .. } => {
+                        acc.proc_macros.insert(item.id, item);
+                    }
+                    _ => {}
+                }
+            }
+
+            acc
+        })
+    }
 }
 
 /// Map a Key to a List (Vec) of values
@@ -442,6 +535,9 @@ fn build_impl_index(index: &HashMap<Id, Item>) -> MapList<ImplEntry<'_>, (&Item,
 
 impl<'a> IndexedCrate<'a> {
     pub fn new(crate_: &'a Crate) -> Self {
+        let fn_owner_index = build_fn_owner_index(&crate_.index);
+        let pub_item_kind_index = PubItemKindIndex::from_crate(crate_, &fn_owner_index);
+
         let (manually_inlined_builtin_traits, sized_trait) =
             create_manually_inlined_builtin_traits(crate_);
 
@@ -463,6 +559,7 @@ impl<'a> IndexedCrate<'a> {
             fn_owner_index: None,
             export_name_index: None,
             target_features,
+            pub_item_kind_index,
         };
 
         debug_assert!(
@@ -502,7 +599,7 @@ impl<'a> IndexedCrate<'a> {
         value.imports_index = Some(imports_index);
 
         value.impl_method_index = Some(build_impl_index(&crate_.index).into_inner());
-        value.fn_owner_index = Some(build_fn_owner_index(&crate_.index));
+        value.fn_owner_index = Some(fn_owner_index);
         value.export_name_index = Some(build_export_name_index(&crate_.index));
 
         value


### PR DESCRIPTION
This PR is based on #676. Due to merge conflicts it was easier to create
a new PR than attempt to build on that one, but all the points made in
that PR remain current.

**Purpose of Change**
From @obi1kenobi in #676:
> Most items we'll see in the crate either aren't public, or aren't
top-level items that would be returned by the `Crate -[item]-> Item`
edge. For example, many of those items are methods, impls, trait
associated types, associated constants, etc.
>
> In this PR, we ensure we don't bother iterating over such items in
queries where they can't possibly match. Queries that look at public
structs should only iterate over structs, ones that look at enums should
only iterate over enums, etc.
>
> This has a substantial performance effect: it speeds up the median
`cargo-semver-checks` lint by ~100x, and makes it so that a tiny handful
(~5) of lints dominate all linting runtime — the combined runtime of all
other lints becomes negligible. In end-to-end terms,
`cargo-semver-checks` becomes about ~35% faster on our largest workload,
but this number is misleadingly small w.r.t. the impact of this
optimization: the new runtime is now equal to ~101% of the slowest lint,
whereas that number was ~140% previously. If we can now optimize that
slow lint in particular, we'll get tens of percent of additional speedup
from the optimization in this PR.

On top of that, when calling `resolve_crate_items` and resolving a path,
all items matching that path are returned from `imports_index`. However,
a single path might have dozens of imports, and only some of these items
will be of the right type (e.g. a Trait or Enum).

**Describe the Solution**
In order to return only the items of the right type, we can take the
intersection of `imports_index` and `pub_item_kind_index`. However, as
both of these were vectors, it was very inefficient to find their
intersection. Replacing the vectors inside `pub_item_kind_index` with
maps allows efficiently taking the intersection of indices.

As noted in
https://github.com/obi1kenobi/trustfall-rustdoc-adapter/pull/676#issuecomment-3051767440,
there is a decent improvement in performance thanks to this change
(roughly a 40% improvement in total time spent in queries).
Additionally, since the indices are generally quite small there is a
negligible effect on indexed crate creation time.

**Describe alternatives you've considered**
- Use an `Rc<str>` instead of `Arc<str>`. I think it would be safe, but
I don't know enough about trustfall's internals to be sure.
- ~~Inline `PubItemKindIndex::contains` into
`resolve_items_by_importable_path_field_value`~~. This was done.
- Create the index in parallel. Benchmarks showed parallel construction
used in the original commit was significantly slower than the
single-threaded version, taking over a second compared to the
single-threaded version resolving in milliseconds.

---------

Co-authored-by: Predrag Gruevski <obi1kenobi82@gmail.com>
Co-authored-by: Predrag Gruevski <2348618+obi1kenobi@users.noreply.github.com>
