### PR TITLE
Introduce new function, `crate_at_origin` to simplify common code path.

### DIFF
--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -51,44 +51,31 @@ pub(super) fn resolve_crate_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
     match edge_name {
         "item" => optimizations::item_lookup::resolve_crate_items(adapter, contexts, resolve_info),
-        "root_module" => {
-            let current_crate = adapter.current_crate;
-            let previous_crate = adapter.previous_crate;
+        "root_module" => resolve_neighbors_with(contexts, move |vertex| {
+            let origin = vertex.origin;
+            let crate_ = vertex.as_crate().expect("vertex was not a crate!");
+            let item_index = &adapter
+                .crate_at_origin(&origin)
+                .expect("no crate with given origin")
+                .own_crate
+                .inner
+                .index;
 
-            resolve_neighbors_with(contexts, move |vertex| {
-                let origin = vertex.origin;
-                let crate_ = vertex.as_crate().expect("vertex was not a crate!");
-                let item_index = match origin {
-                    Origin::CurrentCrate => &current_crate.own_crate.inner.index,
-                    Origin::PreviousCrate => {
-                        &previous_crate
-                            .expect("no previous crate provided")
-                            .own_crate
-                            .inner
-                            .index
-                    }
-                };
-
-                let module = item_index
-                    .get(&crate_.root)
-                    .expect("crate had no root module");
-                Box::new(std::iter::once(origin.make_item_vertex(module)))
-            })
-        }
+            let module = item_index
+                .get(&crate_.root)
+                .expect("crate had no root module");
+            Box::new(std::iter::once(origin.make_item_vertex(module)))
+        }),
         "feature" => {
-            let current_crate = adapter.current_crate;
-            let previous_crate = adapter.previous_crate;
-
             resolve_neighbors_with(contexts, move |vertex| {
                 let origin = vertex.origin;
 
-                let Some(features_lookup) = match origin {
-                    Origin::CurrentCrate => &current_crate.features,
-                    Origin::PreviousCrate => {
-                        &previous_crate.expect("no previous crate provided").features
-                    }
-                }
-                .as_ref() else {
+                let Some(features_lookup) = adapter
+                    .crate_at_origin(&origin)
+                    .expect("no crate with given origin")
+                    .features
+                    .as_ref()
+                else {
                     // No feature data was loaded.
                     return Box::new(std::iter::empty());
                 };

--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -54,12 +54,7 @@ pub(super) fn resolve_crate_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
         "root_module" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
             let crate_ = vertex.as_crate().expect("vertex was not a crate!");
-            let item_index = &adapter
-                .crate_at_origin(&origin)
-                .expect("no crate with given origin")
-                .own_crate
-                .inner
-                .index;
+            let item_index = &adapter.crate_at_origin(origin).own_crate.inner.index;
 
             let module = item_index
                 .get(&crate_.root)
@@ -70,11 +65,7 @@ pub(super) fn resolve_crate_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
             resolve_neighbors_with(contexts, move |vertex| {
                 let origin = vertex.origin;
 
-                let Some(features_lookup) = adapter
-                    .crate_at_origin(&origin)
-                    .expect("no crate with given origin")
-                    .features
-                    .as_ref()
+                let Some(features_lookup) = adapter.crate_at_origin(origin).features.as_ref()
                 else {
                     // No feature data was loaded.
                     return Box::new(std::iter::empty());
@@ -89,19 +80,11 @@ pub(super) fn resolve_crate_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
             })
         }
         "default_feature" => {
-            let current_crate = adapter.current_crate;
-            let previous_crate = adapter.previous_crate;
-
             resolve_neighbors_with(contexts, move |vertex| {
                 let origin = vertex.origin;
 
-                let Some(features_lookup) = match origin {
-                    Origin::CurrentCrate => &current_crate.features,
-                    Origin::PreviousCrate => {
-                        &previous_crate.expect("no previous crate provided").features
-                    }
-                }
-                .as_ref() else {
+                let Some(features_lookup) = adapter.crate_at_origin(origin).features.as_ref()
+                else {
                     // No feature data was loaded.
                     return Box::new(std::iter::empty());
                 };
@@ -120,41 +103,31 @@ pub(super) fn resolve_crate_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
                 )
             })
         }
-        "ffi_exported_function" => {
-            let current_crate = adapter.current_crate;
-            let previous_crate = adapter.previous_crate;
-
-            resolve_neighbors_with(contexts, move |vertex| {
-                let origin = vertex.origin;
-                let export_name_index = match origin {
-                    Origin::CurrentCrate => &current_crate.own_crate.export_name_index,
-                    Origin::PreviousCrate => {
-                        &previous_crate
-                            .expect("no previous crate provided")
-                            .own_crate
-                            .export_name_index
-                    }
-                }
+        "ffi_exported_function" => resolve_neighbors_with(contexts, move |vertex| {
+            let origin = vertex.origin;
+            let export_name_index = &adapter
+                .crate_at_origin(origin)
+                .own_crate
+                .export_name_index
                 .as_ref()
                 .expect("export_name_index was never constructed");
 
-                Box::new(
-                    export_name_index
-                        .values()
-                        .filter_map(move |item| match &item.inner {
-                            ItemEnum::Function(..) => {
-                                debug_assert!(
-                                    crate::exported_name::item_export_name(item).is_some(),
-                                    "item was part of export_name_index but did not have \
+            Box::new(
+                export_name_index
+                    .values()
+                    .filter_map(move |item| match &item.inner {
+                        ItemEnum::Function(..) => {
+                            debug_assert!(
+                                crate::exported_name::item_export_name(item).is_some(),
+                                "item was part of export_name_index but did not have \
                                 an exported name: {item:?}"
-                                );
-                                Some(origin.make_item_vertex(item))
-                            }
-                            _ => None,
-                        }),
-                )
-            })
-        }
+                            );
+                            Some(origin.make_item_vertex(item))
+                        }
+                        _ => None,
+                    }),
+            )
+        }),
         _ => unreachable!("resolve_crate_edge {edge_name}"),
     }
 }
@@ -655,24 +628,13 @@ pub(super) fn resolve_impl_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     edge_name: &str,
     resolve_info: &ResolveEdgeInfo,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
-    let current_crate = adapter.current_crate;
-    let previous_crate = adapter.previous_crate;
     match edge_name {
         "method" => {
             optimizations::method_lookup::resolve_impl_methods(adapter, contexts, resolve_info)
         }
         "implemented_trait" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
-            let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
-                Origin::PreviousCrate => {
-                    &previous_crate
-                        .expect("no previous crate provided")
-                        .own_crate
-                        .inner
-                        .index
-                }
-            };
+            let item_index = &adapter.crate_at_origin(origin).own_crate.inner.index;
 
             let impl_vertex = vertex.as_impl().expect("not an Impl vertex");
 
@@ -686,18 +648,11 @@ pub(super) fn resolve_impl_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
                 // Rust built-in traits are manually "inlined"
                 // with items stored in `manually_inlined_builtin_traits`.
                 let found_item = item_index.get(&path.id).or_else(|| {
-                    let manually_inlined_builtin_traits = match origin {
-                        Origin::CurrentCrate => {
-                            &current_crate.own_crate.manually_inlined_builtin_traits
-                        }
-                        Origin::PreviousCrate => {
-                            &previous_crate
-                                .expect("no previous crate provided")
-                                .own_crate
-                                .manually_inlined_builtin_traits
-                        }
-                    };
-                    manually_inlined_builtin_traits.get(&path.id)
+                    adapter
+                        .crate_at_origin(origin)
+                        .own_crate
+                        .manually_inlined_builtin_traits
+                        .get(&path.id)
                 });
 
                 Box::new(std::iter::once(
@@ -709,16 +664,7 @@ pub(super) fn resolve_impl_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
         }),
         "associated_constant" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
-            let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
-                Origin::PreviousCrate => {
-                    &previous_crate
-                        .expect("no previous crate provided")
-                        .own_crate
-                        .inner
-                        .index
-                }
-            };
+            let item_index = &adapter.crate_at_origin(origin).own_crate.inner.index;
 
             let impl_vertex = vertex.as_impl().expect("not an Impl vertex");
             Box::new(impl_vertex.items.iter().filter_map(move |item_id| {

--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -9,7 +9,6 @@ use trustfall::provider::{
 };
 
 use crate::{
-    PackageIndex,
     adapter::supported_item_kind,
     attributes::Attribute,
     hashtables::{HashMap, HashSet},
@@ -135,8 +134,7 @@ pub(super) fn resolve_crate_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 pub(super) fn resolve_importable_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     edge_name: &str,
-    current_crate: &'a PackageIndex<'a>,
-    previous_crate: Option<&'a PackageIndex<'a>>,
+    adapter: &'a RustdocAdapter<'a>,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
     match edge_name {
         "canonical_path" => resolve_neighbors_with(contexts, move |vertex| {
@@ -144,21 +142,14 @@ pub(super) fn resolve_importable_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
             let item = vertex.as_item().expect("vertex was not an Item");
             let item_id = &item.id;
 
-            if let Some(path) = match origin {
-                Origin::CurrentCrate => current_crate
-                    .own_crate
-                    .inner
-                    .paths
-                    .get(item_id)
-                    .map(|x| &x.path),
-                Origin::PreviousCrate => previous_crate
-                    .expect("no baseline provided")
-                    .own_crate
-                    .inner
-                    .paths
-                    .get(item_id)
-                    .map(|x| &x.path),
-            } {
+            if let Some(path) = adapter
+                .crate_at_origin(origin)
+                .own_crate
+                .inner
+                .paths
+                .get(item_id)
+                .map(|x| &x.path)
+            {
                 Box::new(std::iter::once(origin.make_path_vertex(path)))
             } else {
                 Box::new(std::iter::empty())
@@ -169,10 +160,7 @@ pub(super) fn resolve_importable_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
             let item = vertex.as_item().expect("vertex was not an Item");
             let item_id = &item.id;
 
-            let parent_crate = match origin {
-                Origin::CurrentCrate => current_crate,
-                Origin::PreviousCrate => previous_crate.expect("no baseline provided"),
-            };
+            let parent_crate = adapter.crate_at_origin(origin);
 
             Box::new(
                 parent_crate
@@ -352,24 +340,14 @@ pub(super) fn resolve_generic_parameter_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 pub(super) fn resolve_module_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     edge_name: &str,
-    current_crate: &'a PackageIndex<'a>,
-    previous_crate: Option<&'a PackageIndex<'a>>,
+    adapter: &'a RustdocAdapter<'a>,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
     match edge_name {
         "item" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
             let module_item = vertex.as_module().expect("vertex was not a Module");
 
-            let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
-                Origin::PreviousCrate => {
-                    &previous_crate
-                        .expect("no previous crate provided")
-                        .own_crate
-                        .inner
-                        .index
-                }
-            };
+            let item_index = &adapter.crate_at_origin(origin).own_crate.inner.index;
 
             Box::new(module_item.items.iter().filter_map(move |item_id| {
                 item_index
@@ -385,24 +363,14 @@ pub(super) fn resolve_module_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 pub(super) fn resolve_struct_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     edge_name: &str,
-    current_crate: &'a PackageIndex<'a>,
-    previous_crate: Option<&'a PackageIndex<'a>>,
+    adapter: &'a RustdocAdapter<'a>,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
     match edge_name {
         "field" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
             let struct_item = vertex.as_struct().expect("vertex was not a Struct");
 
-            let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
-                Origin::PreviousCrate => {
-                    &previous_crate
-                        .expect("no previous crate provided")
-                        .own_crate
-                        .inner
-                        .index
-                }
-            };
+            let item_index = &adapter.crate_at_origin(origin).own_crate.inner.index;
 
             let field_ids_iter: Box<dyn Iterator<Item = &Id>> = match &struct_item.kind {
                 rustdoc_types::StructKind::Unit => Box::new(std::iter::empty()),
@@ -426,8 +394,7 @@ pub(super) fn resolve_struct_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 pub(super) fn resolve_variant_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     edge_name: &str,
-    current_crate: &'a PackageIndex<'a>,
-    previous_crate: Option<&'a PackageIndex<'a>>,
+    adapter: &'a RustdocAdapter<'a>,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
     match edge_name {
         "field" => resolve_neighbors_with(contexts, move |vertex| {
@@ -436,16 +403,7 @@ pub(super) fn resolve_variant_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
                 .as_variant()
                 .expect("vertex was not a Variant")
                 .variant();
-            let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
-                Origin::PreviousCrate => {
-                    &previous_crate
-                        .expect("no previous crate provided")
-                        .own_crate
-                        .inner
-                        .index
-                }
-            };
+            let item_index = &adapter.crate_at_origin(origin).own_crate.inner.index;
 
             match &item.kind {
                 VariantKind::Plain => Box::new(std::iter::empty()),
@@ -490,8 +448,7 @@ pub(super) fn resolve_variant_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 pub(super) fn resolve_enum_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     edge_name: &str,
-    current_crate: &'a PackageIndex<'a>,
-    previous_crate: Option<&'a PackageIndex<'a>>,
+    adapter: &'a RustdocAdapter<'a>,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
     match edge_name {
         "variant" => resolve_neighbors_with(contexts, move |vertex| {
@@ -499,16 +456,7 @@ pub(super) fn resolve_enum_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
             let enum_item = vertex.as_enum().expect("vertex was not an Enum");
             let outer_item = vertex.as_item().expect("enum was not a vertex");
 
-            let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
-                Origin::PreviousCrate => {
-                    &previous_crate
-                        .expect("no previous crate provided")
-                        .own_crate
-                        .inner
-                        .index
-                }
-            };
+            let item_index = &adapter.crate_at_origin(origin).own_crate.inner.index;
 
             let discriminants = {
                 // Discriminants are only well-defined if either:
@@ -572,24 +520,14 @@ pub(super) fn resolve_enum_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 pub(super) fn resolve_union_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     edge_name: &str,
-    current_crate: &'a PackageIndex<'a>,
-    previous_crate: Option<&'a PackageIndex<'a>>,
+    adapter: &'a RustdocAdapter<'a>,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
     match edge_name {
         "field" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
             let union_item = vertex.as_union().expect("vertex was not an Union");
 
-            let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
-                Origin::PreviousCrate => {
-                    &previous_crate
-                        .expect("no previous crate provided")
-                        .own_crate
-                        .inner
-                        .index
-                }
-            };
+            let item_index = &adapter.crate_at_origin(origin).own_crate.inner.index;
 
             Box::new(
                 union_item
@@ -683,22 +621,12 @@ pub(super) fn resolve_impl_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 pub(super) fn resolve_trait_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     edge_name: &str,
-    current_crate: &'a PackageIndex<'a>,
-    previous_crate: Option<&'a PackageIndex<'a>>,
+    adapter: &'a RustdocAdapter<'a>,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
     match edge_name {
         "supertrait" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
-            let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
-                Origin::PreviousCrate => {
-                    &previous_crate
-                        .expect("no previous crate provided")
-                        .own_crate
-                        .inner
-                        .index
-                }
-            };
+            let item_index = &adapter.crate_at_origin(origin).own_crate.inner.index;
 
             let trait_vertex = vertex.as_trait().expect("not a Trait vertex");
             Box::new(trait_vertex.bounds.iter().filter_map(move |bound| {
@@ -712,18 +640,11 @@ pub(super) fn resolve_trait_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
                     // Rust built-in traits are manually "inlined"
                     // with items stored in `manually_inlined_builtin_traits`.
                     let found_item = item_index.get(&trait_.id).or_else(|| {
-                        let manually_inlined_builtin_traits = match origin {
-                            Origin::CurrentCrate => {
-                                &current_crate.own_crate.manually_inlined_builtin_traits
-                            }
-                            Origin::PreviousCrate => {
-                                &previous_crate
-                                    .expect("no previous crate provided")
-                                    .own_crate
-                                    .manually_inlined_builtin_traits
-                            }
-                        };
-                        manually_inlined_builtin_traits.get(&trait_.id)
+                        adapter
+                            .crate_at_origin(origin)
+                            .own_crate
+                            .manually_inlined_builtin_traits
+                            .get(&trait_.id)
                     });
 
                     // TODO: Remove this once rust-analyzer stops falsely inferring the type of
@@ -740,16 +661,7 @@ pub(super) fn resolve_trait_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
         }),
         "method" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
-            let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
-                Origin::PreviousCrate => {
-                    &previous_crate
-                        .expect("no previous crate provided")
-                        .own_crate
-                        .inner
-                        .index
-                }
-            };
+            let item_index = &adapter.crate_at_origin(origin).own_crate.inner.index;
 
             let trait_vertex = vertex.as_trait().expect("not a Trait vertex");
             Box::new(trait_vertex.items.iter().filter_map(move |item_id| {
@@ -768,16 +680,7 @@ pub(super) fn resolve_trait_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
         }),
         "associated_type" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
-            let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
-                Origin::PreviousCrate => {
-                    &previous_crate
-                        .expect("no previous crate provided")
-                        .own_crate
-                        .inner
-                        .index
-                }
-            };
+            let item_index = &adapter.crate_at_origin(origin).own_crate.inner.index;
 
             let trait_vertex = vertex.as_trait().expect("not a Trait vertex");
             Box::new(trait_vertex.items.iter().filter_map(move |item_id| {
@@ -796,16 +699,7 @@ pub(super) fn resolve_trait_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
         }),
         "associated_constant" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
-            let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
-                Origin::PreviousCrate => {
-                    &previous_crate
-                        .expect("no previous crate provided")
-                        .own_crate
-                        .inner
-                        .index
-                }
-            };
+            let item_index = &adapter.crate_at_origin(origin).own_crate.inner.index;
 
             let trait_vertex = vertex.as_trait().expect("not a Trait vertex");
             Box::new(trait_vertex.items.iter().filter_map(move |item_id| {
@@ -909,22 +803,12 @@ pub(super) fn resolve_derive_proc_macro_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 pub(super) fn resolve_generic_type_parameter_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     edge_name: &str,
-    current_crate: &'a PackageIndex<'a>,
-    previous_crate: Option<&'a PackageIndex<'a>>,
+    adapter: &'a RustdocAdapter<'a>,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
     match edge_name {
         "type_bound" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
-            let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
-                Origin::PreviousCrate => {
-                    &previous_crate
-                        .expect("no previous crate provided")
-                        .own_crate
-                        .inner
-                        .index
-                }
-            };
+            let item_index = &adapter.crate_at_origin(origin).own_crate.inner.index;
 
             let (generics, param): (
                 &'a rustdoc_types::Generics,
@@ -984,18 +868,11 @@ pub(super) fn resolve_generic_type_parameter_edge<'a, V: AsVertex<Vertex<'a>> + 
                             // Rust built-in traits are manually "inlined"
                             // with items stored in `manually_inlined_builtin_traits`.
                             let found_item = item_index.get(&trait_.id).or_else(|| {
-                                let manually_inlined_builtin_traits = match origin {
-                                    Origin::CurrentCrate => {
-                                        &current_crate.own_crate.manually_inlined_builtin_traits
-                                    }
-                                    Origin::PreviousCrate => {
-                                        &previous_crate
-                                            .expect("no previous crate provided")
-                                            .own_crate
-                                            .manually_inlined_builtin_traits
-                                    }
-                                };
-                                manually_inlined_builtin_traits.get(&trait_.id)
+                                adapter
+                                    .crate_at_origin(origin)
+                                    .own_crate
+                                    .manually_inlined_builtin_traits
+                                    .get(&trait_.id)
                             });
 
                             Some(origin.make_implemented_trait_vertex(
@@ -1016,22 +893,18 @@ pub(super) fn resolve_generic_type_parameter_edge<'a, V: AsVertex<Vertex<'a>> + 
 pub(super) fn resolve_feature_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     edge_name: &str,
-    current_crate: &'a PackageIndex<'a>,
-    previous_crate: Option<&'a PackageIndex<'a>>,
+    adapter: &'a RustdocAdapter<'a>,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
     match edge_name {
         "directly_enables" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
             let feature: &Feature<'_> = vertex.as_feature().expect("vertex was not a Feature");
 
-            let features_lookup = match origin {
-                Origin::CurrentCrate => &current_crate.features,
-                Origin::PreviousCrate => {
-                    &previous_crate.expect("no previous crate provided").features
-                }
-            }
-            .as_ref()
-            .expect("no feature data was loaded");
+            let features_lookup = adapter
+                .crate_at_origin(origin)
+                .features
+                .as_ref()
+                .expect("no feature data was loaded");
 
             Box::new(
                 feature
@@ -1053,22 +926,13 @@ pub(super) fn resolve_feature_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 
 pub(super) fn resolve_requires_target_feature_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
-    current_crate: &'a PackageIndex<'a>,
-    previous_crate: Option<&'a PackageIndex<'a>>,
+    adapter: &'a RustdocAdapter<'a>,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
     resolve_neighbors_with(contexts, move |vertex| {
         let origin = vertex.origin;
         let item = vertex.as_item().expect("vertex was not an Item");
 
-        let features_lookup = match origin {
-            Origin::CurrentCrate => &current_crate.own_crate.target_features,
-            Origin::PreviousCrate => {
-                &previous_crate
-                    .expect("no previous crate provided")
-                    .own_crate
-                    .target_features
-            }
-        };
+        let features_lookup = &adapter.crate_at_origin(origin).own_crate.target_features;
 
         let enabled_features = item
             .attrs

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -53,10 +53,16 @@ impl<'a> RustdocAdapter<'a> {
         &SCHEMA
     }
 
-    pub(crate) fn crate_at_origin(&self, origin: &Origin) -> Option<&'a PackageIndex<'a>> {
+    /// Returns the crate at the given origin.
+    ///
+    /// Panics if `Origin::PreviousCrate` is passed and there is no previous crate.
+    #[inline]
+    pub(crate) fn crate_at_origin(&self, origin: Origin) -> &'a PackageIndex<'a> {
         match origin {
-            Origin::CurrentCrate => Some(self.current_crate),
-            Origin::PreviousCrate => self.previous_crate,
+            Origin::CurrentCrate => self.current_crate,
+            Origin::PreviousCrate => self
+                .previous_crate
+                .expect("previous crate was not provided"),
         }
     }
 }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -193,18 +193,10 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
                 "AttributeMetaItem" => {
                     properties::resolve_attribute_meta_item_property(contexts, property_name)
                 }
-                "Trait" => properties::resolve_trait_property(
-                    contexts,
-                    property_name,
-                    self.current_crate,
-                    self.previous_crate,
-                ),
-                "ImplementedTrait" => properties::resolve_implemented_trait_property(
-                    contexts,
-                    property_name,
-                    self.current_crate,
-                    self.previous_crate,
-                ),
+                "Trait" => properties::resolve_trait_property(contexts, property_name, self),
+                "ImplementedTrait" => {
+                    properties::resolve_implemented_trait_property(contexts, property_name, self)
+                }
                 "Static" => properties::resolve_static_property(contexts, property_name),
                 "RawType" | "ResolvedPathType" if matches!(property_name.as_ref(), "name") => {
                     // fields from "RawType"
@@ -238,8 +230,7 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
                 "GenericTypeParameter" => properties::resolve_generic_type_parameter_property(
                     contexts,
                     property_name,
-                    self.current_crate,
-                    self.previous_crate,
+                    self,
                 ),
                 "GenericConstParameter" => {
                     properties::resolve_generic_const_parameter_property(contexts, property_name)
@@ -282,12 +273,7 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
             | "DeriveProcMacro"
                 if matches!(edge_name.as_ref(), "importable_path" | "canonical_path") =>
             {
-                edges::resolve_importable_edge(
-                    contexts,
-                    edge_name,
-                    self.current_crate,
-                    self.previous_crate,
-                )
+                edges::resolve_importable_edge(contexts, edge_name, self)
             }
             "Item"
             | "GenericItem"
@@ -340,68 +326,26 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
                 edges::resolve_receiver_edge(contexts, edge_name)
             }
             "Function" | "Method" if matches!(edge_name.as_ref(), "requires_feature") => {
-                edges::resolve_requires_target_feature_edge(
-                    contexts,
-                    self.current_crate,
-                    self.previous_crate,
-                )
+                edges::resolve_requires_target_feature_edge(contexts, self)
             }
-            "Module" => edges::resolve_module_edge(
-                contexts,
-                edge_name,
-                self.current_crate,
-                self.previous_crate,
-            ),
-            "Struct" => edges::resolve_struct_edge(
-                contexts,
-                edge_name,
-                self.current_crate,
-                self.previous_crate,
-            ),
+            "Module" => edges::resolve_module_edge(contexts, edge_name, self),
+            "Struct" => edges::resolve_struct_edge(contexts, edge_name, self),
             "Variant" | "PlainVariant" | "TupleVariant" | "StructVariant" => {
-                edges::resolve_variant_edge(
-                    contexts,
-                    edge_name,
-                    self.current_crate,
-                    self.previous_crate,
-                )
+                edges::resolve_variant_edge(contexts, edge_name, self)
             }
-            "Enum" => edges::resolve_enum_edge(
-                contexts,
-                edge_name,
-                self.current_crate,
-                self.previous_crate,
-            ),
-            "Union" => edges::resolve_union_edge(
-                contexts,
-                edge_name,
-                self.current_crate,
-                self.previous_crate,
-            ),
+            "Enum" => edges::resolve_enum_edge(contexts, edge_name, self),
+            "Union" => edges::resolve_union_edge(contexts, edge_name, self),
             "StructField" => edges::resolve_struct_field_edge(contexts, edge_name),
             "Impl" => edges::resolve_impl_edge(self, contexts, edge_name, resolve_info),
-            "Trait" => edges::resolve_trait_edge(
-                contexts,
-                edge_name,
-                self.current_crate,
-                self.previous_crate,
-            ),
+            "Trait" => edges::resolve_trait_edge(contexts, edge_name, self),
             "ImplementedTrait" => edges::resolve_implemented_trait_edge(contexts, edge_name),
             "Attribute" => edges::resolve_attribute_edge(contexts, edge_name),
             "AttributeMetaItem" => edges::resolve_attribute_meta_item_edge(contexts, edge_name),
-            "Feature" => edges::resolve_feature_edge(
-                contexts,
-                edge_name,
-                self.current_crate,
-                self.previous_crate,
-            ),
+            "Feature" => edges::resolve_feature_edge(contexts, edge_name, self),
             "DeriveProcMacro" => edges::resolve_derive_proc_macro_edge(contexts, edge_name),
-            "GenericTypeParameter" => edges::resolve_generic_type_parameter_edge(
-                contexts,
-                edge_name,
-                self.current_crate,
-                self.previous_crate,
-            ),
+            "GenericTypeParameter" => {
+                edges::resolve_generic_type_parameter_edge(contexts, edge_name, self)
+            }
             _ => unreachable!("resolve_neighbors {type_name} {edge_name} {parameters:?}"),
         }
     }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -52,6 +52,13 @@ impl<'a> RustdocAdapter<'a> {
     pub fn schema() -> &'static Schema {
         &SCHEMA
     }
+
+    pub(crate) fn crate_at_origin(&self, origin: &Origin) -> Option<&'a PackageIndex<'a>> {
+        match origin {
+            Origin::CurrentCrate => Some(self.current_crate),
+            Origin::PreviousCrate => self.previous_crate,
+        }
+    }
 }
 
 impl Drop for RustdocAdapter<'_> {

--- a/src/adapter/optimizations/impl_lookup.rs
+++ b/src/adapter/optimizations/impl_lookup.rs
@@ -7,7 +7,7 @@ use trustfall::{
     },
 };
 
-use crate::{adapter::PackageIndex, hashtables::HashMap, indexed_crate::ImplEntry};
+use crate::{hashtables::HashMap, indexed_crate::ImplEntry};
 
 use super::super::{RustdocAdapter, origin::Origin, vertex::Vertex};
 
@@ -18,8 +18,6 @@ pub(crate) fn resolve_owner_impl<'a, V: AsVertex<Vertex<'a>> + 'a>(
     edge_name: &str,
     resolve_info: &ResolveEdgeInfo,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
-    let current_crate = adapter.current_crate;
-    let previous_crate = adapter.previous_crate;
     let inherent_impls_only = match edge_name {
         "inherent_impl" => true,
         "impl" => false,
@@ -37,15 +35,13 @@ pub(crate) fn resolve_owner_impl<'a, V: AsVertex<Vertex<'a>> + 'a>(
         resolve_owner_impl_based_on_method_info(
             adapter,
             contexts,
-            current_crate,
-            previous_crate,
             inherent_impls_only,
             method_vertex_info,
         )
     } else {
         // We don't seem to be looking up methods. No fast path available.
         resolve_neighbors_with(contexts, move |vertex| {
-            resolve_owner_impl_slow_path(vertex, current_crate, previous_crate, inherent_impls_only)
+            resolve_owner_impl_slow_path(vertex, adapter, inherent_impls_only)
         })
     }
 }
@@ -53,8 +49,6 @@ pub(crate) fn resolve_owner_impl<'a, V: AsVertex<Vertex<'a>> + 'a>(
 fn resolve_owner_impl_based_on_method_info<'a, V: AsVertex<Vertex<'a>> + 'a>(
     adapter: &'a RustdocAdapter<'a>,
     contexts: ContextIterator<'a, V>,
-    current_crate: &'a PackageIndex<'a>,
-    previous_crate: Option<&'a PackageIndex<'a>>,
     inherent_impls_only: bool,
     method_vertex_info: &impl VertexInfo,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
@@ -68,8 +62,7 @@ fn resolve_owner_impl_based_on_method_info<'a, V: AsVertex<Vertex<'a>> + 'a>(
         resolver.resolve_with(&adapter, contexts, move |vertex, candidate| {
             resolve_impl_based_on_method_name_candidate(
                 vertex,
-                current_crate,
-                previous_crate,
+                adapter,
                 inherent_impls_only,
                 candidate,
             )
@@ -78,8 +71,7 @@ fn resolve_owner_impl_based_on_method_info<'a, V: AsVertex<Vertex<'a>> + 'a>(
         resolve_neighbors_with(contexts, move |vertex| {
             resolve_impl_based_on_method_name_candidate(
                 vertex,
-                current_crate,
-                previous_crate,
+                adapter,
                 inherent_impls_only,
                 candidate.clone(),
             )
@@ -87,32 +79,24 @@ fn resolve_owner_impl_based_on_method_info<'a, V: AsVertex<Vertex<'a>> + 'a>(
     } else {
         // The methods are not looked up by name. None of the fast paths are available.
         resolve_neighbors_with(contexts, move |vertex| {
-            resolve_owner_impl_slow_path(vertex, current_crate, previous_crate, inherent_impls_only)
+            resolve_owner_impl_slow_path(vertex, adapter, inherent_impls_only)
         })
     }
 }
 
 fn resolve_impl_based_on_method_name_candidate<'a>(
     vertex: &Vertex<'a>,
-    current_crate: &'a PackageIndex<'a>,
-    previous_crate: Option<&'a PackageIndex<'a>>,
+    adapter: &'a RustdocAdapter<'a>,
     inherent_impls_only: bool,
     method_name: CandidateValue<FieldValue>,
 ) -> VertexIterator<'a, Vertex<'a>> {
     let origin = vertex.origin;
-    let impl_index = match origin {
-        Origin::CurrentCrate => current_crate
-            .own_crate
-            .impl_method_index
-            .as_ref()
-            .expect("no impl index present"),
-        Origin::PreviousCrate => previous_crate
-            .expect("no previous crate provided")
-            .own_crate
-            .impl_method_index
-            .as_ref()
-            .expect("no impl index provided"),
-    };
+    let impl_index = adapter
+        .crate_at_origin(origin)
+        .own_crate
+        .impl_method_index
+        .as_ref()
+        .expect("no impl index present");
 
     let item_id = &vertex.as_item().expect("not an item").id;
     match method_name {
@@ -139,7 +123,7 @@ fn resolve_impl_based_on_method_name_candidate<'a>(
         })),
         _ => {
             // fall through to slow path
-            resolve_owner_impl_slow_path(vertex, current_crate, previous_crate, inherent_impls_only)
+            resolve_owner_impl_slow_path(vertex, adapter, inherent_impls_only)
         }
     }
 }
@@ -173,21 +157,11 @@ the `impl_index` returned a value where the `impl_item` was not an impl: {impl_i
 
 fn resolve_owner_impl_slow_path<'a>(
     vertex: &Vertex<'a>,
-    current_crate: &'a PackageIndex<'a>,
-    previous_crate: Option<&'a PackageIndex<'a>>,
+    adapter: &'a RustdocAdapter<'a>,
     inherent_impls_only: bool,
 ) -> VertexIterator<'a, Vertex<'a>> {
     let origin = vertex.origin;
-    let item_index = match origin {
-        Origin::CurrentCrate => &current_crate.own_crate.inner.index,
-        Origin::PreviousCrate => {
-            &previous_crate
-                .expect("no previous crate provided")
-                .own_crate
-                .inner
-                .index
-        }
-    };
+    let item_index = &adapter.crate_at_origin(origin).own_crate.inner.index;
 
     // Get the IDs of all the impl blocks.
     // Relies on the fact that only structs, enums, and unions can have impls,

--- a/src/adapter/optimizations/method_lookup.rs
+++ b/src/adapter/optimizations/method_lookup.rs
@@ -46,12 +46,7 @@ pub(crate) fn resolve_impl_methods<'a, V: AsVertex<Vertex<'a>> + 'a>(
     } else {
         resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
-            let item_index = &adapter
-                .crate_at_origin(&origin)
-                .expect("no crate with given origin")
-                .own_crate
-                .inner
-                .index;
+            let item_index = &adapter.crate_at_origin(origin).own_crate.inner.index;
 
             let impl_vertex = vertex.as_impl().expect("not an Impl vertex");
             resolve_methods_slow_path(impl_vertex, origin, item_index)

--- a/src/adapter/optimizations/method_lookup.rs
+++ b/src/adapter/optimizations/method_lookup.rs
@@ -46,16 +46,12 @@ pub(crate) fn resolve_impl_methods<'a, V: AsVertex<Vertex<'a>> + 'a>(
     } else {
         resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
-            let item_index = match origin {
-                Origin::CurrentCrate => &current_crate.own_crate.inner.index,
-                Origin::PreviousCrate => {
-                    &previous_crate
-                        .expect("no previous crate provided")
-                        .own_crate
-                        .inner
-                        .index
-                }
-            };
+            let item_index = &adapter
+                .crate_at_origin(&origin)
+                .expect("no crate with given origin")
+                .own_crate
+                .inner
+                .index;
 
             let impl_vertex = vertex.as_impl().expect("not an Impl vertex");
             resolve_methods_slow_path(impl_vertex, origin, item_index)

--- a/src/adapter/optimizations/method_lookup.rs
+++ b/src/adapter/optimizations/method_lookup.rs
@@ -9,7 +9,7 @@ use trustfall::{
 
 use crate::{
     RustdocAdapter,
-    adapter::{Origin, PackageIndex, Vertex},
+    adapter::{Origin, Vertex},
     hashtables::{HashMap, HashSet},
     indexed_crate::ImplEntry,
 };
@@ -19,9 +19,6 @@ pub(crate) fn resolve_impl_methods<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     resolve_info: &ResolveEdgeInfo,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
-    let current_crate = adapter.current_crate;
-    let previous_crate = adapter.previous_crate;
-
     let neighbor_info = resolve_info.destination();
 
     // Is the `name` value within that edge known, either statically or dynamically?
@@ -32,16 +29,11 @@ pub(crate) fn resolve_impl_methods<'a, V: AsVertex<Vertex<'a>> + 'a>(
     // it might be more specific.
     if let Some(resolver) = neighbor_info.dynamically_required_property("name") {
         resolver.resolve_with(&adapter, contexts, move |vertex, candidate| {
-            resolve_method_from_candidate_value(current_crate, previous_crate, vertex, candidate)
+            resolve_method_from_candidate_value(adapter, vertex, candidate)
         })
     } else if let Some(candidate) = neighbor_info.statically_required_property("name") {
         resolve_neighbors_with(contexts, move |vertex| {
-            resolve_method_from_candidate_value(
-                current_crate,
-                previous_crate,
-                vertex,
-                candidate.clone(),
-            )
+            resolve_method_from_candidate_value(adapter, vertex, candidate.clone())
         })
     } else {
         resolve_neighbors_with(contexts, move |vertex| {
@@ -83,33 +75,18 @@ fn find_impl_owner_id(impl_vertex: &Impl) -> Option<&Id> {
 }
 
 fn resolve_method_from_candidate_value<'a>(
-    current_crate: &'a PackageIndex<'a>,
-    previous_crate: Option<&'a PackageIndex<'a>>,
+    adapter: &'a RustdocAdapter<'a>,
     vertex: &Vertex<'a>,
     method_name: CandidateValue<FieldValue>,
 ) -> VertexIterator<'a, Vertex<'a>> {
     let origin = vertex.origin;
-    let (item_index, impl_index) = match origin {
-        Origin::CurrentCrate => (
-            &current_crate.own_crate.inner.index,
-            current_crate
-                .own_crate
-                .impl_method_index
-                .as_ref()
-                .expect("no impl index present"),
-        ),
-        Origin::PreviousCrate => {
-            let previous_crate = previous_crate.expect("no previous crate provided");
-            (
-                &previous_crate.own_crate.inner.index,
-                previous_crate
-                    .own_crate
-                    .impl_method_index
-                    .as_ref()
-                    .expect("no impl index provided"),
-            )
-        }
-    };
+    let item_index = &adapter.crate_at_origin(origin).own_crate.inner.index;
+    let impl_index = adapter
+        .crate_at_origin(origin)
+        .own_crate
+        .impl_method_index
+        .as_ref()
+        .expect("no impl index provided");
 
     let impl_id = &vertex.as_item().expect("not an Item vertex").id;
     let impl_vertex = vertex.as_impl().expect("not an Impl vertex");

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -7,12 +7,9 @@ use trustfall::{
     },
 };
 
-use crate::{
-    PackageIndex,
-    attributes::{Attribute, structured_attr_to_arc_str},
-};
+use crate::attributes::{Attribute, structured_attr_to_arc_str};
 
-use super::{origin::Origin, rust_type_name, vertex::Vertex};
+use super::{RustdocAdapter, rust_type_name, vertex::Vertex};
 
 pub(super) fn resolve_crate_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
@@ -514,8 +511,7 @@ pub(super) fn resolve_raw_type_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
 pub(super) fn resolve_trait_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     property_name: &str,
-    current_crate: &'a PackageIndex<'a>,
-    previous_crate: Option<&'a PackageIndex<'a>>,
+    adapter: &'a RustdocAdapter<'a>,
 ) -> ContextOutcomeIterator<'a, V, FieldValue> {
     match property_name {
         "unsafe" => resolve_property_with(contexts, field_property!(as_trait, is_unsafe)),
@@ -526,23 +522,18 @@ pub(super) fn resolve_trait_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
             let trait_item = vertex.as_item().expect("not an Item");
             let origin = vertex.origin;
 
-            let handler = match origin {
-                Origin::CurrentCrate => current_crate,
-                Origin::PreviousCrate => previous_crate.expect("no previous crate provided"),
-            };
-
-            handler.own_crate.is_trait_sealed(&trait_item.id).into()
+            adapter
+                .crate_at_origin(origin)
+                .own_crate
+                .is_trait_sealed(&trait_item.id)
+                .into()
         }),
         "public_api_sealed" => resolve_property_with(contexts, move |vertex| {
             let trait_item = vertex.as_item().expect("not an Item");
             let origin = vertex.origin;
 
-            let handler = match origin {
-                Origin::CurrentCrate => current_crate,
-                Origin::PreviousCrate => previous_crate.expect("no previous crate provided"),
-            };
-
-            handler
+            adapter
+                .crate_at_origin(origin)
                 .own_crate
                 .is_trait_public_api_sealed(&trait_item.id)
                 .into()
@@ -554,17 +545,11 @@ pub(super) fn resolve_trait_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
 pub(super) fn resolve_implemented_trait_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     property_name: &str,
-    current_crate: &'a PackageIndex<'a>,
-    previous_crate: Option<&'a PackageIndex<'a>>,
+    adapter: &'a RustdocAdapter<'a>,
 ) -> ContextOutcomeIterator<'a, V, FieldValue> {
     match property_name {
         "name" | "bare_name" => resolve_property_with(contexts, move |vertex| {
-            let origin_crate = match vertex.origin {
-                Origin::CurrentCrate => current_crate,
-                Origin::PreviousCrate => {
-                    previous_crate.as_ref().expect("no previous crate provided")
-                }
-            };
+            let origin_crate = adapter.crate_at_origin(vertex.origin);
             let impld = vertex
                 .as_implemented_trait()
                 .expect("not an ImplementedTrait");
@@ -781,8 +766,7 @@ pub(crate) fn resolve_generic_parameter_property<'a, V: AsVertex<Vertex<'a>> + '
 pub(crate) fn resolve_generic_type_parameter_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     property_name: &str,
-    current_crate: &'a PackageIndex<'a>,
-    previous_crate: Option<&'a PackageIndex<'a>>,
+    adapter: &'a RustdocAdapter<'a>,
 ) -> ContextOutcomeIterator<'a, V, FieldValue> {
     match property_name {
         "has_default" => resolve_property_with(contexts, |vertex| {
@@ -814,12 +798,7 @@ pub(crate) fn resolve_generic_type_parameter_property<'a, V: AsVertex<Vertex<'a>
                 .as_generic_parameter()
                 .expect("vertex was not a GenericTypeParameter");
 
-            let sized_trait_id = match vertex.origin {
-                Origin::CurrentCrate => current_crate,
-                Origin::PreviousCrate => previous_crate.expect("no previous crate provided"),
-            }
-            .own_crate
-            .sized_trait;
+            let sized_trait_id = adapter.crate_at_origin(vertex.origin).own_crate.sized_trait;
 
             let mut maybe_sized = false;
 


### PR DESCRIPTION
**Purpose of Change**
This is something that is done a lot and is basically copy-pasted between call sites. Especially in lookup code, such as in #926, the match can harm readability.

**Describe the Change**
Introduce a new function `crate_at_origin`. Since it's `pub(crate)`, it won't affect the API, but it can make internal code easier to read. I have changed some of the uses to demonstrate the changes.

**Describe Alternatives**
Perhaps `package_index_at_origin` may be a better name.