### PR TITLE
Initial work towards dynamically resolving enum variants. (#926)

### DIFF
--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeSet, num::NonZeroUsize, rc::Rc};
+use std::{collections::BTreeSet, num::NonZeroUsize};
 
 use rustdoc_types::{
     GenericBound::TraitBound, GenericParamDefKind, Id, ItemEnum, VariantKind, WherePredicate,
@@ -15,9 +15,7 @@ use crate::{
 };
 
 use super::{
-    RustdocAdapter,
-    enum_variant::LazyDiscriminants,
-    optimizations,
+    RustdocAdapter, optimizations,
     origin::Origin,
     receiver::Receiver,
     vertex::{Feature, Vertex},
@@ -449,85 +447,12 @@ pub(super) fn resolve_enum_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     edge_name: &str,
     adapter: &'a RustdocAdapter<'a>,
+    resolve_info: &ResolveEdgeInfo,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
     match edge_name {
-        "variant" => resolve_neighbors_with(contexts, move |vertex| {
-            let origin = vertex.origin;
-            let enum_item = vertex.as_enum().expect("vertex was not an Enum");
-            let outer_item = vertex.as_item().expect("enum was not a vertex");
-
-            let item_index = &adapter.crate_at_origin(origin).own_crate.inner.index;
-
-            let discriminants = {
-                // Discriminants are only well-defined if either:
-                // - the enum has a defined `repr` binary representation, or
-                // - none of the enum variants contain any fields of their own.
-
-                let has_repr = outer_item.attrs.iter().any(move |attr| {
-                    let parsed_attr = Attribute::new(attr.as_str());
-
-                    parsed_attr.content.base == "repr"
-                        && parsed_attr.content.arguments.iter().flatten().any(|repr| {
-                            repr.base == "isize"
-                                || repr.base == "usize"
-                                || repr
-                                    .base
-                                    .strip_prefix("i")
-                                    .map(|num| num.chars().all(|c| c.is_ascii_digit()))
-                                    .unwrap_or(false)
-                                || repr
-                                    .base
-                                    .strip_prefix("u")
-                                    .map(|num| num.chars().all(|c| c.is_ascii_digit()))
-                                    .unwrap_or(false)
-                        })
-                });
-
-                let mut has_fields_in_variants = false;
-                let variants = enum_item
-                    .variants
-                    .iter()
-                    .map(|field_id| {
-                        let inner = &item_index.get(field_id).expect("missing item").inner;
-                        match inner {
-                            ItemEnum::Variant(v) => {
-                                match &v.kind {
-                                    VariantKind::Plain => {}
-                                    VariantKind::Tuple(t) => {
-                                        has_fields_in_variants |= !t.is_empty()
-                                    }
-                                    VariantKind::Struct { fields, .. } => {
-                                        has_fields_in_variants |= fields.is_empty()
-                                    }
-                                }
-                                v
-                            }
-                            _ => unreachable!("Item {inner:?} not a Variant"),
-                        }
-                    })
-                    .collect();
-
-                if has_repr || !has_fields_in_variants {
-                    Some(Rc::new(LazyDiscriminants::new(variants)))
-                } else {
-                    None
-                }
-            };
-
-            Box::new(
-                enum_item
-                    .variants
-                    .iter()
-                    .enumerate()
-                    .map(move |(index, field_id)| {
-                        origin.make_variant_vertex(
-                            item_index.get(field_id).expect("missing item"),
-                            discriminants.clone(),
-                            index,
-                        )
-                    }),
-            )
-        }),
+        "variant" => {
+            optimizations::variant_lookup::resolve_enum_variant(adapter, contexts, resolve_info)
+        }
         _ => unreachable!("resolve_enum_edge {edge_name}"),
     }
 }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -333,7 +333,7 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
             "Variant" | "PlainVariant" | "TupleVariant" | "StructVariant" => {
                 edges::resolve_variant_edge(contexts, edge_name, self)
             }
-            "Enum" => edges::resolve_enum_edge(contexts, edge_name, self),
+            "Enum" => edges::resolve_enum_edge(contexts, edge_name, self, resolve_info),
             "Union" => edges::resolve_union_edge(contexts, edge_name, self),
             "StructField" => edges::resolve_struct_field_edge(contexts, edge_name),
             "Impl" => edges::resolve_impl_edge(self, contexts, edge_name, resolve_info),

--- a/src/adapter/optimizations/mod.rs
+++ b/src/adapter/optimizations/mod.rs
@@ -1,3 +1,4 @@
 pub(super) mod impl_lookup;
 pub(super) mod item_lookup;
 pub(super) mod method_lookup;
+pub(super) mod variant_lookup;

--- a/src/adapter/optimizations/variant_lookup.rs
+++ b/src/adapter/optimizations/variant_lookup.rs
@@ -1,0 +1,212 @@
+use std::rc::Rc;
+
+use rustdoc_types::{Id, Item, ItemEnum, VariantKind};
+use trustfall::FieldValue;
+use trustfall::provider::{
+    AsVertex, CandidateValue, ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo, VertexInfo,
+    VertexIterator, resolve_neighbors_with,
+};
+
+use crate::attributes::Attribute;
+use crate::hashtables::HashMap;
+
+use super::super::{
+    RustdocAdapter, enum_variant::LazyDiscriminants, origin::Origin, vertex::Vertex,
+};
+
+fn compute_variant_discriminants<'a>(
+    outer_item: &'a Item,
+    item_index: &'a HashMap<Id, Item>,
+) -> Option<Rc<LazyDiscriminants<'a>>> {
+    // Discriminants are only well-defined if either:
+    // - the enum has a defined `repr` binary representation, or
+    // - none of the enum variants contain any fields of their own.
+    let has_repr = outer_item.attrs.iter().any(move |attr| {
+        let parsed_attr = Attribute::new(attr.as_str());
+
+        parsed_attr.content.base == "repr"
+            && parsed_attr.content.arguments.iter().flatten().any(|repr| {
+                repr.base == "isize"
+                    || repr.base == "usize"
+                    || repr
+                        .base
+                        .strip_prefix("i")
+                        .map(|num| num.chars().all(|c| c.is_ascii_digit()))
+                        .unwrap_or(false)
+                    || repr
+                        .base
+                        .strip_prefix("u")
+                        .map(|num| num.chars().all(|c| c.is_ascii_digit()))
+                        .unwrap_or(false)
+            })
+    });
+
+    let enum_item = match &outer_item.inner {
+        ItemEnum::Enum(x) => x,
+        _ => unreachable!("Item {outer_item:?} is not an Enum"),
+    };
+
+    let mut has_fields_in_variants = false;
+    let variants = enum_item
+        .variants
+        .iter()
+        .map(|field_id| {
+            let inner = &item_index.get(field_id).expect("missing item").inner;
+            match inner {
+                ItemEnum::Variant(v) => {
+                    match &v.kind {
+                        VariantKind::Plain => {}
+                        VariantKind::Tuple(t) => has_fields_in_variants |= !t.is_empty(),
+                        VariantKind::Struct { fields, .. } => {
+                            has_fields_in_variants |= fields.is_empty()
+                        }
+                    }
+                    v
+                }
+                _ => unreachable!("Item {inner:?} not a Variant"),
+            }
+        })
+        .collect();
+
+    if has_repr || !has_fields_in_variants {
+        Some(Rc::new(LazyDiscriminants::new(variants)))
+    } else {
+        None
+    }
+}
+
+fn resolve_enum_variants_slow_path<'a>(
+    origin: Origin,
+    item_vertex: &'a Item,
+    item_index: &'a HashMap<Id, Item>,
+) -> VertexIterator<'a, Vertex<'a>> {
+    let discriminants = compute_variant_discriminants(item_vertex, item_index);
+    let enum_item = match &item_vertex.inner {
+        ItemEnum::Enum(x) => x,
+        _ => unreachable!("Item {item_vertex:?} is not an Enum"),
+    };
+
+    Box::new(
+        enum_item
+            .variants
+            .iter()
+            .enumerate()
+            .map(move |(index, field_id)| {
+                origin.make_variant_vertex(
+                    item_index.get(field_id).expect("missing item"),
+                    discriminants.clone(),
+                    index,
+                )
+            }),
+    )
+}
+
+fn resolve_enum_variant_by_name<'a>(
+    origin: Origin,
+    item_vertex: &'a Item,
+    name: FieldValue,
+    variant_name_index: &'a HashMap<(Id, &str), (&'a Item, usize)>,
+    item_index: &'a HashMap<Id, Item>,
+) -> VertexIterator<'a, Vertex<'a>> {
+    match name {
+        FieldValue::String(name) => match variant_name_index.get(&(item_vertex.id, &name)) {
+            Some((item, index)) => {
+                let discriminants = compute_variant_discriminants(item_vertex, item_index);
+                Box::new(std::iter::once(origin.make_variant_vertex(
+                    item,
+                    discriminants.clone(),
+                    *index,
+                )))
+            }
+            None => Box::new(std::iter::empty()),
+        },
+        _ => Box::new(std::iter::empty()),
+    }
+}
+
+fn resolve_enum_variant_by_candidate_value<'a>(
+    origin: Origin,
+    item_vertex: &'a Item,
+    candidate: CandidateValue<FieldValue>,
+    variant_name_index: &'a HashMap<(Id, &str), (&'a Item, usize)>,
+    item_index: &'a HashMap<Id, Item>,
+) -> VertexIterator<'a, Vertex<'a>> {
+    match candidate {
+        CandidateValue::Impossible => Box::new(std::iter::empty()),
+        CandidateValue::Single(name) => {
+            resolve_enum_variant_by_name(origin, item_vertex, name, variant_name_index, item_index)
+        }
+        CandidateValue::Multiple(values) => Box::new(values.into_iter().flat_map(move |name| {
+            resolve_enum_variant_by_name(origin, item_vertex, name, variant_name_index, item_index)
+        })),
+        _ => resolve_enum_variants_slow_path(origin, item_vertex, item_index),
+    }
+}
+
+pub(crate) fn resolve_enum_variant<'a, V: AsVertex<Vertex<'a>> + 'a>(
+    adapter: &'a RustdocAdapter<'a>,
+    contexts: ContextIterator<'a, V>,
+    resolve_info: &ResolveEdgeInfo,
+) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
+    // If the name of the variant is required to be a particular value, we can
+    // use the variant_name_index to find the corresponding variant.
+    //
+    // There's no advantage in our implementation between knowing values
+    // statically vs dynamically, so we check the dynamic case first since
+    // it might be more specific.
+    if let Some(dynamic_value) = resolve_info
+        .destination()
+        .dynamically_required_property("name")
+    {
+        dynamic_value.resolve_with(&adapter, contexts, move |vertex, candidate| {
+            let origin = vertex.origin;
+            let item_vertex = vertex.as_item().expect("vertex is not an item.");
+            let item_index = &adapter.crate_at_origin(origin).own_crate.inner.index;
+
+            let variant_name_index = adapter
+                .crate_at_origin(origin)
+                .own_crate
+                .variant_name_index
+                .as_ref()
+                .expect("variant_name_index was never constructed");
+
+            resolve_enum_variant_by_candidate_value(
+                origin,
+                item_vertex,
+                candidate,
+                variant_name_index,
+                item_index,
+            )
+        })
+    } else if let Some(name_value) = resolve_info
+        .destination()
+        .statically_required_property("name")
+    {
+        resolve_neighbors_with(contexts, move |vertex| {
+            let origin = vertex.origin;
+            let item_vertex = vertex.as_item().expect("vertex is not an item.");
+            let item_index = &adapter.crate_at_origin(origin).own_crate.inner.index;
+
+            let variant_name_index = adapter
+                .crate_at_origin(origin)
+                .own_crate
+                .variant_name_index
+                .as_ref()
+                .expect("variant_name_index was never constructed");
+
+            resolve_enum_variant_by_candidate_value(
+                origin,
+                item_vertex,
+                name_value.clone(),
+                variant_name_index,
+                item_index,
+            )
+        })
+    } else {
+        resolve_neighbors_with(contexts, move |vertex| {
+            let item_index = &adapter.crate_at_origin(vertex.origin).own_crate.inner.index;
+            let item_vertex = vertex.as_item().expect("vertex is not an item.");
+            resolve_enum_variants_slow_path(vertex.origin, item_vertex, item_index)
+        })
+    }
+}

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -5614,6 +5614,175 @@ fn enum_variant_positions() {
 }
 
 #[test]
+fn enum_variant_name_resolution_dynamic() {
+    get_test_data!(data, enum_variants_position);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+    {
+        Crate {
+            item {
+                ... on Enum {
+                    enum_name: name @output
+
+                    variant {
+                        variant_name: name @tag @output
+                    }
+
+                    variant {
+                        other_name: name @filter(op: "=", value: ["%variant_name"]) @output
+                    }
+                }
+            }
+        }
+    }
+    "#;
+
+    let variables: BTreeMap<&str, &str> = BTreeMap::new();
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        enum_name: String,
+        variant_name: String,
+        other_name: String,
+    }
+
+    let mut results: Vec<Output> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables)
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    let mut expected_results = vec![
+        Output {
+            enum_name: "AllVariantTypes".into(),
+            variant_name: "First".into(),
+            other_name: "First".into(),
+        },
+        Output {
+            enum_name: "AllVariantTypes".into(),
+            variant_name: "Second".into(),
+            other_name: "Second".into(),
+        },
+        Output {
+            enum_name: "AllVariantTypes".into(),
+            variant_name: "Third".into(),
+            other_name: "Third".into(),
+        },
+        Output {
+            enum_name: "AllVariantTypes".into(),
+            variant_name: "Fourth".into(),
+            other_name: "Fourth".into(),
+        },
+        Output {
+            enum_name: "AllVariantTypes".into(),
+            variant_name: "Fifth".into(),
+            other_name: "Fifth".into(),
+        },
+        Output {
+            enum_name: "AllVariantTypes".into(),
+            variant_name: "Sixth".into(),
+            other_name: "Sixth".into(),
+        },
+        Output {
+            enum_name: "WithDiscriminants".into(),
+            variant_name: "A".into(),
+            other_name: "A".into(),
+        },
+        Output {
+            enum_name: "WithDiscriminants".into(),
+            variant_name: "B".into(),
+            other_name: "B".into(),
+        },
+        Output {
+            enum_name: "WithDiscriminants".into(),
+            variant_name: "C".into(),
+            other_name: "C".into(),
+        },
+        Output {
+            enum_name: "WithDiscriminants".into(),
+            variant_name: "D".into(),
+            other_name: "D".into(),
+        },
+        Output {
+            enum_name: "WithDiscriminants".into(),
+            variant_name: "E".into(),
+            other_name: "E".into(),
+        },
+    ];
+    expected_results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
+#[test]
+fn enum_variant_name_resolution_static() {
+    get_test_data!(data, enum_variants_position);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+    {
+        Crate {
+            item {
+                ... on Enum {
+                    enum_name: name @output
+
+                    variant {
+                        name: name @filter(op: "one_of", value: ["$name"]) @output
+                    }
+                }
+            }
+        }
+    }
+    "#;
+
+    let variables: BTreeMap<&str, Vec<&str>> =
+        BTreeMap::from([("name", ["First", "Second", "Third", "A"].to_vec())]);
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        enum_name: String,
+        name: String,
+    }
+
+    let mut results: Vec<Output> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables)
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    let mut expected_results = vec![
+        Output {
+            enum_name: "AllVariantTypes".into(),
+            name: "First".into(),
+        },
+        Output {
+            enum_name: "AllVariantTypes".into(),
+            name: "Second".into(),
+        },
+        Output {
+            enum_name: "AllVariantTypes".into(),
+            name: "Third".into(),
+        },
+        Output {
+            enum_name: "WithDiscriminants".into(),
+            name: "A".into(),
+        },
+    ];
+    expected_results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
+#[test]
 fn enum_struct_variant_fields() {
     get_test_data!(data, enum_variants_position);
     let adapter = RustdocAdapter::new(&data, None);

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -211,6 +211,10 @@ pub struct IndexedCrate<'a> {
     /// index: kind of public top-level item -> `IndexMap<Id, &'a Item>` of that kind
     pub(crate) pub_item_kind_index: PubItemKindIndex<'a>,
 
+    /// index: enum id + variant name -> variant, index of variant inside enum.
+    #[expect(clippy::type_complexity)]
+    pub(crate) variant_name_index: Option<HashMap<(Id, &'a str), (&'a Item, usize)>>,
+
     /// Trait items defined in external crates are not present in the `inner: &Crate` field,
     /// even if they are implemented by a type in that crate. This also includes
     /// Rust's built-in traits like `Debug, Send, Eq` etc.
@@ -558,6 +562,7 @@ impl<'a> IndexedCrate<'a> {
             impl_method_index: None,
             fn_owner_index: None,
             export_name_index: None,
+            variant_name_index: None,
             target_features,
             pub_item_kind_index,
         };
@@ -601,6 +606,7 @@ impl<'a> IndexedCrate<'a> {
         value.impl_method_index = Some(build_impl_index(&crate_.index).into_inner());
         value.fn_owner_index = Some(fn_owner_index);
         value.export_name_index = Some(build_export_name_index(&crate_.index));
+        value.variant_name_index = Some(build_variant_name_index(&crate_.index));
 
         value
     }
@@ -763,6 +769,68 @@ fn build_export_name_index(index: &HashMap<Id, Item>) -> HashMap<&str, &Item> {
         crate::exported_name::item_export_name(item).map(move |name| (name, item))
     })
     .collect()
+}
+
+fn build_variant_name_index(item_index: &HashMap<Id, Item>) -> HashMap<(Id, &str), (&Item, usize)> {
+    #[cfg(feature = "rayon")]
+    let iter = item_index.par_iter().map(|(_, value)| value);
+    #[cfg(not(feature = "rayon"))]
+    let iter = item_index.values();
+
+    let intermediate_iter = iter.filter_map(|item| match &item.inner {
+        rustdoc_types::ItemEnum::Enum(e) => Some((item.id, e)),
+        _ => None,
+    });
+
+    #[cfg(feature = "rayon")]
+    return intermediate_iter
+        .flat_map_iter(|(enum_id, enum_item)| {
+            // Since the variant index order needs to be deterministic, we don't
+            // iterate over variants in parallel.
+            let base_iter = enum_item.variants.iter();
+
+            // Since bugs in rustdoc sometimes result in dangling ids, we filter out any
+            // variants that are not part of the item index.
+            base_iter
+                .copied()
+                .filter_map(|variant_id| item_index.get(&variant_id))
+                .enumerate()
+                .map(move |(variant_index, variant_item)| {
+                    let variant_name = variant_item
+                        .name
+                        .as_ref()
+                        .expect("Variant should have a name.")
+                        .as_str();
+
+                    ((enum_id, variant_name), (variant_item, variant_index))
+                })
+        })
+        .collect();
+
+    #[cfg(not(feature = "rayon"))]
+    return intermediate_iter
+        .flat_map(|(enum_id, enum_item)| {
+            // Since the variant index order needs to be deterministic, we don't
+            // iterate over variants in parallel.
+            let base_iter = enum_item.variants.iter();
+
+            // Since bugs in rustdoc sometimes result in dangling ids, we filter out any
+            // variants that are not part of the item index.
+            base_iter
+                .copied()
+                .filter_map(|variant_id| item_index.get(&variant_id))
+                .enumerate()
+                .map(move |(variant_index, variant_item)| {
+                    let variant_name = variant_item
+                        .name
+                        .as_ref()
+                        .expect("Variant should have a name.")
+                        .as_str();
+
+                    ((enum_id, variant_name), (variant_item, variant_index))
+                })
+        })
+        .collect();
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
**Purpose of Change**
Resolving enum variants costs a lot of time in already heavy queries. In
particular, the following lints will run faster after this change.
```
enum_no_repr_variant_discriminant_changed
enum_unit_variant_changed_kind
enum_variant_marked_non_exhaustive
enum_variant_missing
partial_ord_enum_variants_reordered
```

**Describe the Change**
Implement a custom resolver for enum variants based on a new index.

**Additional Context**
If all of the above lints act only on public enums then index creation
can be made faster by using `pub_item_kind_index`.

---------

Co-authored-by: Predrag Gruevski <2348618+obi1kenobi@users.noreply.github.com>
