### PR TITLE
Force regeneration when toolchain specified (#953)

### DIFF
--- a/scripts/regenerate_test_rustdocs.sh
+++ b/scripts/regenerate_test_rustdocs.sh
@@ -41,6 +41,11 @@ else
     ALWAYS_UPDATE=1
 fi
 
+# If a toolchain was explicitly requested, always regenerate.
+if [[ -n "$TOOLCHAIN" ]]; then
+    ALWAYS_UPDATE=1
+fi
+
 JOBS=${JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)}
 
 CRATES_TO_BUILD=()


### PR DESCRIPTION
## Summary
- always rebuild test crate rustdocs when a specific toolchain is
provided

## Testing
- `cargo fmt --all`
- `cargo test -- --quiet` *(fails: Expected to find rustdoc v55 but got
v56 instead)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f2e1007c832d96c339d9f6e52514
