### PR TITLE
Add parallel test crate runner and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,14 @@ jobs:
     needs:
       - lint
       - rust-tests
+      - test-crates
     if: ${{ success() || failure() }}  # Run this job even if a dependency has failed.
     steps:
       - name: Job outcomes
         run: |
           echo "lint: ${{ needs.lint.result }}"
           echo "rust-tests: ${{ needs.rust-tests.result }}"
+          echo "test-crates: ${{ needs.test-crates.result }}"
 
       # Fail this required job if any of its dependent jobs have failed.
       #
@@ -37,6 +39,8 @@ jobs:
       - if: ${{ needs.lint.result != 'success' }}
         run: exit 1
       - if: ${{ needs.rust-tests.result != 'success' }}
+        run: exit 1
+      - if: ${{ needs.test-crates.result != 'success' }}
         run: exit 1
 
   lint:
@@ -103,6 +107,24 @@ jobs:
 
       - name: test with rayon and rustc-hash
         run: cargo test --features rayon,rustc-hash
+
+  test-crates:
+    name: Run test crate tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          rustflags: ""
+
+      - name: Run test crate tests
+        run: ./scripts/test_crates.sh
 
   publish:
     name: Publish to crates.io

--- a/scripts/test_crates.sh
+++ b/scripts/test_crates.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Fail on first error, on undefined variables, and on failures in pipelines.
+set -euo pipefail
+
+BASE_CARGO_TARGET_DIR=/tmp/test_crates
+TOPLEVEL="$(git rev-parse --show-toplevel)"
+
+JOBS=${JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)}
+
+CRATES=$(find "$TOPLEVEL/test_crates" -maxdepth 1 -mindepth 1 -type d -exec basename {} \;)
+
+test_crate() {
+    local crate="$1"
+    local crate_target_dir="$BASE_CARGO_TARGET_DIR/$crate"
+    echo "Testing: $crate"
+    (
+        cd "$TOPLEVEL/test_crates/$crate"
+        CARGO_TARGET_DIR="$crate_target_dir" cargo test --no-run
+        CARGO_TARGET_DIR="$crate_target_dir" cargo test
+    )
+}
+export -f test_crate
+export TOPLEVEL BASE_CARGO_TARGET_DIR
+
+printf '%s\n' $CRATES | xargs -I{} -P "$JOBS" bash -c 'test_crate "$@"' _ {}


### PR DESCRIPTION
## Summary
- add script to run tests for each test crate concurrently
- run the new script in CI on the stable toolchain

## Testing
- `cargo fmt -- --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings -Dclippy::print_stdout -Dclippy::print_stderr -Dclippy::dbg_macro --allow deprecated`
- `cargo test --no-run`
- `cargo test -- --quiet` *(fails: expected to find rustdoc v55 but got v56 instead)*
- `./scripts/test_crates.sh` *(fails: `generic_param_positions` crate: `()` is not an iterator; `feature_not_on_our_target_triple` crate: `leoncasa` target feature not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fb855f50832d98bb108a023a448b