### PR TITLE
Add an index for `ImportablePath`

### DIFF
--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -165,7 +165,7 @@ pub(super) fn resolve_importable_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
             match importable_paths {
                 Some(importable_paths) => Box::new(
                     importable_paths
-                        .into_iter()
+                        .iter()
                         .map(move |x| origin.make_importable_path_vertex(x)),
                 ),
                 None => Box::new(std::iter::empty()),

--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -160,13 +160,21 @@ pub(super) fn resolve_importable_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 
             let parent_crate = adapter.crate_at_origin(origin);
 
-            Box::new(
-                parent_crate
-                    .own_crate
-                    .publicly_importable_names(item_id)
-                    .into_iter()
-                    .map(move |x| origin.make_importable_path_vertex(x)),
-            )
+            let importable_paths = parent_crate
+                .own_crate
+                .importable_paths_index
+                .as_ref()
+                .unwrap()
+                .get(item_id);
+
+            match importable_paths {
+                Some(importable_paths) => Box::new(
+                    importable_paths
+                        .into_iter()
+                        .map(move |x| origin.make_importable_path_vertex(x)),
+                ),
+                None => Box::new(std::iter::empty()),
+            }
         }),
         _ => unreachable!("resolve_importable_edge {edge_name}"),
     }

--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -163,8 +163,6 @@ pub(super) fn resolve_importable_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
             let importable_paths = parent_crate
                 .own_crate
                 .importable_paths_index
-                .as_ref()
-                .unwrap()
                 .get(item_id);
 
             match importable_paths {

--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -160,10 +160,7 @@ pub(super) fn resolve_importable_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
 
             let parent_crate = adapter.crate_at_origin(origin);
 
-            let importable_paths = parent_crate
-                .own_crate
-                .importable_paths_index
-                .get(item_id);
+            let importable_paths = parent_crate.own_crate.importable_paths_index.get(item_id);
 
             match importable_paths {
                 Some(importable_paths) => Box::new(

--- a/src/adapter/origin.rs
+++ b/src/adapter/origin.rs
@@ -56,11 +56,11 @@ impl Origin {
 
     pub(super) fn make_importable_path_vertex<'a>(
         &self,
-        importable_path: ImportablePath<'a>,
+        importable_path: &'a ImportablePath<'a>,
     ) -> Vertex<'a> {
         Vertex {
             origin: *self,
-            kind: VertexKind::ImportablePath(Rc::from(importable_path)),
+            kind: VertexKind::ImportablePath(importable_path),
         }
     }
 

--- a/src/adapter/vertex.rs
+++ b/src/adapter/vertex.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, num::NonZeroUsize, rc::Rc};
+use std::{borrow::Cow, num::NonZeroUsize};
 
 use rustdoc_types::{
     Abi, Constant, Crate, Enum, Function, GenericBound, GenericParamDef, Impl, Item, Module, Path,

--- a/src/adapter/vertex.rs
+++ b/src/adapter/vertex.rs
@@ -39,7 +39,7 @@ pub enum VertexKind<'a> {
     Path(&'a [String]),
 
     #[non_exhaustive]
-    ImportablePath(Rc<ImportablePath<'a>>),
+    ImportablePath(&'a ImportablePath<'a>),
 
     #[non_exhaustive]
     RawType(&'a Type),

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -648,10 +648,14 @@ impl<'a> IndexedCrate<'a> {
     /// Return all the paths with which the given item can be imported from this crate.
     #[inline]
     pub fn publicly_importable_names(&'a self, id: &'a Id) -> Option<&'a Vec<ImportablePath<'a>>> {
-        self.importable_paths_index
-            .as_ref()
-            .expect("importable_paths index was never initialised")
-            .get(id)
+        if self.inner.index.contains_key(id) {
+            self.importable_paths_index
+                .as_ref()
+                .expect("importable_paths index was never initialised")
+                .get(id)
+        } else {
+            None
+        }
     }
 
     /// Return `true` if our analysis indicates the trait is sealed, and `false` otherwise.

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -236,6 +236,9 @@ pub struct IndexedCrate<'a> {
 
     /// Target feature information about our current target triple.
     pub(crate) target_features: HashMap<&'a str, &'a rustdoc_types::TargetFeature>,
+
+    /// index: item id -> Vector of importable paths.
+    pub(crate) importable_paths_index: Option<HashMap<Id, Vec<ImportablePath<'a>>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -565,12 +568,32 @@ impl<'a> IndexedCrate<'a> {
             variant_name_index: None,
             target_features,
             pub_item_kind_index,
+            importable_paths_index: None,
         };
 
         debug_assert!(
             !value.manually_inlined_builtin_traits.is_empty(),
             "failed to find any traits to manually inline",
         );
+
+        value.importable_paths_index = Some({
+            #[cfg(feature = "rayon")]
+            let iter = crate_.index.par_iter();
+            #[cfg(not(feature = "rayon"))]
+            let iter = crate_.index.iter();
+
+            iter.filter_map(|(_id, item)| {
+                if item.visibility == rustdoc_types::Visibility::Public {
+                    let import_paths = value
+                        .visibility_tracker
+                        .collect_publicly_importable_names(_id.0);
+                    Some((*_id, import_paths))
+                } else {
+                    None
+                }
+            })
+            .collect()
+        });
 
         // Build the imports index
         //
@@ -614,8 +637,15 @@ impl<'a> IndexedCrate<'a> {
     /// Return all the paths with which the given item can be imported from this crate.
     pub fn publicly_importable_names(&self, id: &'a Id) -> Vec<ImportablePath<'a>> {
         if self.inner.index.contains_key(id) {
-            self.visibility_tracker
-                .collect_publicly_importable_names(id.0)
+            self.importable_paths_index
+                .as_ref()
+                .expect("importable_paths index was never initialised")
+                .get(id)
+                .map(|x| x.clone())
+                .unwrap_or_else(|| {
+                    self.visibility_tracker
+                        .collect_publicly_importable_names(id.0)
+                })
         } else {
             Default::default()
         }

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -12,8 +12,8 @@ use crate::hashtables::HashMapExt as _;
 use crate::{
     adapter::supported_item_kind,
     hashtables::{HashMap, HashSet, IndexMap},
-    item_flags::{ItemFlag, build_flags_index},
-    visibility_tracker::VisibilityTracker,
+    item_flags::{build_flags_index, ItemFlag},
+    visibility_tracker::{self, VisibilityTracker},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -238,7 +238,7 @@ pub struct IndexedCrate<'a> {
     pub(crate) target_features: HashMap<&'a str, &'a rustdoc_types::TargetFeature>,
 
     /// index: item id -> Vector of importable paths.
-    pub(crate) importable_paths_index: Option<HashMap<Id, Vec<ImportablePath<'a>>>>,
+    pub(crate) importable_paths_index: HashMap<Id, Vec<ImportablePath<'a>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -555,28 +555,8 @@ impl<'a> IndexedCrate<'a> {
             .map(|feat| (feat.name.as_str(), feat))
             .collect();
 
-        let mut value = Self {
-            inner: crate_,
-            visibility_tracker: VisibilityTracker::from_crate(crate_),
-            manually_inlined_builtin_traits,
-            sized_trait,
-            flags: None,
-            imports_index: None,
-            impl_method_index: None,
-            fn_owner_index: None,
-            export_name_index: None,
-            variant_name_index: None,
-            target_features,
-            pub_item_kind_index,
-            importable_paths_index: None,
-        };
-
-        debug_assert!(
-            !value.manually_inlined_builtin_traits.is_empty(),
-            "failed to find any traits to manually inline",
-        );
-
-        value.importable_paths_index = Some({
+        let visibility_tracker = VisibilityTracker::from_crate(crate_);
+        let importable_paths_index = {
             #[cfg(feature = "rayon")]
             let iter = crate_.index.par_iter();
             #[cfg(not(feature = "rayon"))]
@@ -588,8 +568,7 @@ impl<'a> IndexedCrate<'a> {
                         // Items must have a name in order to be importable.
                         return None;
                     }
-                    let import_paths = value
-                        .visibility_tracker
+                    let import_paths = visibility_tracker
                         .collect_publicly_importable_names(_id.0);
                     Some((*_id, import_paths))
                 } else {
@@ -597,7 +576,28 @@ impl<'a> IndexedCrate<'a> {
                 }
             })
             .collect()
-        });
+        };
+
+        let mut value = Self {
+            inner: crate_,
+            visibility_tracker: visibility_tracker,
+            manually_inlined_builtin_traits,
+            sized_trait,
+            flags: None,
+            imports_index: None,
+            impl_method_index: None,
+            fn_owner_index: None,
+            export_name_index: None,
+            variant_name_index: None,
+            target_features,
+            pub_item_kind_index,
+            importable_paths_index: importable_paths_index,
+        };
+
+        debug_assert!(
+            !value.manually_inlined_builtin_traits.is_empty(),
+            "failed to find any traits to manually inline",
+        );
 
         // Build the imports index
         //
@@ -613,7 +613,7 @@ impl<'a> IndexedCrate<'a> {
                 if !supported_item_kind(item) {
                     return None;
                 }
-                let importable_paths = value.importable_paths_index.as_ref().unwrap().get(&item.id);
+                let importable_paths = value.importable_paths_index.get(&item.id);
                 if importable_paths.is_none() {
                     return None;
                 }
@@ -648,14 +648,8 @@ impl<'a> IndexedCrate<'a> {
     /// Return all the paths with which the given item can be imported from this crate.
     #[inline]
     pub fn publicly_importable_names(&'a self, id: &'a Id) -> Option<&'a Vec<ImportablePath<'a>>> {
-        if self.inner.index.contains_key(id) {
-            self.importable_paths_index
-                .as_ref()
-                .expect("importable_paths index was never initialised")
-                .get(id)
-        } else {
-            None
-        }
+        self.importable_paths_index
+            .get(id)
     }
 
     /// Return `true` if our analysis indicates the trait is sealed, and `false` otherwise.

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -12,8 +12,8 @@ use crate::hashtables::HashMapExt as _;
 use crate::{
     adapter::supported_item_kind,
     hashtables::{HashMap, HashSet, IndexMap},
-    item_flags::{build_flags_index, ItemFlag},
-    visibility_tracker::{self, VisibilityTracker},
+    item_flags::{ItemFlag, build_flags_index},
+    visibility_tracker::VisibilityTracker,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -459,7 +459,10 @@ fn build_impl_index(index: &HashMap<Id, Item>) -> MapList<ImplEntry<'_>, (&Item,
 
             let impl_entries = impl_items.filter_map(move |item_id| {
                 let item = index.get(item_id)?;
-                let item_name = item.name.as_deref()?;
+                if item.name.is_none() {
+                    // Items must have a name in order to be importable.
+                    return None;
+                }
 
                 // The `impl_index` contains only methods, discard other item types.
                 if matches!(item.inner, rustdoc_types::ItemEnum::Function { .. }) {
@@ -564,12 +567,9 @@ impl<'a> IndexedCrate<'a> {
 
             iter.filter_map(|(_id, item)| {
                 if item.visibility == rustdoc_types::Visibility::Public {
-                    if item.name.is_none() {
-                        // Items must have a name in order to be importable.
-                        return None;
-                    }
-                    let import_paths = visibility_tracker
-                        .collect_publicly_importable_names(_id.0);
+                    // Items must have a name in order to be importable.
+                    item.name.as_ref()?;
+                    let import_paths = visibility_tracker.collect_publicly_importable_names(_id.0);
                     Some((*_id, import_paths))
                 } else {
                     None
@@ -580,7 +580,7 @@ impl<'a> IndexedCrate<'a> {
 
         let mut value = Self {
             inner: crate_,
-            visibility_tracker: visibility_tracker,
+            visibility_tracker,
             manually_inlined_builtin_traits,
             sized_trait,
             flags: None,
@@ -591,7 +591,7 @@ impl<'a> IndexedCrate<'a> {
             variant_name_index: None,
             target_features,
             pub_item_kind_index,
-            importable_paths_index: importable_paths_index,
+            importable_paths_index,
         };
 
         debug_assert!(
@@ -620,9 +620,9 @@ impl<'a> IndexedCrate<'a> {
                 let importable_paths = importable_paths.unwrap();
 
                 #[cfg(feature = "rayon")]
-                let iter = importable_paths.into_par_iter();
+                let iter = importable_paths.par_iter();
                 #[cfg(not(feature = "rayon"))]
-                let iter = importable_paths.into_iter();
+                let iter = importable_paths.iter();
 
                 Some(iter.map(move |importable_path| {
                     (
@@ -648,8 +648,7 @@ impl<'a> IndexedCrate<'a> {
     /// Return all the paths with which the given item can be imported from this crate.
     #[inline]
     pub fn publicly_importable_names(&'a self, id: &'a Id) -> Option<&'a Vec<ImportablePath<'a>>> {
-        self.importable_paths_index
-            .get(id)
+        self.importable_paths_index.get(id)
     }
 
     /// Return `true` if our analysis indicates the trait is sealed, and `false` otherwise.

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -459,14 +459,14 @@ fn build_impl_index(index: &HashMap<Id, Item>) -> MapList<ImplEntry<'_>, (&Item,
 
             let impl_entries = impl_items.filter_map(move |item_id| {
                 let item = index.get(item_id)?;
-                if item.name.is_none() {
-                    // Items must have a name in order to be importable.
-                    return None;
-                }
-
-                // The `impl_index` contains only methods, discard other item types.
-                if matches!(item.inner, rustdoc_types::ItemEnum::Function { .. }) {
-                    Some((ImplEntry::new(id, item_name), (impl_item, item)))
+                // Items must have a name in order to be importable.
+                if let Some(item_name) = &item.name {
+                    // The `impl_index` contains only methods, discard other item types.
+                    if matches!(item.inner, rustdoc_types::ItemEnum::Function { .. }) {
+                        Some((ImplEntry::new(id, item_name), (impl_item, item)))
+                    } else {
+                        None
+                    }
                 } else {
                     None
                 }
@@ -613,11 +613,7 @@ impl<'a> IndexedCrate<'a> {
                 if !supported_item_kind(item) {
                     return None;
                 }
-                let importable_paths = value.importable_paths_index.get(&item.id);
-                if importable_paths.is_none() {
-                    return None;
-                }
-                let importable_paths = importable_paths.unwrap();
+                let importable_paths = value.importable_paths_index.get(&item.id)?;
 
                 #[cfg(feature = "rayon")]
                 let iter = importable_paths.par_iter();

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -584,6 +584,10 @@ impl<'a> IndexedCrate<'a> {
 
             iter.filter_map(|(_id, item)| {
                 if item.visibility == rustdoc_types::Visibility::Public {
+                    if item.name.is_none() {
+                        // Items must have a name in order to be importable.
+                        return None;
+                    }
                     let import_paths = value
                         .visibility_tracker
                         .collect_publicly_importable_names(_id.0);
@@ -609,7 +613,11 @@ impl<'a> IndexedCrate<'a> {
                 if !supported_item_kind(item) {
                     return None;
                 }
-                let importable_paths = value.publicly_importable_names(&item.id);
+                let importable_paths = value.importable_paths_index.as_ref().unwrap().get(&item.id);
+                if importable_paths.is_none() {
+                    return None;
+                }
+                let importable_paths = importable_paths.unwrap();
 
                 #[cfg(feature = "rayon")]
                 let iter = importable_paths.into_par_iter();
@@ -617,7 +625,10 @@ impl<'a> IndexedCrate<'a> {
                 let iter = importable_paths.into_iter();
 
                 Some(iter.map(move |importable_path| {
-                    (importable_path.path, (item, importable_path.modifiers))
+                    (
+                        importable_path.path.clone(),
+                        (item, importable_path.modifiers.clone()),
+                    )
                 }))
             })
             .flatten()
@@ -635,20 +646,12 @@ impl<'a> IndexedCrate<'a> {
     }
 
     /// Return all the paths with which the given item can be imported from this crate.
-    pub fn publicly_importable_names(&self, id: &'a Id) -> Vec<ImportablePath<'a>> {
-        if self.inner.index.contains_key(id) {
-            self.importable_paths_index
-                .as_ref()
-                .expect("importable_paths index was never initialised")
-                .get(id)
-                .map(|x| x.clone())
-                .unwrap_or_else(|| {
-                    self.visibility_tracker
-                        .collect_publicly_importable_names(id.0)
-                })
-        } else {
-            Default::default()
-        }
+    #[inline]
+    pub fn publicly_importable_names(&'a self, id: &'a Id) -> Option<&'a Vec<ImportablePath<'a>>> {
+        self.importable_paths_index
+            .as_ref()
+            .expect("importable_paths index was never initialised")
+            .get(id)
     }
 
     /// Return `true` if our analysis indicates the trait is sealed, and `false` otherwise.


### PR DESCRIPTION
**Purpose of Change**
Tracing shows that `ResolveNeighbors(ImportablePath, Path)` can take a significant fraction of total runtime (5-10%).  

**Describe the Change**
Pre-calculate the importable path for every public item and replace path calculations with a lookup into a `HashMap`. 

**What alternatives have you considered?**
- The main speedup comes from eliminating the allocations of the paths, so if there was a way to do that without adding an index, it would be an easy win. 

**Additional Context**
This is a draft because I'm not sure of the performance impact. Last time I measured it, it came out neutral overall, but a new index and another dozen or so lints have been added since then.