### PR TITLE
Fix crash on explicitly specified generic receiver type. (#1046)

### DIFF
--- a/src/adapter/receiver.rs
+++ b/src/adapter/receiver.rs
@@ -48,8 +48,8 @@ fn extract_kind_string(ty: &Type) -> Cow<'_, str> {
         // For &self and &mut self, we need to extract the inner type
         Type::BorrowedRef { type_, .. } => extract_kind_string(type_),
 
-        // Self is the simplest case - this handles both 'self' and 'mut self'
-        Type::Generic(name) if name == "Self" => Cow::Borrowed("Self"),
+        // Generic receiver components can be `Self` or any named type parameter.
+        Type::Generic(name) => Cow::Borrowed(name.as_str()),
 
         // Handle ResolvedPath types like Box<Self>, Pin<&mut Self>, etc.
         Type::ResolvedPath(path) => {

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -8176,6 +8176,22 @@ fn method_self_receiver() {
             by_mut_reference: false,
             kind: "Pin<&Arc<Self>>".into(),
         },
+        Output {
+            struct_name: "GenericExample".into(),
+            method_name: "by_generic_ref".into(),
+            by_value: false,
+            by_reference: true,
+            by_mut_reference: false,
+            kind: "GenericExample<'a, T>".into(),
+        },
+        Output {
+            struct_name: "GenericExample".into(),
+            method_name: "by_generic_value".into(),
+            by_value: true,
+            by_reference: false,
+            by_mut_reference: false,
+            kind: "GenericExample<'a, T>".into(),
+        },
     ];
     expected_results.sort_unstable();
     similar_asserts::assert_eq!(expected_results, results);

--- a/test_crates/method_self_receivers/src/lib.rs
+++ b/test_crates/method_self_receivers/src/lib.rs
@@ -4,6 +4,8 @@ pub struct Example(i64);
 
 pub struct CustomReceiver<T>(T);
 
+pub struct GenericExample<'a, T: ?Sized + 'a>(&'a T);
+
 /// Per the docs: <https://doc.rust-lang.org/std/ops/trait.Receiver.html>
 ///
 /// N.B.: `Pin` currently doesn't appear to be able to be combined with custom receivers.
@@ -78,4 +80,14 @@ impl Example {
     pub fn by_pinned_ref_arc(self: std::pin::Pin<&std::sync::Arc<Self>>) {}
 
     pub fn wrong_self(selfless: ()) {}
+}
+
+impl<'a, T: ?Sized + 'a> GenericExample<'a, T> {
+    pub fn by_generic_value(self: GenericExample<'a, T>) -> &'a T {
+        self.0
+    }
+
+    pub fn by_generic_ref(self: &GenericExample<'a, T>) -> &&'a T {
+        &self.0
+    }
 }


### PR DESCRIPTION
Add receiver coverage for a legal explicit self type containing a
generic parameter: `GenericExample<'a, T>`.

Fix receiver kind formatting so named generic parameters are printed
instead of triggering an `unreachable!()` when a resolved receiver type
contains nested `Type::Generic(...)` values.

Fixes https://github.com/obi1kenobi/cargo-semver-checks/issues/1600
