### PR TITLE
Drop support for Rust 1.91.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: ["1.91", "1.92"]
+        toolchain: ["1.92"]
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
It doesn't support one of our type normalization tests.
