### PR TITLE
Report trait supertraits from `where Self: ...` bounds.

### DIFF
--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeSet, num::NonZeroUsize};
 
 use rustdoc_types::{
-    GenericBound::TraitBound, GenericParamDefKind, Id, ItemEnum, VariantKind, WherePredicate,
+    GenericBound::TraitBound, GenericParamDefKind, Id, ItemEnum, Type, VariantKind, WherePredicate,
 };
 use trustfall::provider::{
     AsVertex, ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo, VertexIterator,
@@ -580,35 +580,48 @@ pub(super) fn resolve_trait_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
             let item_index = &adapter.crate_at_origin(origin).own_crate.inner.index;
 
             let trait_vertex = vertex.as_trait().expect("not a Trait vertex");
-            Box::new(trait_vertex.bounds.iter().filter_map(move |bound| {
-                if let TraitBound { trait_, .. } = &bound {
-                    // When the implemented trait is from the same crate
-                    // as its definition, the trait is expected to be present
-                    // in `item_index`. Otherwise, the
-                    // `rustdoc_types::Trait` is not in this rustdoc,
-                    // even if the trait is part of Rust `core` or `std`.
-                    // As a temporary workaround, some common
-                    // Rust built-in traits are manually "inlined"
-                    // with items stored in `manually_inlined_builtin_traits`.
-                    let found_item = item_index.get(&trait_.id).or_else(|| {
-                        adapter
-                            .crate_at_origin(origin)
-                            .own_crate
-                            .manually_inlined_builtin_traits
-                            .get(&trait_.id)
-                    });
+            let colon_supertraits = trait_vertex.bounds.iter();
+            let where_self_supertraits = trait_vertex
+                .generics
+                .where_predicates
+                .iter()
+                .filter_map(|predicate| match predicate {
+                    WherePredicate::BoundPredicate {
+                        type_: Type::Generic(name),
+                        bounds,
+                        ..
+                    } if name == "Self" => Some(bounds.as_slice()),
+                    _ => None,
+                })
+                .flatten();
 
-                    // TODO: Remove this once rust-analyzer stops falsely inferring the type of
-                    //       `bound` as `GenericBound` when in fact it's `&GenericBound`.
-                    //       It shows a phantom compile error unless we add `&` before `bound`.
-                    #[allow(clippy::needless_borrow)]
-                    let trait_bound: Option<&rustdoc_types::GenericBound> = Some(&bound);
+            Box::new(
+                colon_supertraits
+                    .chain(where_self_supertraits)
+                    .filter_map(move |bound| {
+                        let TraitBound { trait_, .. } = bound else {
+                            return None;
+                        };
 
-                    Some(origin.make_implemented_trait_vertex(trait_, trait_bound, found_item))
-                } else {
-                    None
-                }
-            }))
+                        // When the implemented trait is from the same crate
+                        // as its definition, the trait is expected to be present
+                        // in `item_index`. Otherwise, the
+                        // `rustdoc_types::Trait` is not in this rustdoc,
+                        // even if the trait is part of Rust `core` or `std`.
+                        // As a temporary workaround, some common
+                        // Rust built-in traits are manually "inlined"
+                        // with items stored in `manually_inlined_builtin_traits`.
+                        let found_item = item_index.get(&trait_.id).or_else(|| {
+                            adapter
+                                .crate_at_origin(origin)
+                                .own_crate
+                                .manually_inlined_builtin_traits
+                                .get(&trait_.id)
+                        });
+
+                        Some(origin.make_implemented_trait_vertex(trait_, Some(bound), found_item))
+                    }),
+            )
         }),
         "method" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -202,6 +202,113 @@ fn rustdoc_finds_supertrait() {
 }
 
 #[test]
+fn rustdoc_finds_where_self_supertraits() {
+    get_test_data!(data, supertrait_where_self);
+    let adapter = RustdocAdapter::new(&data, None);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Trait {
+                name @output @filter(op: "one_of", value: ["$traits"])
+
+                supertrait {
+                    supertrait: name @output
+                    instantiated_name @output
+                }
+            }
+        }
+    }
+}
+"#;
+
+    let mut variables: BTreeMap<&str, FieldValue> = BTreeMap::default();
+    variables.insert(
+        "traits",
+        vec![
+            "HeaderSupertrait",
+            "MixedSuperAndNonSuper",
+            "NonSelfWhere",
+            "RefSelfWithTraitLifetime",
+            "RefSelfWhere",
+            "TwoColonTwoWhere",
+            "WhereSelfGeneric",
+            "WhereSelfSupertrait",
+        ]
+        .into(),
+    );
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        supertrait: String,
+        instantiated_name: String,
+    }
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, Arc::new(&adapter), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    similar_asserts::assert_eq!(
+        vec![
+            Output {
+                name: "HeaderSupertrait".into(),
+                supertrait: "Base".into(),
+                instantiated_name: "Base<Assoc = u8>".into(),
+            },
+            Output {
+                name: "MixedSuperAndNonSuper".into(),
+                supertrait: "Base".into(),
+                instantiated_name: "Base<Assoc = u8>".into(),
+            },
+            Output {
+                name: "MixedSuperAndNonSuper".into(),
+                supertrait: "GenericBase".into(),
+                instantiated_name: "GenericBase<T>".into(),
+            },
+            Output {
+                name: "TwoColonTwoWhere".into(),
+                supertrait: "Base".into(),
+                instantiated_name: "Base<Assoc = u8>".into(),
+            },
+            Output {
+                name: "TwoColonTwoWhere".into(),
+                supertrait: "GenericBase".into(),
+                instantiated_name: "GenericBase<T>".into(),
+            },
+            Output {
+                name: "TwoColonTwoWhere".into(),
+                supertrait: "GenericMarker".into(),
+                instantiated_name: "GenericMarker<T>".into(),
+            },
+            Output {
+                name: "TwoColonTwoWhere".into(),
+                supertrait: "LocalMarker".into(),
+                instantiated_name: "LocalMarker".into(),
+            },
+            Output {
+                name: "WhereSelfGeneric".into(),
+                supertrait: "GenericBase".into(),
+                instantiated_name: "GenericBase<T>".into(),
+            },
+            Output {
+                name: "WhereSelfSupertrait".into(),
+                supertrait: "Base".into(),
+                instantiated_name: "Base<Assoc = u8>".into(),
+            },
+        ],
+        results
+    );
+}
+
+#[test]
 fn rustdoc_sealed_traits() {
     get_test_data!(data, sealed_traits);
     let adapter = RustdocAdapter::new(&data, None);

--- a/test_crates/supertrait_where_self/Cargo.toml
+++ b/test_crates/supertrait_where_self/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "supertrait_where_self"
+version = "0.1.0"
+edition = "2024"

--- a/test_crates/supertrait_where_self/src/lib.rs
+++ b/test_crates/supertrait_where_self/src/lib.rs
@@ -1,0 +1,56 @@
+pub trait Base {
+    type Assoc;
+}
+
+pub trait GenericBase<T> {}
+
+pub trait GenericMarker<T> {}
+
+pub trait LocalMarker {}
+
+pub trait HeaderSupertrait: Base<Assoc = u8> {}
+
+pub trait WhereSelfSupertrait
+where
+    Self: Base<Assoc = u8>,
+{
+}
+
+pub trait WhereSelfGeneric<T>
+where
+    Self: GenericBase<T>,
+{
+}
+
+pub trait NonSelfWhere<T>
+where
+    T: Base<Assoc = u8>,
+{
+}
+
+pub trait RefSelfWhere<T>
+where
+    for<'a> &'a Self: GenericBase<T>,
+{
+}
+
+pub trait RefSelfWithTraitLifetime<'a, T>
+where
+    Self: 'a,
+    &'a Self: GenericBase<T>,
+{
+}
+
+pub trait TwoColonTwoWhere<T>: Base<Assoc = u8> + GenericBase<T>
+where
+    Self: GenericMarker<T>,
+    Self: LocalMarker,
+{
+}
+
+pub trait MixedSuperAndNonSuper<T>: Base<Assoc = u8>
+where
+    Self: GenericBase<T>,
+    for<'a> &'a Self: GenericMarker<T>,
+{
+}


### PR DESCRIPTION
The `trait Foo: Bar` syntax is sugar for `trait Foo where Self: Bar`. But our supertraits edge only considered the former form and ignored valid supertraits given in `where` form. Fix that and ensure that mixing and matching both forms works as well.
