### PR TITLE
Implement type normalization for fn params and returns. (#1064)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,5 +74,6 @@ Before proposing a code change:
 - Run `cargo test` to ensure the code passes tests.
 
 If adding new test crates, then additionally:
+- Ensure their `Cargo.toml` sets `publish = false`.
 - Ensure `RUSTFLAGS="-A dead_code -A deprecated -A unused -A private_bounds" cargo check --manifest-path=<path-to-new-crate-cargo-toml>` passes without warnings on each new test crate.
 - Run `./scripts/regenerate_test_rustdocs.sh` before running the top-level `cargo test` to ensure generated rustdoc is updated.

--- a/src/adapter/edges.rs
+++ b/src/adapter/edges.rs
@@ -18,7 +18,7 @@ use super::{
     RustdocAdapter, optimizations,
     origin::Origin,
     receiver::Receiver,
-    vertex::{Feature, Vertex},
+    vertex::{Feature, FunctionContext, TypeSignatureComponent, Vertex, VertexKind},
 };
 
 pub(super) fn resolve_crate_diff_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
@@ -221,29 +221,61 @@ pub(super) fn resolve_function_like_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
     edge_name: &str,
 ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
     match edge_name {
-        "parameter" => resolve_neighbors_with(contexts, move |vertex| {
-            let origin = vertex.origin;
+        "parameter" => {
+            resolve_neighbors_with(contexts, move |vertex| {
+                let origin = vertex.origin;
+                let (function_item, function, parent) = match &vertex.kind {
+                    VertexKind::Method(method) => {
+                        let ItemEnum::Function(function) = &method.function.inner else {
+                            unreachable!("Method vertex did not contain a function item");
+                        };
+                        (method.function, function, Some(method.parent))
+                    }
+                    VertexKind::Item(item) | VertexKind::PositionedItem(_, item) => {
+                        let ItemEnum::Function(function) = &item.inner else {
+                            unreachable!("vertex was not a FunctionLike");
+                        };
+                        (*item, function, None)
+                    }
+                    _ => unreachable!("vertex was not a FunctionLike"),
+                };
+                let context = FunctionContext {
+                    function: function_item,
+                    parent,
+                };
 
-            Box::new(
-                vertex
-                    .as_function()
-                    .expect("vertex was not a Function")
-                    .sig
-                    .inputs
-                    .iter()
-                    .map(move |(name, _type_)| origin.make_function_parameter_vertex(name)),
-            )
-        }),
+                Box::new(function.sig.inputs.iter().enumerate().map(
+                    move |(index, (name, type_))| {
+                        let position = NonZeroUsize::new(index + 1)
+                            .expect("function parameter positions are 1-based");
+                        origin.make_function_parameter_vertex(context, position, name, type_)
+                    },
+                ))
+            })
+        }
         "return_value" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
-            let return_value = origin.make_return_value_vertex(
-                vertex
-                    .as_function()
-                    .expect("vertex was not a Function")
-                    .sig
-                    .output
-                    .as_ref(),
-            );
+            let (function_item, function, parent) = match &vertex.kind {
+                VertexKind::Method(method) => {
+                    let ItemEnum::Function(function) = &method.function.inner else {
+                        unreachable!("Method vertex did not contain a function item");
+                    };
+                    (method.function, function, Some(method.parent))
+                }
+                VertexKind::Item(item) | VertexKind::PositionedItem(_, item) => {
+                    let ItemEnum::Function(function) = &item.inner else {
+                        unreachable!("vertex was not a FunctionLike");
+                    };
+                    (*item, function, None)
+                }
+                _ => unreachable!("vertex was not a FunctionLike"),
+            };
+            let context = FunctionContext {
+                function: function_item,
+                parent,
+            };
+            let return_value =
+                origin.make_return_value_vertex(context, function.sig.output.as_ref());
 
             Box::new(std::iter::once(return_value))
         }),
@@ -258,6 +290,35 @@ pub(super) fn resolve_function_like_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
             Box::new(std::iter::once(origin.make_function_abi_vertex(abi)))
         }),
         _ => unreachable!("resolve_function_like_edge {edge_name}"),
+    }
+}
+
+pub(super) fn resolve_normalized_type_signature_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
+    contexts: ContextIterator<'a, V>,
+    edge_name: &str,
+) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex<'a>>> {
+    match edge_name {
+        "normalized_type_signature" => resolve_neighbors_with(contexts, move |vertex| {
+            let origin = vertex.origin;
+            let (context, component, type_) = match &vertex.kind {
+                VertexKind::FunctionParameter(parameter) => (
+                    parameter.context,
+                    TypeSignatureComponent::FunctionParameter(parameter.position),
+                    Some(parameter.type_),
+                ),
+                VertexKind::ReturnValue(return_value) => (
+                    return_value.context,
+                    TypeSignatureComponent::ReturnValue,
+                    return_value.type_,
+                ),
+                _ => unreachable!("vertex was not a normalized type signature source"),
+            };
+
+            Box::new(std::iter::once(
+                origin.make_normalized_type_signature_vertex(context, component, type_),
+            ))
+        }),
+        _ => unreachable!("resolve_normalized_type_signature_edge {edge_name}"),
     }
 }
 
@@ -626,6 +687,7 @@ pub(super) fn resolve_trait_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
         "method" => resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
             let item_index = &adapter.crate_at_origin(origin).own_crate.inner.index;
+            let trait_item = vertex.as_item().expect("not a Trait item");
 
             let trait_vertex = vertex.as_trait().expect("not a Trait vertex");
             Box::new(trait_vertex.items.iter().filter_map(move |item_id| {
@@ -633,7 +695,7 @@ pub(super) fn resolve_trait_edge<'a, V: AsVertex<Vertex<'a>> + 'a>(
                 if let Some(next_item) = next_item {
                     match &next_item.inner {
                         rustdoc_types::ItemEnum::Function(..) => {
-                            Some(origin.make_item_vertex(next_item))
+                            Some(origin.make_method_vertex(next_item, trait_item))
                         }
                         _ => None,
                     }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -18,6 +18,7 @@ use self::{
 
 mod edges;
 mod enum_variant;
+mod normalize;
 mod optimizations;
 mod origin;
 mod properties;
@@ -189,6 +190,13 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
                     properties::resolve_function_parameter_property(contexts, property_name)
                 }
                 "ReturnValue" => properties::resolve_return_value_property(contexts, property_name),
+                "NormalizedTypeSignature" => {
+                    properties::resolve_normalized_type_signature_property(
+                        contexts,
+                        property_name,
+                        self,
+                    )
+                }
                 "FunctionAbi" => properties::resolve_function_abi_property(contexts, property_name),
                 "Impl" => properties::resolve_impl_property(contexts, property_name),
                 "Attribute" => properties::resolve_attribute_property(contexts, property_name),
@@ -322,6 +330,11 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
                 if matches!(edge_name.as_ref(), "parameter" | "abi" | "return_value") =>
             {
                 edges::resolve_function_like_edge(contexts, edge_name)
+            }
+            "FunctionParameter" | "ReturnValue"
+                if matches!(edge_name.as_ref(), "normalized_type_signature") =>
+            {
+                edges::resolve_normalized_type_signature_edge(contexts, edge_name)
             }
             "GenericItem" | "ImplOwner" | "Struct" | "Enum" | "Union" | "Trait" | "Function"
             | "Method" | "Impl"

--- a/src/adapter/normalize/context.rs
+++ b/src/adapter/normalize/context.rs
@@ -1,0 +1,436 @@
+use std::{borrow::Cow, num::NonZeroUsize};
+
+use rustdoc_types::{
+    AssocItemConstraint, AssocItemConstraintKind, FunctionSignature, GenericArg, GenericArgs,
+    GenericBound, GenericParamDef, GenericParamDefKind, ItemEnum, Path, Term, Type,
+};
+
+use crate::{PackageIndex, adapter::vertex::FunctionContext};
+
+use super::names::Names;
+
+/// Per-function state used while rendering one normalized signature.
+///
+/// A context is built for the function item that owns the parameter or return
+/// value currently being rendered. It includes generics from the containing
+/// trait or `impl` when there is one, but it is not shared across all methods in
+/// an `impl` block: each function has its own rustdoc signature and its own
+/// synthetic generic parameters.
+#[derive(Clone)]
+pub(super) struct FnNormalizationContext<'a> {
+    crate_: &'a PackageIndex<'a>,
+    names: Names<'a>,
+
+    /// Outer vec: one slot per function parameter, indexed by 0-based parameter.
+    /// Inner vec: the normalized names for the visible parameter-position
+    /// `impl Trait` nodes inside that parameter's type, in the
+    /// same preorder recursive traversal the type formatter walks them.
+    ///
+    /// For example, in `fn f<T>(a: T, b: &impl Clone, c: (impl Default, Vec<impl Into<String>>))`,
+    /// the function-level type counter assigns `T1`, `IT2`, `IT3`, and `IT4`.
+    /// This field then holds `[[], [IT2], [IT3, IT4]]`: parameter `a` has no
+    /// `impl Trait`, parameter `b` has one, and parameter `c` has two.
+    ///
+    /// Bounds inside an `impl Trait` belong to that synthetic type parameter, not
+    /// to the normalized signature of the containing parameter type. In
+    /// `fn g(value: impl Iterator<Item = impl Into<String>>)`, we create
+    /// `IT1` for the nested `impl Into<String>` and `IT2` for the outer
+    /// `impl Iterator<...>`. However, `value`'s type signature is just `IT2`.
+    ///
+    /// Rustdoc represents parameter-position `impl Trait` in two separate places:
+    /// the parameter type tree contains `Type::ImplTrait`, while the function's
+    /// generic parameter list contains the corresponding synthetic type params.
+    /// There is no ID or reference connecting those two representations. The
+    /// shared invariant we can rely on is rustdoc's traversal order, so we
+    /// pre-partition the synthetic names by parameter and give the formatter a
+    /// cursor over the relevant inner vec.
+    ///
+    /// The values are `Cow<'static, str>` because common names such as `IT1`
+    /// through `IT8` are borrowed statics; larger counters fall back to owned
+    /// strings.
+    parameter_impl_trait_names: Vec<Vec<Cow<'static, str>>>,
+}
+
+/// Cursor over the synthetic type-param names for one function parameter.
+///
+/// A parameter may contain multiple `impl Trait` occurrences, such as
+/// `(&impl Clone, Vec<impl Into<String>>)`. During parameter formatting, each
+/// `Type::ImplTrait` consumes the next name from this cursor. Return-position
+/// `impl Trait` formatting does not use this cursor, so it remains an opaque
+/// `impl` type rather than becoming `ITn`.
+pub(super) struct ParameterImplTraitNames<'a> {
+    names: &'a [Cow<'static, str>],
+    next: usize,
+}
+
+impl<'a> ParameterImplTraitNames<'a> {
+    pub(super) fn next(&mut self) -> &str {
+        let name = self.names.get(self.next).unwrap_or_else(|| {
+            unreachable!(
+                "parameter-position impl Trait had no matching synthetic generic parameter"
+            )
+        });
+        self.next += 1;
+        name.as_ref()
+    }
+
+    pub(super) fn assert_finished(&self) {
+        assert_eq!(
+            self.next,
+            self.names.len(),
+            "not all parameter-position impl Trait synthetic generic parameters were used",
+        );
+    }
+}
+
+impl<'a> FnNormalizationContext<'a> {
+    pub(super) fn new(crate_: &'a PackageIndex<'a>, fn_ctx: FunctionContext<'a>) -> Self {
+        let mut names = Names::default();
+
+        // Parent generics must be introduced before function generics so
+        // normalized numbering follows the source-visible outer-to-inner scope.
+        if let Some(item) = fn_ctx.parent {
+            match &item.inner {
+                ItemEnum::Trait(trait_) => {
+                    names.add_params(&trait_.generics.params);
+                }
+                ItemEnum::Impl(impl_) => {
+                    names.add_params(&impl_.generics.params);
+                }
+                _ => unreachable!("function parent was not a trait or impl: {item:?}"),
+            }
+        }
+
+        let ItemEnum::Function(function_inner) = &fn_ctx.function.inner else {
+            unreachable!("normalized type signatures require a function item");
+        };
+        names.add_params(&function_inner.generics.params);
+        let parameter_impl_trait_names = parameter_impl_trait_names(
+            &function_inner.sig.inputs,
+            &function_inner.generics.params,
+            &names,
+        );
+
+        Self {
+            crate_,
+            names,
+            parameter_impl_trait_names,
+        }
+    }
+
+    pub(super) fn with_params(&self, params: &'a [rustdoc_types::GenericParamDef]) -> Self {
+        // HRTB and function-pointer binders add a nested scope. Clone the
+        // context so outer generic mappings remain available while nested
+        // parameters get fresh canonical names.
+        // TODO: If this cloning becomes a bottleneck, we can probably design
+        // a hierarchical name structure, since we don't expect deep levels of nesting.
+        let mut value = self.clone();
+        value.names.add_params(params);
+        value
+    }
+
+    pub(super) fn crate_(&self) -> &'a PackageIndex<'a> {
+        self.crate_
+    }
+
+    pub(super) fn names(&self) -> &Names<'a> {
+        &self.names
+    }
+
+    /// Get the synthetic generic names for a parameter's `impl Trait` nodes.
+    ///
+    /// Rustdoc stores each argument-position `impl Trait` occurrence twice: as a
+    /// `Type::ImplTrait` node at its input position, and as a synthetic generic
+    /// parameter in the containing function's generics. Rustdoc does not link
+    /// those two representations directly, so we rely on their shared traversal
+    /// order within function inputs. Return-position `impl Trait` is formatted
+    /// without this cursor and therefore remains an opaque `impl` type.
+    pub(super) fn parameter_impl_trait_names(
+        &self,
+        position: NonZeroUsize,
+    ) -> ParameterImplTraitNames<'_> {
+        let index = position.get() - 1;
+        let names = self
+            .parameter_impl_trait_names
+            .get(index)
+            .expect("function parameter position was out of bounds");
+        ParameterImplTraitNames { names, next: 0 }
+    }
+}
+
+/// Build the per-parameter cursor data from rustdoc's synthetic generics.
+fn parameter_impl_trait_names<'a>(
+    inputs: &'a [(String, Type)],
+    params: &'a [GenericParamDef],
+    names: &Names<'a>,
+) -> Vec<Vec<Cow<'static, str>>> {
+    let mut synthetic_params = params.iter().filter(|param| {
+        matches!(
+            param.kind,
+            GenericParamDefKind::Type {
+                is_synthetic: true,
+                ..
+            }
+        )
+    });
+
+    let mut output = Vec::with_capacity(inputs.len());
+    for (_, type_) in inputs {
+        let mut parameter_names = Vec::new();
+        collect_type_impl_trait_names(
+            type_,
+            &mut synthetic_params,
+            names,
+            &mut parameter_names,
+            true,
+        );
+        output.push(parameter_names);
+    }
+
+    assert!(
+        synthetic_params.next().is_none(),
+        "rustdoc synthetic generic parameters outnumbered parameter-position impl Trait occurrences",
+    );
+    output
+}
+
+fn collect_type_impl_trait_names<'a>(
+    type_: &'a Type,
+    synthetic_params: &mut impl Iterator<Item = &'a GenericParamDef>,
+    names: &Names<'a>,
+    output: &mut Vec<Cow<'static, str>>,
+    emit: bool,
+) {
+    match type_ {
+        Type::ResolvedPath(path) => {
+            collect_path_impl_trait_names(path, synthetic_params, names, output, emit);
+        }
+        Type::DynTrait(dyn_trait) => {
+            for trait_ in &dyn_trait.traits {
+                collect_generic_params_impl_trait_names(
+                    &trait_.generic_params,
+                    synthetic_params,
+                    names,
+                    output,
+                    emit,
+                );
+                collect_path_impl_trait_names(
+                    &trait_.trait_,
+                    synthetic_params,
+                    names,
+                    output,
+                    emit,
+                );
+            }
+        }
+        Type::Generic(_) | Type::Primitive(_) | Type::Infer | Type::Pat { .. } => {}
+        Type::FunctionPointer(pointer) => {
+            collect_generic_params_impl_trait_names(
+                &pointer.generic_params,
+                synthetic_params,
+                names,
+                output,
+                emit,
+            );
+            collect_function_signature_impl_trait_names(
+                &pointer.sig,
+                synthetic_params,
+                names,
+                output,
+                emit,
+            );
+        }
+        Type::Tuple(types) => {
+            for type_ in types {
+                collect_type_impl_trait_names(type_, synthetic_params, names, output, emit);
+            }
+        }
+        Type::Slice(type_) | Type::Array { type_, .. } => {
+            collect_type_impl_trait_names(type_, synthetic_params, names, output, emit);
+        }
+        Type::ImplTrait(bounds) => {
+            collect_bounds_impl_trait_names(bounds, synthetic_params, names, output, false);
+            let name = next_synthetic_impl_trait_name(synthetic_params, names);
+            if emit {
+                output.push(name);
+            }
+        }
+        Type::RawPointer { type_, .. } | Type::BorrowedRef { type_, .. } => {
+            collect_type_impl_trait_names(type_, synthetic_params, names, output, emit);
+        }
+        Type::QualifiedPath {
+            args,
+            self_type,
+            trait_,
+            ..
+        } => {
+            collect_type_impl_trait_names(self_type, synthetic_params, names, output, emit);
+            if let Some(trait_) = trait_ {
+                collect_path_impl_trait_names(trait_, synthetic_params, names, output, emit);
+            }
+            if let Some(args) = args.as_deref() {
+                collect_generic_args_impl_trait_names(args, synthetic_params, names, output, emit);
+            }
+        }
+    }
+}
+
+fn collect_generic_params_impl_trait_names<'a>(
+    params: &'a [GenericParamDef],
+    synthetic_params: &mut impl Iterator<Item = &'a GenericParamDef>,
+    names: &Names<'a>,
+    output: &mut Vec<Cow<'static, str>>,
+    emit: bool,
+) {
+    for param in params {
+        match &param.kind {
+            GenericParamDefKind::Const { type_, .. } => {
+                collect_type_impl_trait_names(type_, synthetic_params, names, output, emit);
+            }
+            GenericParamDefKind::Lifetime { .. } | GenericParamDefKind::Type { .. } => {}
+        }
+    }
+}
+
+fn collect_path_impl_trait_names<'a>(
+    path: &'a Path,
+    synthetic_params: &mut impl Iterator<Item = &'a GenericParamDef>,
+    names: &Names<'a>,
+    output: &mut Vec<Cow<'static, str>>,
+    emit: bool,
+) {
+    if let Some(args) = path.args.as_deref() {
+        collect_generic_args_impl_trait_names(args, synthetic_params, names, output, emit);
+    }
+}
+
+fn collect_generic_args_impl_trait_names<'a>(
+    args: &'a GenericArgs,
+    synthetic_params: &mut impl Iterator<Item = &'a GenericParamDef>,
+    names: &Names<'a>,
+    output: &mut Vec<Cow<'static, str>>,
+    emit: bool,
+) {
+    match args {
+        GenericArgs::AngleBracketed { args, constraints } => {
+            for arg in args {
+                match arg {
+                    GenericArg::Type(type_) => {
+                        collect_type_impl_trait_names(type_, synthetic_params, names, output, emit);
+                    }
+                    GenericArg::Lifetime(_) | GenericArg::Const(_) | GenericArg::Infer => {}
+                }
+            }
+            for constraint in constraints {
+                collect_assoc_item_constraint_impl_trait_names(
+                    constraint,
+                    synthetic_params,
+                    names,
+                    output,
+                    emit,
+                );
+            }
+        }
+        GenericArgs::Parenthesized {
+            inputs,
+            output: return_type,
+        } => {
+            for type_ in inputs {
+                collect_type_impl_trait_names(type_, synthetic_params, names, output, emit);
+            }
+            if let Some(return_type) = return_type {
+                collect_type_impl_trait_names(return_type, synthetic_params, names, output, emit);
+            }
+        }
+        GenericArgs::ReturnTypeNotation => {}
+    }
+}
+
+fn collect_assoc_item_constraint_impl_trait_names<'a>(
+    constraint: &'a AssocItemConstraint,
+    synthetic_params: &mut impl Iterator<Item = &'a GenericParamDef>,
+    names: &Names<'a>,
+    output: &mut Vec<Cow<'static, str>>,
+    emit: bool,
+) {
+    if let Some(args) = constraint.args.as_deref() {
+        collect_generic_args_impl_trait_names(args, synthetic_params, names, output, emit);
+    }
+
+    match &constraint.binding {
+        AssocItemConstraintKind::Constraint(bounds) => {
+            collect_bounds_impl_trait_names(bounds, synthetic_params, names, output, emit);
+        }
+        AssocItemConstraintKind::Equality(term) => {
+            collect_term_impl_trait_names(term, synthetic_params, names, output, emit);
+        }
+    }
+}
+
+fn collect_bounds_impl_trait_names<'a>(
+    bounds: &'a [GenericBound],
+    synthetic_params: &mut impl Iterator<Item = &'a GenericParamDef>,
+    names: &Names<'a>,
+    output: &mut Vec<Cow<'static, str>>,
+    emit: bool,
+) {
+    for bound in bounds {
+        match bound {
+            GenericBound::TraitBound {
+                trait_,
+                generic_params,
+                ..
+            } => {
+                collect_generic_params_impl_trait_names(
+                    generic_params,
+                    synthetic_params,
+                    names,
+                    output,
+                    emit,
+                );
+                collect_path_impl_trait_names(trait_, synthetic_params, names, output, emit);
+            }
+            GenericBound::Outlives(_) | GenericBound::Use(_) => {}
+        }
+    }
+}
+
+fn collect_term_impl_trait_names<'a>(
+    term: &'a Term,
+    synthetic_params: &mut impl Iterator<Item = &'a GenericParamDef>,
+    names: &Names<'a>,
+    output: &mut Vec<Cow<'static, str>>,
+    emit: bool,
+) {
+    match term {
+        Term::Type(type_) => {
+            collect_type_impl_trait_names(type_, synthetic_params, names, output, emit);
+        }
+        Term::Constant(_) => {}
+    }
+}
+
+fn collect_function_signature_impl_trait_names<'a>(
+    signature: &'a FunctionSignature,
+    synthetic_params: &mut impl Iterator<Item = &'a GenericParamDef>,
+    names: &Names<'a>,
+    output: &mut Vec<Cow<'static, str>>,
+    emit: bool,
+) {
+    for (_, type_) in &signature.inputs {
+        collect_type_impl_trait_names(type_, synthetic_params, names, output, emit);
+    }
+    if let Some(return_type) = &signature.output {
+        collect_type_impl_trait_names(return_type, synthetic_params, names, output, emit);
+    }
+}
+
+fn next_synthetic_impl_trait_name<'a>(
+    synthetic_params: &mut impl Iterator<Item = &'a GenericParamDef>,
+    names: &Names<'a>,
+) -> Cow<'static, str> {
+    let param = synthetic_params
+        .next()
+        .expect("parameter-position impl Trait had no matching synthetic generic parameter");
+    names.type_name(&param.name)
+}

--- a/src/adapter/normalize/mod.rs
+++ b/src/adapter/normalize/mod.rs
@@ -1,0 +1,34 @@
+//! Normalized signature rendering works from rustdoc's structured data, not
+//! from Rust source text or already-rendered type strings. That keeps item IDs,
+//! generic scopes, and path resolution available while formatting.
+//!
+//! The adapter layer decides which item component is being normalized and passes
+//! the containing-item context here explicitly. Normalization is lazy:
+//! we render the requested component after the query has traversed to a
+//! normalized-signature vertex; we do not perform any kind of eager normalization.
+
+mod context;
+mod names;
+mod paths;
+mod types;
+
+use crate::PackageIndex;
+
+use super::vertex::{FunctionContext, TypeSignatureComponent};
+
+/// Produce a normalized type signature for a function param or return type.
+pub(super) fn fn_param_or_return_type_signature<'a>(
+    crate_: &'a PackageIndex<'a>,
+    function: FunctionContext<'a>,
+    component: TypeSignatureComponent,
+    type_: Option<&'a rustdoc_types::Type>,
+) -> String {
+    let context = context::FnNormalizationContext::new(crate_, function);
+    match (component, type_) {
+        (TypeSignatureComponent::FunctionParameter(position), Some(type_)) => {
+            types::format_parameter_type(&context, position, type_)
+        }
+        (TypeSignatureComponent::ReturnValue, Some(type_)) => types::format_type(&context, type_),
+        (_, None) => "()".to_string(), // empty fn return values hit this branch
+    }
+}

--- a/src/adapter/normalize/names.rs
+++ b/src/adapter/normalize/names.rs
@@ -1,0 +1,246 @@
+use std::{borrow::Cow, collections::BTreeMap};
+
+use rustdoc_types::{GenericParamDef, GenericParamDefKind};
+
+// Avoid allocations for common amounts of generics: 8 of each kind.
+const LIFETIME_NAMES: [&str; 8] = ["'a", "'b", "'c", "'d", "'e", "'f", "'g", "'h"];
+const TYPE_NAMES: [&str; 8] = ["T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8"];
+const IMPL_TRAIT_TYPE_NAMES: [&str; 8] = ["IT1", "IT2", "IT3", "IT4", "IT5", "IT6", "IT7", "IT8"];
+const CONST_NAMES: [&str; 8] = ["C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8"];
+
+/// Canonical names for generics visible in the current normalized signature.
+///
+/// Keys borrow generic parameter names from rustdoc data. Map values are
+/// generated canonical spellings such as `T1`, `IT2`, `C1`, and `'a`; lookup
+/// methods can also return borrowed special names such as `Self` and `'static`.
+///
+/// A missing lookup for a named generic is a bug in scope construction, not a
+/// cue to preserve the source spelling. Arbitrary const expressions are the
+/// exception: rustdoc gives them as strings, and many are not bare const
+/// parameter names.
+#[derive(Clone, Debug, Default)]
+pub(super) struct Names<'a> {
+    lifetimes: BTreeMap<&'a str, Cow<'static, str>>,
+    types: BTreeMap<&'a str, Cow<'static, str>>,
+    consts: BTreeMap<&'a str, Cow<'static, str>>,
+}
+
+impl<'a> Names<'a> {
+    pub(super) fn add_params(&mut self, params: &'a [GenericParamDef]) {
+        for param in params {
+            match param.kind {
+                GenericParamDefKind::Lifetime { .. } => {
+                    let index = self.lifetimes.len();
+                    let normalized = LIFETIME_NAMES
+                        .get(index)
+                        .copied()
+                        .map(Cow::Borrowed)
+                        .unwrap_or_else(|| Cow::Owned(format!("'{}", letter_name(index))));
+                    assert!(
+                        self.lifetimes
+                            .insert(lifetime_key(&param.name), normalized)
+                            .is_none(),
+                        "duplicate lifetime parameter `{}`",
+                        param.name,
+                    );
+                }
+                GenericParamDefKind::Type { is_synthetic, .. } => {
+                    // Non-synthetic type parameters and parameter-position
+                    // `impl Trait` share one normalized type-parameter counter.
+                    let index = self.types.len();
+                    let number = index + 1;
+                    let predefined_names = if is_synthetic {
+                        &IMPL_TRAIT_TYPE_NAMES
+                    } else {
+                        &TYPE_NAMES
+                    };
+                    let prefix = if is_synthetic { "IT" } else { "T" };
+                    let normalized = predefined_names
+                        .get(index)
+                        .copied()
+                        .map(Cow::Borrowed)
+                        .unwrap_or_else(|| Cow::Owned(format!("{prefix}{number}")));
+                    assert!(
+                        self.types.insert(param.name.as_str(), normalized).is_none(),
+                        "duplicate type parameter `{}`",
+                        param.name,
+                    );
+                }
+                GenericParamDefKind::Const { .. } => {
+                    let index = self.consts.len();
+                    let number = index + 1;
+                    let normalized = CONST_NAMES
+                        .get(index)
+                        .copied()
+                        .map(Cow::Borrowed)
+                        .unwrap_or_else(|| Cow::Owned(format!("C{number}")));
+                    assert!(
+                        self.consts
+                            .insert(param.name.as_str(), normalized)
+                            .is_none(),
+                        "duplicate const parameter `{}`",
+                        param.name,
+                    );
+                }
+            }
+        }
+    }
+
+    pub(super) fn lifetime(&self, name: &str) -> Cow<'static, str> {
+        let key = lifetime_key(name);
+        match key {
+            "static" => Cow::Borrowed("'static"),
+            "_" => Cow::Borrowed("'_"),
+            _ => self
+                .lifetimes
+                .get(key)
+                .cloned()
+                .unwrap_or_else(|| unreachable!("unmapped lifetime parameter `{name}`")),
+        }
+    }
+
+    pub(super) fn type_name(&self, name: &str) -> Cow<'static, str> {
+        if name == "Self" {
+            Cow::Borrowed("Self")
+        } else {
+            self.types
+                .get(name)
+                .cloned()
+                .unwrap_or_else(|| unreachable!("unmapped type parameter `{name}`"))
+        }
+    }
+
+    pub(super) fn const_name(&self, name: &str) -> Cow<'static, str> {
+        self.consts
+            .get(name)
+            .cloned()
+            .unwrap_or_else(|| unreachable!("unmapped const parameter `{name}`"))
+    }
+
+    pub(super) fn type_or_const_name(&self, name: &str) -> Cow<'static, str> {
+        self.types
+            .get(name)
+            .or_else(|| self.consts.get(name))
+            .cloned()
+            .unwrap_or_else(|| unreachable!("unmapped type or const parameter `{name}`"))
+    }
+
+    pub(super) fn const_expr<'b>(&self, expr: &'b str) -> Cow<'b, str> {
+        match self.consts.get(expr) {
+            Some(Cow::Borrowed(name)) => Cow::Borrowed(*name),
+            Some(Cow::Owned(name)) => Cow::Owned(name.clone()),
+            None => Cow::Borrowed(expr),
+        }
+    }
+}
+
+fn lifetime_key(name: &str) -> &str {
+    name.strip_prefix('\'').unwrap_or(name)
+}
+
+fn letter_name(mut index: usize) -> String {
+    let mut output = String::new();
+
+    loop {
+        let offset = (index % 26) as u8;
+        output.insert(0, char::from(b'a' + offset));
+        if index < 26 {
+            break;
+        }
+        index = (index / 26) - 1;
+    }
+
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use rustdoc_types::{GenericParamDef, GenericParamDefKind, Type};
+
+    use super::Names;
+
+    #[test]
+    fn type_param_names_use_one_counter_with_static_prefix() {
+        let params = (0..9)
+            .flat_map(|index| {
+                [
+                    type_param(format!("T{index}"), false),
+                    type_param(format!("impl Trait {index}"), true),
+                ]
+            })
+            .collect::<Vec<_>>();
+        let mut names = Names::default();
+        names.add_params(&params);
+
+        assert!(matches!(names.type_name("T0"), Cow::Borrowed("T1")));
+        assert!(matches!(
+            names.type_name("impl Trait 0"),
+            Cow::Borrowed("IT2")
+        ));
+        assert!(matches!(names.type_name("T3"), Cow::Borrowed("T7")));
+        assert!(matches!(
+            names.type_name("impl Trait 3"),
+            Cow::Borrowed("IT8")
+        ));
+        assert!(matches!(names.type_name("T4"), Cow::Owned(value) if value == "T9"));
+        assert!(matches!(
+            names.type_name("impl Trait 4"),
+            Cow::Owned(value) if value == "IT10"
+        ));
+    }
+
+    #[test]
+    fn lifetime_and_const_names_use_static_prefix() {
+        let params = (0..9)
+            .map(|index| lifetime_param(format!("'lt{index}")))
+            .chain((0..9).map(|index| const_param(format!("N{index}"))))
+            .collect::<Vec<_>>();
+        let mut names = Names::default();
+        names.add_params(&params);
+
+        assert!(matches!(names.lifetime("'lt0"), Cow::Borrowed("'a")));
+        assert!(matches!(names.lifetime("'lt7"), Cow::Borrowed("'h")));
+        assert!(matches!(names.lifetime("'lt8"), Cow::Owned(value) if value == "'i"));
+        assert!(matches!(names.const_name("N0"), Cow::Borrowed("C1")));
+        assert!(matches!(names.const_name("N7"), Cow::Borrowed("C8")));
+        assert!(matches!(names.const_name("N8"), Cow::Owned(value) if value == "C9"));
+        assert!(matches!(names.const_expr("N0"), Cow::Borrowed("C1")));
+        assert!(matches!(names.const_expr("N8"), Cow::Owned(value) if value == "C9"));
+
+        let expression = String::from("N0 + 1");
+        assert!(matches!(
+            names.const_expr(&expression),
+            Cow::Borrowed(value) if value == expression
+        ));
+    }
+
+    fn lifetime_param(name: String) -> GenericParamDef {
+        GenericParamDef {
+            name,
+            kind: GenericParamDefKind::Lifetime { outlives: vec![] },
+        }
+    }
+
+    fn type_param(name: String, is_synthetic: bool) -> GenericParamDef {
+        GenericParamDef {
+            name,
+            kind: GenericParamDefKind::Type {
+                bounds: vec![],
+                default: None,
+                is_synthetic,
+            },
+        }
+    }
+
+    fn const_param(name: String) -> GenericParamDef {
+        GenericParamDef {
+            name,
+            kind: GenericParamDefKind::Const {
+                type_: Type::Primitive("usize".into()),
+                default: None,
+            },
+        }
+    }
+}

--- a/src/adapter/normalize/paths.rs
+++ b/src/adapter/normalize/paths.rs
@@ -1,0 +1,44 @@
+use super::context::FnNormalizationContext;
+
+/// Return a normalized representation of the given rustdoc path.
+///
+/// For items in the current crate, use a publicly importable path when one is
+/// available so reexports normalize to the spelling downstream users can name.
+/// For other resolved items, fall back to rustdoc's path summary. The raw path
+/// fallback is only for rustdoc data that did not resolve to either source.
+pub(super) fn normalized_path(
+    context: &FnNormalizationContext<'_>,
+    path: &rustdoc_types::Path,
+) -> String {
+    let crate_ = context.crate_();
+    if crate_.own_crate.inner.index.contains_key(&path.id) {
+        let importable_paths = crate_
+            .own_crate
+            .visibility_tracker
+            .collect_publicly_importable_names(path.id.0);
+        if let Some(importable_path) = importable_paths.first() {
+            return absolute_path(importable_path.path.components.iter().copied());
+        }
+    }
+
+    if let Some(summary) = crate_.own_crate.inner.paths.get(&path.id) {
+        return absolute_path(summary.path.iter().map(String::as_str));
+    }
+
+    assert_ne!(path.path, "");
+    if path.path.starts_with("::") {
+        path.path.clone()
+    } else {
+        format!("::{}", path.path)
+    }
+}
+
+fn absolute_path<'a>(components: impl ExactSizeIterator<Item = &'a str>) -> String {
+    let length = components.len();
+    let mut output = String::with_capacity(10 * length);
+    for component in components {
+        output.push_str("::");
+        output.push_str(component);
+    }
+    output
+}

--- a/src/adapter/normalize/types.rs
+++ b/src/adapter/normalize/types.rs
@@ -1,0 +1,681 @@
+use std::num::NonZeroUsize;
+
+use rustdoc_types::{
+    Abi, AssocItemConstraint, AssocItemConstraintKind, FunctionHeader, GenericArg, GenericBound,
+    GenericParamDef, GenericParamDefKind, Term, TraitBoundModifier, Type,
+};
+
+use super::{
+    context::{FnNormalizationContext, ParameterImplTraitNames},
+    paths,
+};
+
+/// Output a normalized parameter type.
+///
+/// In parameters, `impl Trait` is normalized to a synthetic generic type, not an opaque type.
+pub(super) fn format_parameter_type<'a>(
+    context: &FnNormalizationContext<'a>,
+    position: NonZeroUsize,
+    type_: &'a Type,
+) -> String {
+    let mut parameter_impl_trait_names = Some(context.parameter_impl_trait_names(position));
+    let mut output = String::new();
+    format_type_inner(
+        context,
+        type_,
+        false,
+        &mut parameter_impl_trait_names,
+        &mut output,
+    );
+    parameter_impl_trait_names
+        .as_ref()
+        .expect("parameter impl Trait cursor disappeared")
+        .assert_finished();
+    output
+}
+
+/// Output a normalized type for positions other than parameter position.
+///
+/// In non-parameters, `impl Trait` is normalized to an opaque type, not a synthetic generic type.
+pub(super) fn format_type<'a>(context: &FnNormalizationContext<'a>, type_: &'a Type) -> String {
+    let mut parameter_impl_trait_names = None;
+    let mut output = String::new();
+    format_type_inner(
+        context,
+        type_,
+        false,
+        &mut parameter_impl_trait_names,
+        &mut output,
+    );
+    output
+}
+
+fn format_type_inner<'a>(
+    context: &FnNormalizationContext<'a>,
+    type_: &'a Type,
+    wrap_before_bounds: bool,
+    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
+    output: &mut String,
+) {
+    match type_ {
+        Type::ResolvedPath(path) => {
+            format_path(context, path, false, parameter_impl_trait_names, output);
+        }
+        Type::DynTrait(dyn_trait) => {
+            if wrap_before_bounds {
+                output.push('(');
+            }
+            output.push_str("dyn ");
+
+            let mut traits = dyn_trait
+                .traits
+                .iter()
+                .map(|poly_trait| {
+                    let mut formatted = String::new();
+                    format_poly_trait(
+                        context,
+                        poly_trait,
+                        dyn_trait.traits.len() + usize::from(dyn_trait.lifetime.is_some()) > 1,
+                        parameter_impl_trait_names,
+                        &mut formatted,
+                    );
+                    formatted
+                })
+                .collect::<Vec<_>>();
+            traits.sort_unstable();
+
+            let mut traits_iter = traits.iter();
+            if let Some(trait_) = traits_iter.next() {
+                output.push_str(trait_);
+            }
+            for trait_ in traits_iter {
+                output.push_str(" + ");
+                output.push_str(trait_);
+            }
+            if let Some(lifetime) = &dyn_trait.lifetime {
+                assert!(
+                    !traits.is_empty(),
+                    "trait object lifetime bound cannot appear without a trait bound",
+                );
+                output.push_str(" + ");
+                let lifetime = context.names().lifetime(lifetime);
+                output.push_str(lifetime.as_ref());
+            }
+            if wrap_before_bounds {
+                output.push(')');
+            }
+        }
+        Type::Generic(name) => {
+            let name = context.names().type_name(name);
+            output.push_str(name.as_ref());
+        }
+        Type::Primitive(name) => output.push_str(name),
+        Type::FunctionPointer(pointer) => {
+            // Function-pointer ABI and safety are part of the type being
+            // normalized, unlike ABI and safety on the containing function.
+            let pointer_context = context.with_params(&pointer.generic_params);
+            format_scoped_generic_params(
+                &pointer_context,
+                &pointer.generic_params,
+                parameter_impl_trait_names,
+                output,
+            );
+            format_function_header(&pointer.header, output);
+            output.push_str("fn");
+            format_function_signature(
+                &pointer_context,
+                &pointer.sig,
+                wrap_before_bounds,
+                parameter_impl_trait_names,
+                output,
+            );
+        }
+        Type::Tuple(types) => format_tuple(context, types, parameter_impl_trait_names, output),
+        Type::Slice(type_) => {
+            output.push('[');
+            format_type_inner(context, type_, false, parameter_impl_trait_names, output);
+            output.push(']');
+        }
+        Type::Array { type_, len } => {
+            output.push('[');
+            format_type_inner(context, type_, false, parameter_impl_trait_names, output);
+            output.push_str("; ");
+            let len = context.names().const_expr(len);
+            output.push_str(len.as_ref());
+            output.push(']');
+        }
+        Type::Pat { .. } => unimplemented!("Type::Pat is unstable"),
+        Type::ImplTrait(bounds) => {
+            if let Some(names) = parameter_impl_trait_names.as_mut() {
+                // We're in parameter mode, output a synthetic generic.
+                output.push_str(names.next());
+            } else {
+                // We're in non-parameter mode, output an opaque (`impl Trait`).
+                if wrap_before_bounds {
+                    output.push('(');
+                }
+                output.push_str("impl ");
+                format_bounds(context, bounds, parameter_impl_trait_names, output);
+                if wrap_before_bounds {
+                    output.push(')');
+                }
+            }
+        }
+        Type::Infer => output.push('_'),
+        Type::RawPointer { is_mutable, type_ } => {
+            output.push('*');
+            if *is_mutable {
+                output.push_str("mut");
+            } else {
+                output.push_str("const");
+            }
+            output.push(' ');
+            format_type_inner(
+                context,
+                type_,
+                wrap_before_bounds || needs_parens_before_bounds(type_),
+                parameter_impl_trait_names,
+                output,
+            );
+        }
+        Type::BorrowedRef {
+            lifetime,
+            is_mutable,
+            type_,
+        } => {
+            output.push('&');
+            if let Some(lifetime) = lifetime {
+                let normalized_lifetime = context.names().lifetime(lifetime);
+                output.push_str(normalized_lifetime.as_ref());
+                output.push(' ');
+            }
+            if *is_mutable {
+                output.push_str("mut ");
+            }
+            format_type_inner(
+                context,
+                type_,
+                wrap_before_bounds || needs_parens_before_bounds(type_),
+                parameter_impl_trait_names,
+                output,
+            );
+        }
+        Type::QualifiedPath {
+            name,
+            args,
+            self_type,
+            trait_,
+        } => {
+            if let Some(trait_) = trait_ {
+                if trait_.path.is_empty() {
+                    format_type_inner(
+                        context,
+                        self_type,
+                        false,
+                        parameter_impl_trait_names,
+                        output,
+                    );
+                } else {
+                    output.push('<');
+                    format_type_inner(
+                        context,
+                        self_type,
+                        false,
+                        parameter_impl_trait_names,
+                        output,
+                    );
+                    output.push_str(" as ");
+                    format_path(context, trait_, false, parameter_impl_trait_names, output);
+                    output.push('>');
+                }
+            } else {
+                format_type_inner(
+                    context,
+                    self_type,
+                    false,
+                    parameter_impl_trait_names,
+                    output,
+                );
+            }
+
+            output.push_str("::");
+            output.push_str(name);
+            if let Some(args) = args.as_deref() {
+                format_generic_args(context, args, false, parameter_impl_trait_names, output);
+            }
+        }
+    }
+}
+
+fn format_tuple<'a>(
+    context: &FnNormalizationContext<'a>,
+    types: &'a [Type],
+    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
+    output: &mut String,
+) {
+    match types {
+        [] => output.push_str("()"),
+        [type_] => {
+            output.push('(');
+            format_type_inner(context, type_, false, parameter_impl_trait_names, output);
+            output.push_str(",)");
+        }
+        _ => {
+            output.push('(');
+            for (index, type_) in types.iter().enumerate() {
+                if index != 0 {
+                    output.push_str(", ");
+                }
+                format_type_inner(context, type_, false, parameter_impl_trait_names, output);
+            }
+            output.push(')');
+        }
+    }
+}
+
+fn format_poly_trait<'a>(
+    context: &FnNormalizationContext<'a>,
+    poly_trait: &'a rustdoc_types::PolyTrait,
+    wrap_before_bounds: bool,
+    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
+    output: &mut String,
+) {
+    let context = context.with_params(&poly_trait.generic_params);
+    format_scoped_generic_params(
+        &context,
+        &poly_trait.generic_params,
+        parameter_impl_trait_names,
+        output,
+    );
+    format_path(
+        &context,
+        &poly_trait.trait_,
+        wrap_before_bounds,
+        parameter_impl_trait_names,
+        output,
+    );
+}
+
+fn format_path<'a>(
+    context: &FnNormalizationContext<'a>,
+    path: &'a rustdoc_types::Path,
+    wrap_args_before_bounds: bool,
+    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
+    output: &mut String,
+) {
+    output.push_str(&paths::normalized_path(context, path));
+    if let Some(args) = path.args.as_deref() {
+        format_generic_args(
+            context,
+            args,
+            wrap_args_before_bounds,
+            parameter_impl_trait_names,
+            output,
+        );
+    }
+}
+
+fn format_generic_args<'a>(
+    context: &FnNormalizationContext<'a>,
+    args: &'a rustdoc_types::GenericArgs,
+    wrap_output_before_bounds: bool,
+    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
+    output: &mut String,
+) {
+    match args {
+        rustdoc_types::GenericArgs::AngleBracketed { args, constraints } => {
+            if args.is_empty() && constraints.is_empty() {
+                return;
+            }
+
+            output.push('<');
+            let mut needs_separator = false;
+            for arg in args {
+                if needs_separator {
+                    output.push_str(", ");
+                }
+                format_generic_arg(context, arg, parameter_impl_trait_names, output);
+                needs_separator = true;
+            }
+
+            let mut constraints = constraints
+                .iter()
+                .map(|constraint| {
+                    let mut formatted = String::new();
+                    format_assoc_item_constraint(
+                        context,
+                        constraint,
+                        parameter_impl_trait_names,
+                        &mut formatted,
+                    );
+                    formatted
+                })
+                .collect::<Vec<_>>();
+            constraints.sort_unstable();
+            if !constraints.is_empty() {
+                if needs_separator {
+                    output.push_str(", ");
+                }
+                let mut constraints_iter = constraints.iter();
+                if let Some(constraint) = constraints_iter.next() {
+                    output.push_str(constraint);
+                }
+                for constraint in constraints_iter {
+                    output.push_str(", ");
+                    output.push_str(constraint);
+                }
+            }
+            output.push('>');
+        }
+        rustdoc_types::GenericArgs::Parenthesized {
+            inputs,
+            output: return_type,
+        } => {
+            output.push('(');
+            for (index, type_) in inputs.iter().enumerate() {
+                if index != 0 {
+                    output.push_str(", ");
+                }
+                format_type_inner(context, type_, false, parameter_impl_trait_names, output);
+            }
+            output.push(')');
+
+            if let Some(return_type) = return_type {
+                output.push_str(" -> ");
+                format_type_inner(
+                    context,
+                    return_type,
+                    wrap_output_before_bounds,
+                    parameter_impl_trait_names,
+                    output,
+                );
+            }
+        }
+        rustdoc_types::GenericArgs::ReturnTypeNotation => output.push_str("(..)"),
+    }
+}
+
+fn format_generic_arg<'a>(
+    context: &FnNormalizationContext<'a>,
+    arg: &'a GenericArg,
+    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
+    output: &mut String,
+) {
+    match arg {
+        GenericArg::Lifetime(lifetime) => {
+            let lifetime = context.names().lifetime(lifetime);
+            output.push_str(lifetime.as_ref());
+        }
+        GenericArg::Type(type_) => {
+            format_type_inner(context, type_, false, parameter_impl_trait_names, output);
+        }
+        GenericArg::Const(constant) => format_constant(context, constant, output),
+        GenericArg::Infer => output.push('_'),
+    }
+}
+
+fn format_assoc_item_constraint<'a>(
+    context: &FnNormalizationContext<'a>,
+    constraint: &'a AssocItemConstraint,
+    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
+    output: &mut String,
+) {
+    output.push_str(&constraint.name);
+    if let Some(args) = constraint.args.as_deref() {
+        format_generic_args(context, args, false, parameter_impl_trait_names, output);
+    }
+
+    match &constraint.binding {
+        AssocItemConstraintKind::Constraint(bounds) => {
+            output.push_str(": ");
+            format_bounds(context, bounds, parameter_impl_trait_names, output);
+        }
+        AssocItemConstraintKind::Equality(term) => {
+            output.push_str(" = ");
+            format_term(context, term, parameter_impl_trait_names, output);
+        }
+    }
+}
+
+fn format_bounds<'a>(
+    context: &FnNormalizationContext<'a>,
+    bounds: &'a [GenericBound],
+    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
+    output: &mut String,
+) {
+    let mut bounds = bounds
+        .iter()
+        .map(|bound| {
+            let mut formatted = String::new();
+            format_generic_bound(
+                context,
+                bound,
+                bounds.len() > 1,
+                parameter_impl_trait_names,
+                &mut formatted,
+            );
+            formatted
+        })
+        .collect::<Vec<_>>();
+    bounds.sort_unstable();
+    let mut bounds_iter = bounds.iter();
+    if let Some(bound) = bounds_iter.next() {
+        output.push_str(bound);
+    }
+    for bound in bounds_iter {
+        output.push_str(" + ");
+        output.push_str(bound);
+    }
+}
+
+fn format_generic_bound<'a>(
+    context: &FnNormalizationContext<'a>,
+    bound: &'a GenericBound,
+    wrap_before_or_after_bounds: bool,
+    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
+    output: &mut String,
+) {
+    match bound {
+        GenericBound::TraitBound {
+            trait_,
+            generic_params,
+            modifier,
+        } => {
+            let context = context.with_params(generic_params);
+            format_scoped_generic_params(
+                &context,
+                generic_params,
+                parameter_impl_trait_names,
+                output,
+            );
+            match modifier {
+                TraitBoundModifier::None => {}
+                TraitBoundModifier::Maybe => output.push('?'),
+                TraitBoundModifier::MaybeConst => output.push_str("~const "),
+            }
+            format_path(
+                &context,
+                trait_,
+                wrap_before_or_after_bounds,
+                parameter_impl_trait_names,
+                output,
+            );
+        }
+        GenericBound::Outlives(lifetime) => {
+            let lifetime = context.names().lifetime(lifetime);
+            output.push_str(lifetime.as_ref());
+        }
+        GenericBound::Use(args) => {
+            output.push_str("use<");
+            for (index, arg) in args.iter().enumerate() {
+                if index != 0 {
+                    output.push_str(", ");
+                }
+                match arg {
+                    rustdoc_types::PreciseCapturingArg::Lifetime(lifetime) => {
+                        let lifetime = context.names().lifetime(lifetime);
+                        output.push_str(lifetime.as_ref());
+                    }
+                    rustdoc_types::PreciseCapturingArg::Param(param) => {
+                        let param = context.names().type_or_const_name(param);
+                        output.push_str(param.as_ref());
+                    }
+                }
+            }
+            output.push('>');
+        }
+    }
+}
+
+fn format_scoped_generic_params<'a>(
+    context: &FnNormalizationContext<'a>,
+    params: &'a [GenericParamDef],
+    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
+    output: &mut String,
+) {
+    if params.is_empty() {
+        return;
+    }
+
+    output.push_str("for<");
+    for (index, param) in params.iter().enumerate() {
+        if index != 0 {
+            output.push_str(", ");
+        }
+        format_generic_param_def(context, param, parameter_impl_trait_names, output);
+    }
+    output.push_str("> ");
+}
+
+fn format_generic_param_def<'a>(
+    context: &FnNormalizationContext<'a>,
+    param: &'a GenericParamDef,
+    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
+    output: &mut String,
+) {
+    match &param.kind {
+        GenericParamDefKind::Lifetime { .. } => {
+            let lifetime = context.names().lifetime(&param.name);
+            output.push_str(lifetime.as_ref());
+        }
+        GenericParamDefKind::Type { .. } => {
+            let name = context.names().type_name(&param.name);
+            output.push_str(name.as_ref());
+        }
+        GenericParamDefKind::Const { type_, .. } => {
+            output.push_str("const ");
+            let name = context.names().const_name(&param.name);
+            output.push_str(name.as_ref());
+            output.push_str(": ");
+            format_type_inner(context, type_, false, parameter_impl_trait_names, output);
+        }
+    }
+}
+
+fn format_function_signature<'a>(
+    context: &FnNormalizationContext<'a>,
+    signature: &'a rustdoc_types::FunctionSignature,
+    wrap_output_before_bounds: bool,
+    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
+    output: &mut String,
+) {
+    output.push('(');
+    let mut needs_separator = false;
+    for (_, type_) in &signature.inputs {
+        if needs_separator {
+            output.push_str(", ");
+        }
+        format_type_inner(context, type_, false, parameter_impl_trait_names, output);
+        needs_separator = true;
+    }
+    if signature.is_c_variadic {
+        if needs_separator {
+            output.push_str(", ");
+        }
+        output.push_str("...");
+    }
+    output.push(')');
+
+    if let Some(return_type) = &signature.output {
+        output.push_str(" -> ");
+        format_type_inner(
+            context,
+            return_type,
+            wrap_output_before_bounds,
+            parameter_impl_trait_names,
+            output,
+        );
+    }
+}
+
+fn format_function_header(header: &FunctionHeader, output: &mut String) {
+    if header.is_const {
+        output.push_str("const ");
+    }
+    if header.is_async {
+        output.push_str("async ");
+    }
+    if header.is_unsafe {
+        output.push_str("unsafe ");
+    }
+
+    match &header.abi {
+        Abi::Rust => {}
+        Abi::C { unwind } => push_abi(output, "C", *unwind),
+        Abi::Cdecl { unwind } => push_abi(output, "cdecl", *unwind),
+        Abi::Stdcall { unwind } => push_abi(output, "stdcall", *unwind),
+        Abi::Fastcall { unwind } => push_abi(output, "fastcall", *unwind),
+        Abi::Aapcs { unwind } => push_abi(output, "aapcs", *unwind),
+        Abi::Win64 { unwind } => push_abi(output, "win64", *unwind),
+        Abi::SysV64 { unwind } => push_abi(output, "sysv64", *unwind),
+        Abi::System { unwind } => push_abi(output, "system", *unwind),
+        Abi::Other(other) => {
+            output.push_str("extern \"");
+            output.push_str(other);
+            output.push_str("\" ");
+        }
+    }
+}
+
+fn push_abi(output: &mut String, name: &str, unwind: bool) {
+    output.push_str("extern \"");
+    output.push_str(name);
+    if unwind {
+        output.push_str("-unwind");
+    }
+    output.push_str("\" ");
+}
+
+fn format_constant<'a>(
+    context: &FnNormalizationContext<'a>,
+    constant: &'a rustdoc_types::Constant,
+    output: &mut String,
+) {
+    let value = constant.value.as_deref().unwrap_or(&constant.expr);
+    let value = context.names().const_expr(value);
+    output.push_str(value.as_ref());
+}
+
+fn format_term<'a>(
+    context: &FnNormalizationContext<'a>,
+    term: &'a Term,
+    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
+    output: &mut String,
+) {
+    match term {
+        Term::Type(type_) => {
+            format_type_inner(context, type_, false, parameter_impl_trait_names, output);
+        }
+        Term::Constant(constant) => format_constant(context, constant, output),
+    }
+}
+
+fn needs_parens_before_bounds(type_: &Type) -> bool {
+    match type_ {
+        Type::DynTrait(dyn_trait) => {
+            dyn_trait.traits.len() + usize::from(dyn_trait.lifetime.is_some()) > 1
+        }
+        Type::ImplTrait(bounds) => bounds.len() > 1,
+        _ => false,
+    }
+}

--- a/src/adapter/optimizations/impl_lookup.rs
+++ b/src/adapter/optimizations/impl_lookup.rs
@@ -7,7 +7,10 @@ use trustfall::{
     },
 };
 
-use crate::{hashtables::HashMap, indexed_crate::ImplEntry};
+use crate::{
+    hashtables::{HashMap, HashSet},
+    indexed_crate::ImplEntry,
+};
 
 use super::super::{RustdocAdapter, origin::Origin, vertex::Vertex};
 
@@ -111,16 +114,13 @@ fn resolve_impl_based_on_method_name_candidate<'a>(
                 method_name,
             )
         }
-        CandidateValue::Multiple(values) => Box::new(values.into_iter().flat_map(move |value| {
-            let method_name = value.as_str().expect("method name was not a string");
-            resolve_impl_based_on_method_name(
-                origin,
-                impl_index,
-                inherent_impls_only,
-                item_id,
-                method_name,
-            )
-        })),
+        CandidateValue::Multiple(values) => resolve_impls_based_on_any_method_name(
+            origin,
+            impl_index,
+            inherent_impls_only,
+            item_id,
+            values,
+        ),
         _ => {
             // fall through to slow path
             resolve_owner_impl_slow_path(vertex, adapter, inherent_impls_only)
@@ -153,6 +153,54 @@ the `impl_index` returned a value where the `impl_item` was not an impl: {impl_i
     } else {
         Box::new(std::iter::empty())
     }
+}
+
+fn resolve_impls_based_on_any_method_name<'a>(
+    origin: Origin,
+    impl_index: &'a HashMap<ImplEntry<'a>, Vec<(&'a Item, &'a Item)>>,
+    inherent_impls_only: bool,
+    item_id: &'a Id,
+    method_names: Vec<FieldValue>,
+) -> VertexIterator<'a, Vertex<'a>> {
+    let mut produced_impls: HashSet<&Id> = Default::default();
+
+    // This is the `ImplOwner.impl` / `ImplOwner.inherent_impl` edge, not the
+    // nested `method` edge. If we're looking up multiple methods that appear inside
+    // the same `impl` block, we must only produce that `impl` vertex *once*.
+    // We can't produce it once per method name, because given 2 methods we'll get 4 results not 2:
+    // each time the `impl` vertex is produced, it'll in turn produce both method vertices.
+    // Hence the need to deduplicate using `produced_impls`.
+    Box::new(
+        method_names
+            .into_iter()
+            .filter_map(move |method_name| {
+                // Use the `impl_index` to find the matching list
+                // of (impl item, method item) tuples, if any.
+                let method_name = method_name.as_str().expect("method name was not a string");
+                impl_index.get(&(item_id, method_name))
+            })
+            .flatten()
+            .filter_map(move |(impl_item, _)| {
+                if !produced_impls.insert(&impl_item.id) {
+                    // The edge already produced that impl vertex.
+                    // The desired methods would already have been produced there.
+                    return None;
+                }
+
+                let impl_content = match &impl_item.inner {
+                    rustdoc_types::ItemEnum::Impl(impl_) => impl_,
+                    _ => unreachable!(
+                        "the `impl_index` returned a value where the `impl_item` was not an impl: \
+                        {impl_item:?}"
+                    ),
+                };
+                if !inherent_impls_only || impl_content.trait_.is_none() {
+                    Some(origin.make_item_vertex(impl_item))
+                } else {
+                    None
+                }
+            }),
+    )
 }
 
 fn resolve_owner_impl_slow_path<'a>(

--- a/src/adapter/optimizations/method_lookup.rs
+++ b/src/adapter/optimizations/method_lookup.rs
@@ -40,8 +40,9 @@ pub(crate) fn resolve_impl_methods<'a, V: AsVertex<Vertex<'a>> + 'a>(
             let origin = vertex.origin;
             let item_index = &adapter.crate_at_origin(origin).own_crate.inner.index;
 
+            let impl_item = vertex.as_item().expect("not an Impl item");
             let impl_vertex = vertex.as_impl().expect("not an Impl vertex");
-            resolve_methods_slow_path(impl_vertex, origin, item_index)
+            resolve_methods_slow_path(impl_item, impl_vertex, origin, item_index)
         })
     }
 }
@@ -96,41 +97,111 @@ fn resolve_method_from_candidate_value<'a>(
             CandidateValue::Impossible => Box::new(std::iter::empty()),
             CandidateValue::Single(name) => {
                 let method_name = name.as_str().expect("method name was not a string");
-                resolve_impl_method_by_name(origin, impl_index, impl_owner_id, impl_id, method_name)
+                resolve_impl_method_by_name(
+                    origin,
+                    impl_index,
+                    item_index,
+                    impl_owner_id,
+                    impl_id,
+                    method_name,
+                )
             }
             CandidateValue::Multiple(names) => Box::new(names.into_iter().flat_map(move |name| {
                 let method_name = name.as_str().expect("method name was not a string");
-                resolve_impl_method_by_name(origin, impl_index, impl_owner_id, impl_id, method_name)
+                resolve_impl_method_by_name(
+                    origin,
+                    impl_index,
+                    item_index,
+                    impl_owner_id,
+                    impl_id,
+                    method_name,
+                )
             })),
             _ => {
                 // Fall back to the default slow path.
-                resolve_methods_slow_path(impl_vertex, origin, item_index)
+                let impl_item = vertex.as_item().expect("not an Impl item");
+                resolve_methods_slow_path(impl_item, impl_vertex, origin, item_index)
             }
         }
     } else {
         // We couldn't determine the Id of the item that owns this method.
         // Fall back to the default slow path.
-        resolve_methods_slow_path(impl_vertex, origin, item_index)
+        let impl_item = vertex.as_item().expect("not an Impl item");
+        resolve_methods_slow_path(impl_item, impl_vertex, origin, item_index)
     }
 }
 
 fn resolve_impl_method_by_name<'a>(
     origin: Origin,
     impl_index: &'a HashMap<ImplEntry<'a>, Vec<(&'a Item, &'a Item)>>,
+    item_index: &'a HashMap<Id, Item>,
     impl_owner_id: &'a Id,
     impl_id: &'a Id,
     method_name: &str,
 ) -> VertexIterator<'a, Vertex<'a>> {
     if let Some(method_ids) = impl_index.get(&(impl_owner_id, method_name)) {
-        Box::new(method_ids.iter().filter_map(move |(impl_item, item)| {
-            (&impl_item.id == impl_id).then_some(origin.make_item_vertex(item))
-        }))
+        Box::new(
+            method_ids
+                .iter()
+                .filter(move |(impl_item, _)| &impl_item.id == impl_id)
+                .map(move |(impl_item, item)| {
+                    let parent = method_parent_for_impl_method(impl_item, item, item_index);
+                    origin.make_method_vertex(item, parent)
+                }),
+        )
     } else {
         Box::new(std::iter::empty())
     }
 }
 
+fn method_parent_for_impl_method<'a>(
+    impl_item: &'a Item,
+    method_item: &'a Item,
+    item_index: &'a HashMap<Id, Item>,
+) -> &'a Item {
+    let ItemEnum::Impl(impl_) = &impl_item.inner else {
+        unreachable!("method index returned a non-impl parent item: {impl_item:?}");
+    };
+
+    // Return the function declaration parent, not necessarily the `impl` we
+    // traversed from. Explicit impl methods use the `impl` generic scope, while
+    // trait-provided default methods use the trait generic scope because the
+    // rustdoc function item is declared on the trait.
+    if impl_.items.contains(&method_item.id) {
+        return impl_item;
+    }
+
+    let method_name = method_item
+        .name
+        .as_deref()
+        .expect("method item had no name");
+    debug_assert!(
+        impl_
+            .provided_trait_methods
+            .iter()
+            .any(|name| name == method_name),
+        "method item was neither explicitly implemented nor trait-provided: {method_item:?}",
+    );
+
+    let trait_path = impl_
+        .trait_
+        .as_ref()
+        .expect("provided trait method appeared on an inherent impl");
+    let trait_item = item_index
+        .get(&trait_path.id)
+        .expect("provided trait method parent trait was missing from the item index");
+    let ItemEnum::Trait(trait_) = &trait_item.inner else {
+        unreachable!("provided method parent was not a trait: {trait_item:?}");
+    };
+    debug_assert!(
+        trait_.items.contains(&method_item.id),
+        "provided method was not listed on its parent trait: {method_item:?}",
+    );
+    trait_item
+}
+
 fn resolve_methods_slow_path<'a>(
+    impl_item: &'a Item,
     impl_vertex: &'a Impl,
     origin: Origin,
     item_index: &'a HashMap<Id, Item>,
@@ -189,7 +260,9 @@ fn resolve_methods_slow_path<'a>(
                             // in the case where a trait provided a default
                             // but the impl had an override.
                             if produced_methods.insert(item_name) {
-                                Some(origin.make_item_vertex(next_item))
+                                let parent =
+                                    method_parent_for_impl_method(impl_item, next_item, item_index);
+                                Some(origin.make_method_vertex(next_item, parent))
                             } else {
                                 None
                             }

--- a/src/adapter/origin.rs
+++ b/src/adapter/origin.rs
@@ -3,7 +3,6 @@ use std::{borrow::Cow, num::NonZeroUsize, rc::Rc};
 use rustdoc_types::{Abi, Item, Span};
 
 use crate::{
-    adapter::vertex::ReturnValue,
     attributes::{Attribute, AttributeMetaItem},
     indexed_crate::ImportablePath,
 };
@@ -11,7 +10,10 @@ use crate::{
 use super::{
     enum_variant::{EnumVariant, LazyDiscriminants},
     receiver::Receiver,
-    vertex::{ImplementedTrait, Vertex, VertexKind},
+    vertex::{
+        FunctionContext, FunctionParameter, ImplementedTrait, Method, NormalizedTypeSignature,
+        ReturnValue, TypeSignatureComponent, Vertex, VertexKind,
+    },
 };
 
 #[non_exhaustive]
@@ -104,20 +106,62 @@ impl Origin {
         }
     }
 
-    pub(super) fn make_function_parameter_vertex<'a>(&self, name: &'a str) -> Vertex<'a> {
+    pub(super) fn make_method_vertex<'a>(
+        &self,
+        function: &'a Item,
+        parent: &'a Item,
+    ) -> Vertex<'a> {
         Vertex {
             origin: *self,
-            kind: VertexKind::FunctionParameter(name),
+            kind: VertexKind::Method(Method { function, parent }),
+        }
+    }
+
+    pub(super) fn make_function_parameter_vertex<'a>(
+        &self,
+        context: FunctionContext<'a>,
+        position: NonZeroUsize,
+        name: &'a str,
+        type_: &'a rustdoc_types::Type,
+    ) -> Vertex<'a> {
+        Vertex {
+            origin: *self,
+            kind: VertexKind::FunctionParameter(FunctionParameter {
+                context,
+                position,
+                name,
+                type_,
+            }),
         }
     }
 
     pub(super) fn make_return_value_vertex<'a>(
         &self,
+        context: FunctionContext<'a>,
         return_type: Option<&'a rustdoc_types::Type>,
     ) -> Vertex<'a> {
         Vertex {
             origin: *self,
-            kind: VertexKind::ReturnValue(ReturnValue { type_: return_type }),
+            kind: VertexKind::ReturnValue(ReturnValue {
+                context,
+                type_: return_type,
+            }),
+        }
+    }
+
+    pub(super) fn make_normalized_type_signature_vertex<'a>(
+        &self,
+        context: FunctionContext<'a>,
+        component: TypeSignatureComponent,
+        type_: Option<&'a rustdoc_types::Type>, // none if `()` in a function return position
+    ) -> Vertex<'a> {
+        Vertex {
+            origin: *self,
+            kind: VertexKind::NormalizedTypeSignature(NormalizedTypeSignature {
+                context,
+                component,
+                type_,
+            }),
         }
     }
 

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -358,7 +358,16 @@ pub(super) fn resolve_function_parameter_property<'a, V: AsVertex<Vertex<'a>> + 
             vertex
                 .as_function_parameter()
                 .expect("not a function parameter")
+                .name
                 .into()
+        }),
+        "position" => resolve_property_with(contexts, |vertex| {
+            let position = vertex
+                .as_function_parameter()
+                .expect("not a function parameter")
+                .position;
+
+            FieldValue::Uint64(position.get() as u64)
         }),
         _ => unreachable!("FunctionParameter property {property_name}"),
     }
@@ -378,6 +387,31 @@ pub(super) fn resolve_return_value_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
                 .into()
         }),
         _ => unreachable!("ReturnValue property {property_name}"),
+    }
+}
+
+pub(super) fn resolve_normalized_type_signature_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
+    contexts: ContextIterator<'a, V>,
+    property_name: &str,
+    adapter: &'a RustdocAdapter<'a>,
+) -> ContextOutcomeIterator<'a, V, FieldValue> {
+    match property_name {
+        "signature" => resolve_property_with(contexts, move |vertex| {
+            let origin = vertex.origin;
+            let normalized_type_signature = vertex
+                .as_normalized_type_signature()
+                .expect("not a NormalizedTypeSignature");
+            let crate_ = adapter.crate_at_origin(origin);
+
+            super::normalize::fn_param_or_return_type_signature(
+                crate_,
+                normalized_type_signature.context,
+                normalized_type_signature.component,
+                normalized_type_signature.type_,
+            )
+            .into()
+        }),
+        _ => unreachable!("NormalizedTypeSignature property {property_name}"),
     }
 }
 

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -6563,6 +6563,68 @@ fn impl_lookup_by_method_name_optimization() {
 }
 
 #[test]
+fn impl_lookup_by_multiple_method_names_visits_each_impl_once() {
+    get_test_data!(data, method_lookup_optimization);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Struct {
+                owner: name @filter(op: "=", value: ["$owner"]) @output
+
+                inherent_impl {
+                    method {
+                        method: name @filter(op: "one_of", value: ["$methods"]) @output
+                    }
+                }
+            }
+        }
+    }
+}
+    "#;
+
+    let variables = btreemap! {
+        "owner" => FieldValue::String("MultiMethodOwner".into()),
+        "methods" => FieldValue::List(vec![
+            FieldValue::String("first".into()),
+            FieldValue::String("second".into()),
+        ].into()),
+    };
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        owner: String,
+        method: String,
+    }
+
+    let mut results: Vec<_> = trustfall::execute_query(&schema, adapter.clone(), query, variables)
+        .expect("failed to run query")
+        .map(|row| row.try_into_struct().expect("shape mismatch"))
+        .collect();
+    results.sort_unstable();
+
+    let mut expected_results = vec![
+        Output {
+            owner: "MultiMethodOwner".into(),
+            method: "first".into(),
+        },
+        Output {
+            owner: "MultiMethodOwner".into(),
+            method: "second".into(),
+        },
+    ];
+    expected_results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
+#[test]
 fn generic_param_positions() {
     get_test_data!(data, generic_param_positions);
     let adapter = RustdocAdapter::new(&data, None);
@@ -9435,11 +9497,80 @@ fn function_parameters() {
             params: vec![],
         },
         Output {
+            name: "concrete_types".into(),
+            params: vec!["value".into()],
+        },
+        Output {
+            name: "generic_identity".into(),
+            params: vec!["value".into()],
+        },
+        Output {
+            name: "lifetime_ref".into(),
+            params: vec!["value".into()],
+        },
+        Output {
+            name: "const_array".into(),
+            params: vec!["value".into()],
+        },
+        Output {
+            name: "path_types".into(),
+            params: vec!["value".into(), "values".into()],
+        },
+        Output {
+            name: "composite_types".into(),
+            params: vec!["tuple".into(), "raw".into()],
+        },
+        Output {
+            name: "function_pointer".into(),
+            params: vec!["callback".into()],
+        },
+        Output {
+            name: "function_pointer_nested_generics".into(),
+            params: vec!["callback".into()],
+        },
+        Output {
+            name: "dyn_trait_lifetime".into(),
+            params: vec!["value".into()],
+        },
+        Output {
+            name: "impl_trait_param".into(),
+            params: vec!["value".into()],
+        },
+        Output {
+            name: "generic_and_impl_trait_params".into(),
+            params: vec!["generic".into(), "first".into(), "second".into()],
+        },
+        Output {
+            name: "nested_impl_trait_params".into(),
+            params: vec![
+                "generic".into(),
+                "borrowed".into(),
+                "values".into(),
+                "nested_tuple".into(),
+            ],
+        },
+        Output {
+            name: "nested_assoc_impl_trait_param".into(),
+            params: vec!["value".into(), "other".into()],
+        },
+        Output {
+            name: "impl_trait_return".into(),
+            params: vec![],
+        },
+        Output {
             name: "add_method".into(),
             params: vec!["self".into(), "left".into(), "right".into()],
         },
         Output {
             name: "method_returns_nothing".into(),
+            params: vec!["self".into()],
+        },
+        Output {
+            name: "combine".into(),
+            params: vec!["self".into(), "owner".into(), "method".into()],
+        },
+        Output {
+            name: "pin_box_self".into(),
             params: vec!["self".into()],
         },
         Output {
@@ -9449,6 +9580,14 @@ fn function_parameters() {
         Output {
             name: "trait_fn_returns_nothing".into(),
             params: vec!["self".into()],
+        },
+        Output {
+            name: "combine_trait".into(),
+            params: vec!["self".into(), "owner".into(), "method".into()],
+        },
+        Output {
+            name: "default_combine".into(),
+            params: vec!["self".into(), "owner".into(), "method".into()],
         },
     ];
     expected_results.sort_unstable();
@@ -9560,11 +9699,75 @@ fn function_return_value() {
             is_unit: true,
         },
         Output {
+            name: "concrete_types".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "generic_identity".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "lifetime_ref".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "const_array".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "path_types".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "composite_types".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "function_pointer".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "function_pointer_nested_generics".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "dyn_trait_lifetime".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "impl_trait_param".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "generic_and_impl_trait_params".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "nested_impl_trait_params".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "nested_assoc_impl_trait_param".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "impl_trait_return".into(),
+            is_unit: false,
+        },
+        Output {
             name: "add_method".into(),
             is_unit: false,
         },
         Output {
             name: "method_returns_nothing".into(),
+            is_unit: true,
+        },
+        Output {
+            name: "combine".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "pin_box_self".into(),
             is_unit: true,
         },
         Output {
@@ -9574,6 +9777,14 @@ fn function_return_value() {
         Output {
             name: "trait_fn_returns_nothing".into(),
             is_unit: true,
+        },
+        Output {
+            name: "combine_trait".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "default_combine".into(),
+            is_unit: false,
         },
     ];
     expected_results.sort_unstable();
@@ -9603,6 +9814,677 @@ fn function_return_value() {
             .collect();
 
     results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
+#[test]
+fn function_parameter_normalized_type_signatures() {
+    get_test_data!(data, function_params_and_return_value);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Function {
+                name @output
+
+                parameter {
+                    position @output
+                    param_name: name @output
+                    normalized_type_signature {
+                        signature @output
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+    let variables: BTreeMap<&str, bool> = BTreeMap::default();
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        position: u64,
+        param_name: String,
+        signature: String,
+    }
+
+    let mut expected_results = vec![
+        Output {
+            name: "add".into(),
+            position: 1,
+            param_name: "left".into(),
+            signature: "u64".into(),
+        },
+        Output {
+            name: "add".into(),
+            position: 2,
+            param_name: "right".into(),
+            signature: "u64".into(),
+        },
+        Output {
+            name: "concrete_types".into(),
+            position: 1,
+            param_name: "value".into(),
+            signature: "u64".into(),
+        },
+        Output {
+            name: "generic_identity".into(),
+            position: 1,
+            param_name: "value".into(),
+            signature: "T1".into(),
+        },
+        Output {
+            name: "lifetime_ref".into(),
+            position: 1,
+            param_name: "value".into(),
+            signature: "&'a str".into(),
+        },
+        Output {
+            name: "const_array".into(),
+            position: 1,
+            param_name: "value".into(),
+            signature: "[u8; C1]".into(),
+        },
+        Output {
+            name: "path_types".into(),
+            position: 1,
+            param_name: "value".into(),
+            signature: "::function_params_and_return_value::PublicType<u8>".into(),
+        },
+        Output {
+            name: "path_types".into(),
+            position: 2,
+            param_name: "values".into(),
+            signature: "::alloc::vec::Vec<::function_params_and_return_value::PublicType<u8>>"
+                .into(),
+        },
+        Output {
+            name: "composite_types".into(),
+            position: 1,
+            param_name: "tuple".into(),
+            signature: "(&'a [T1], *const T1, fn(T1) -> T1, [u8; C1])".into(),
+        },
+        Output {
+            name: "composite_types".into(),
+            position: 2,
+            param_name: "raw".into(),
+            signature: "*mut T1".into(),
+        },
+        Output {
+            name: "function_pointer".into(),
+            position: 1,
+            param_name: "callback".into(),
+            signature: "for<'a> unsafe fn(&'a u8) -> &'a u8".into(),
+        },
+        Output {
+            name: "function_pointer_nested_generics".into(),
+            position: 1,
+            param_name: "callback".into(),
+            signature: "for<'b> fn(&'a T1, &'b [T1; C1]) -> &'b T1".into(),
+        },
+        Output {
+            name: "dyn_trait_lifetime".into(),
+            position: 1,
+            param_name: "value".into(),
+            signature: "::alloc::boxed::Box<dyn ::core::marker::Send + ::core::marker::Sync + 'a>"
+                .into(),
+        },
+        Output {
+            name: "impl_trait_param".into(),
+            position: 1,
+            param_name: "value".into(),
+            signature: "IT1".into(),
+        },
+        Output {
+            name: "generic_and_impl_trait_params".into(),
+            position: 1,
+            param_name: "generic".into(),
+            signature: "T1".into(),
+        },
+        Output {
+            name: "generic_and_impl_trait_params".into(),
+            position: 2,
+            param_name: "first".into(),
+            signature: "IT2".into(),
+        },
+        Output {
+            name: "generic_and_impl_trait_params".into(),
+            position: 3,
+            param_name: "second".into(),
+            signature: "IT3".into(),
+        },
+        Output {
+            name: "nested_impl_trait_params".into(),
+            position: 1,
+            param_name: "generic".into(),
+            signature: "T1".into(),
+        },
+        Output {
+            name: "nested_impl_trait_params".into(),
+            position: 2,
+            param_name: "borrowed".into(),
+            signature: "&IT2".into(),
+        },
+        Output {
+            name: "nested_impl_trait_params".into(),
+            position: 3,
+            param_name: "values".into(),
+            signature: "::alloc::vec::Vec<IT3>".into(),
+        },
+        Output {
+            name: "nested_impl_trait_params".into(),
+            position: 4,
+            param_name: "nested_tuple".into(),
+            signature: "(IT4, T1)".into(),
+        },
+        Output {
+            name: "nested_assoc_impl_trait_param".into(),
+            position: 1,
+            param_name: "value".into(),
+            signature: "IT2".into(),
+        },
+        Output {
+            name: "nested_assoc_impl_trait_param".into(),
+            position: 2,
+            param_name: "other".into(),
+            signature: "IT3".into(),
+        },
+    ];
+    expected_results.sort_unstable();
+
+    let mut results: Vec<Output> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables)
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
+#[test]
+fn function_return_normalized_type_signatures() {
+    get_test_data!(data, function_params_and_return_value);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Function {
+                name @output
+
+                return_value {
+                    normalized_type_signature {
+                        signature @output
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+    let variables: BTreeMap<&str, bool> = BTreeMap::default();
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        signature: String,
+    }
+
+    let mut expected_results = vec![
+        Output {
+            name: "add".into(),
+            signature: "u64".into(),
+        },
+        Output {
+            name: "fn_returns_nothing".into(),
+            signature: "()".into(),
+        },
+        Output {
+            name: "concrete_types".into(),
+            signature: "bool".into(),
+        },
+        Output {
+            name: "generic_identity".into(),
+            signature: "T1".into(),
+        },
+        Output {
+            name: "lifetime_ref".into(),
+            signature: "&'a str".into(),
+        },
+        Output {
+            name: "const_array".into(),
+            signature: "[u8; C1]".into(),
+        },
+        Output {
+            name: "path_types".into(),
+            signature: "::core::option::Option<::function_params_and_return_value::PublicType<u8>>"
+                .into(),
+        },
+        Output {
+            name: "composite_types".into(),
+            signature: "(&'a [T1], *mut T1)".into(),
+        },
+        Output {
+            name: "function_pointer".into(),
+            signature: "for<'a> unsafe fn(&'a u8) -> &'a u8".into(),
+        },
+        Output {
+            name: "function_pointer_nested_generics".into(),
+            signature: "for<'b> fn(&'a T1, &'b [T1; C1]) -> &'b T1".into(),
+        },
+        Output {
+            name: "dyn_trait_lifetime".into(),
+            signature: "::alloc::boxed::Box<dyn ::core::marker::Send + ::core::marker::Sync + 'a>"
+                .into(),
+        },
+        Output {
+            name: "impl_trait_param".into(),
+            signature: "::alloc::string::String".into(),
+        },
+        Output {
+            name: "generic_and_impl_trait_params".into(),
+            signature: "(T1, ::alloc::string::String)".into(),
+        },
+        Output {
+            name: "nested_impl_trait_params".into(),
+            signature: "T1".into(),
+        },
+        Output {
+            name: "nested_assoc_impl_trait_param".into(),
+            signature: "usize".into(),
+        },
+        Output {
+            name: "impl_trait_return".into(),
+            signature: "impl ::core::iter::traits::iterator::Iterator<Item = u8>".into(),
+        },
+    ];
+    expected_results.sort_unstable();
+
+    let mut results: Vec<Output> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables)
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
+#[test]
+fn method_normalized_type_signatures_include_parent_generics() {
+    get_test_data!(data, function_params_and_return_value);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let inherent_query = r#"
+{
+    Crate {
+        item {
+            ... on Struct {
+                owner: name @filter(op: "=", value: ["$inherent_owner"]) @output
+
+                inherent_impl {
+                    method {
+                        method_name: name @filter(op: "one_of", value: ["$inherent_methods"]) @output
+
+                        parameter {
+                            position @output
+                            param_name: name @output
+                            normalized_type_signature {
+                                param_signature: signature @output
+                            }
+                        }
+
+                        return_value {
+                            normalized_type_signature {
+                                return_signature: signature @output
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+    let trait_query = r#"
+{
+    Crate {
+        item {
+            ... on Trait {
+                owner: name @filter(op: "=", value: ["$trait_owner"]) @output
+
+                method {
+                    method_name: name @filter(op: "=", value: ["$trait_method"]) @output
+
+                    parameter {
+                        position @output
+                        param_name: name @output
+                        normalized_type_signature {
+                            param_signature: signature @output
+                        }
+                    }
+
+                    return_value {
+                        normalized_type_signature {
+                            return_signature: signature @output
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+    let trait_impl_query = r#"
+{
+    Crate {
+        item {
+            ... on Struct {
+                owner: name @filter(op: "=", value: ["$trait_impl_owner"]) @output
+
+                impl {
+                    implemented_trait {
+                        bare_name @filter(op: "=", value: ["$trait_owner"])
+                    }
+
+                    method {
+                        method_name: name @filter(op: "=", value: ["$trait_method"]) @output
+
+                        parameter {
+                            position @output
+                            param_name: name @output
+                            normalized_type_signature {
+                                param_signature: signature @output
+                            }
+                        }
+
+                        return_value {
+                            normalized_type_signature {
+                                return_signature: signature @output
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+    let default_trait_impl_query = r#"
+{
+    Crate {
+        item {
+            ... on Struct {
+                owner: name @filter(op: "=", value: ["$default_trait_impl_owner"]) @output
+
+                impl {
+                    implemented_trait {
+                        bare_name @filter(op: "=", value: ["$default_trait_owner"])
+                    }
+
+                    method {
+                        method_name: name @filter(op: "=", value: ["$default_trait_method"]) @output
+
+                        parameter {
+                            position @output
+                            param_name: name @output
+                            normalized_type_signature {
+                                param_signature: signature @output
+                            }
+                        }
+
+                        return_value {
+                            normalized_type_signature {
+                                return_signature: signature @output
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+    let inherent_variables: BTreeMap<&str, FieldValue> = btreemap! {
+        "inherent_owner" => "GenericExample".into(),
+        "inherent_methods" => vec![FieldValue::String("combine".into()), FieldValue::String("pin_box_self".into())].into(),
+    };
+    let trait_variables = btreemap! {
+        "trait_owner" => "GenericTrait",
+        "trait_method" => "combine_trait",
+    };
+    let trait_impl_variables = btreemap! {
+        "trait_owner" => "GenericTrait",
+        "trait_method" => "combine_trait",
+        "trait_impl_owner" => "ImplementsGenericTrait",
+    };
+    let default_trait_impl_variables = btreemap! {
+        "default_trait_owner" => "DefaultGenericTrait",
+        "default_trait_method" => "default_combine",
+        "default_trait_impl_owner" => "UsesDefaultGenericTrait",
+    };
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        owner: String,
+        method_name: String,
+        position: u64,
+        param_name: String,
+        param_signature: String,
+        return_signature: String,
+    }
+
+    let mut expected_results = vec![
+        Output {
+            owner: "GenericExample".into(),
+            method_name: "combine".into(),
+            position: 1,
+            param_name: "self".into(),
+            param_signature: "&Self".into(),
+            return_signature: "(T1, T2)".into(),
+        },
+        Output {
+            owner: "GenericExample".into(),
+            method_name: "combine".into(),
+            position: 2,
+            param_name: "owner".into(),
+            param_signature: "T1".into(),
+            return_signature: "(T1, T2)".into(),
+        },
+        Output {
+            owner: "GenericExample".into(),
+            method_name: "combine".into(),
+            position: 3,
+            param_name: "method".into(),
+            param_signature: "T2".into(),
+            return_signature: "(T1, T2)".into(),
+        },
+        Output {
+            owner: "GenericExample".into(),
+            method_name: "pin_box_self".into(),
+            position: 1,
+            param_name: "self".into(),
+            param_signature: "::core::pin::Pin<::alloc::boxed::Box<Self>>".into(),
+            return_signature: "()".into(),
+        },
+        Output {
+            owner: "GenericTrait".into(),
+            method_name: "combine_trait".into(),
+            position: 1,
+            param_name: "self".into(),
+            param_signature: "&Self".into(),
+            return_signature: "(T1, T2)".into(),
+        },
+        Output {
+            owner: "GenericTrait".into(),
+            method_name: "combine_trait".into(),
+            position: 2,
+            param_name: "owner".into(),
+            param_signature: "T1".into(),
+            return_signature: "(T1, T2)".into(),
+        },
+        Output {
+            owner: "GenericTrait".into(),
+            method_name: "combine_trait".into(),
+            position: 3,
+            param_name: "method".into(),
+            param_signature: "T2".into(),
+            return_signature: "(T1, T2)".into(),
+        },
+        Output {
+            owner: "ImplementsGenericTrait".into(),
+            method_name: "combine_trait".into(),
+            position: 1,
+            param_name: "self".into(),
+            param_signature: "&Self".into(),
+            return_signature: "(T1, T2)".into(),
+        },
+        Output {
+            owner: "ImplementsGenericTrait".into(),
+            method_name: "combine_trait".into(),
+            position: 2,
+            param_name: "owner".into(),
+            param_signature: "T1".into(),
+            return_signature: "(T1, T2)".into(),
+        },
+        Output {
+            owner: "ImplementsGenericTrait".into(),
+            method_name: "combine_trait".into(),
+            position: 3,
+            param_name: "method".into(),
+            param_signature: "T2".into(),
+            return_signature: "(T1, T2)".into(),
+        },
+        Output {
+            owner: "UsesDefaultGenericTrait".into(),
+            method_name: "default_combine".into(),
+            position: 1,
+            param_name: "self".into(),
+            param_signature: "&mut Self".into(),
+            return_signature: "(T1, T2)".into(),
+        },
+        Output {
+            owner: "UsesDefaultGenericTrait".into(),
+            method_name: "default_combine".into(),
+            position: 2,
+            param_name: "owner".into(),
+            param_signature: "T1".into(),
+            return_signature: "(T1, T2)".into(),
+        },
+        Output {
+            owner: "UsesDefaultGenericTrait".into(),
+            method_name: "default_combine".into(),
+            position: 3,
+            param_name: "method".into(),
+            param_signature: "T2".into(),
+            return_signature: "(T1, T2)".into(),
+        },
+    ];
+    expected_results.sort_unstable();
+
+    let mut results: Vec<Output> =
+        trustfall::execute_query(&schema, adapter.clone(), inherent_query, inherent_variables)
+            .expect("failed to run inherent method query")
+            .chain(
+                trustfall::execute_query(&schema, adapter.clone(), trait_query, trait_variables)
+                    .expect("failed to run trait method query"),
+            )
+            .chain(
+                trustfall::execute_query(
+                    &schema,
+                    adapter.clone(),
+                    trait_impl_query,
+                    trait_impl_variables,
+                )
+                .expect("failed to run trait impl method query"),
+            )
+            .chain(
+                trustfall::execute_query(
+                    &schema,
+                    adapter.clone(),
+                    default_trait_impl_query,
+                    default_trait_impl_variables,
+                )
+                .expect("failed to run default trait impl method query"),
+            )
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+
+    results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
+#[test]
+fn function_parameter_normalized_type_signature_lint_shape() {
+    get_test_data!(data, function_params_and_return_value);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Function {
+                importable_path {
+                    path @filter(op: "=", value: ["$path"])
+                    public_api @filter(op: "=", value: ["$true"])
+                }
+
+                parameter {
+                    position @filter(op: "=", value: ["$position"])
+                    normalized_type_signature {
+                        signature @output
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+    let variables = btreemap! {
+        "path" => FieldValue::List(vec![
+            FieldValue::String("function_params_and_return_value".into()),
+            FieldValue::String("path_types".into()),
+        ].into()),
+        "position" => FieldValue::Uint64(2),
+        "true" => FieldValue::Boolean(true),
+    };
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        signature: String,
+    }
+
+    let expected_results = vec![Output {
+        signature: "::alloc::vec::Vec<::function_params_and_return_value::PublicType<u8>>".into(),
+    }];
+
+    let results: Vec<Output> = trustfall::execute_query(&schema, adapter.clone(), query, variables)
+        .expect("failed to run query")
+        .map(|row| row.try_into_struct().expect("shape mismatch"))
+        .collect();
 
     similar_asserts::assert_eq!(expected_results, results);
 }

--- a/src/adapter/vertex.rs
+++ b/src/adapter/vertex.rs
@@ -33,6 +33,9 @@ pub enum VertexKind<'a> {
     Item(&'a Item),
 
     #[non_exhaustive]
+    Method(Method<'a>),
+
+    #[non_exhaustive]
     Span(&'a Span),
 
     #[non_exhaustive]
@@ -54,7 +57,7 @@ pub enum VertexKind<'a> {
     ImplementedTrait(ImplementedTrait<'a>),
 
     #[non_exhaustive]
-    FunctionParameter(&'a str),
+    FunctionParameter(FunctionParameter<'a>),
 
     #[non_exhaustive]
     FunctionAbi(&'a Abi),
@@ -89,6 +92,9 @@ pub enum VertexKind<'a> {
 
     #[non_exhaustive]
     ReturnValue(ReturnValue<'a>),
+
+    #[non_exhaustive]
+    NormalizedTypeSignature(NormalizedTypeSignature<'a>),
 }
 
 impl Typename for Vertex<'_> {
@@ -130,6 +136,7 @@ impl Typename for Vertex<'_> {
             VertexKind::Attribute(..) => "Attribute",
             VertexKind::AttributeMetaItem(..) => "AttributeMetaItem",
             VertexKind::ImplementedTrait(..) => "ImplementedTrait",
+            VertexKind::Method(..) => "Method",
             VertexKind::RawType(ty) => match ty {
                 rustdoc_types::Type::ResolvedPath { .. } => "ResolvedPathType",
                 _ => "RawType",
@@ -152,6 +159,7 @@ impl Typename for Vertex<'_> {
             },
             VertexKind::Feature(..) => "Feature",
             VertexKind::RequiredTargetFeature(..) => "RequiredTargetFeature",
+            VertexKind::NormalizedTypeSignature(..) => "NormalizedTypeSignature",
         }
     }
 }
@@ -194,6 +202,7 @@ impl<'a> Vertex<'a> {
     pub(super) fn as_item(&self) -> Option<&'a Item> {
         match &self.kind {
             VertexKind::Item(item) => Some(item),
+            VertexKind::Method(method) => Some(method.function),
             VertexKind::Variant(variant) => Some(variant.item()),
             VertexKind::PositionedItem(_, item) => Some(item),
             _ => None,
@@ -284,9 +293,9 @@ impl<'a> Vertex<'a> {
         })
     }
 
-    pub(super) fn as_function_parameter(&self) -> Option<&'a str> {
+    pub(super) fn as_function_parameter(&self) -> Option<&FunctionParameter<'a>> {
         match &self.kind {
-            VertexKind::FunctionParameter(name) => Some(name),
+            VertexKind::FunctionParameter(parameter) => Some(parameter),
             _ => None,
         }
     }
@@ -294,6 +303,13 @@ impl<'a> Vertex<'a> {
     pub(super) fn as_return_value(&self) -> Option<&ReturnValue<'a>> {
         match &self.kind {
             VertexKind::ReturnValue(value) => Some(value),
+            _ => None,
+        }
+    }
+
+    pub(super) fn as_normalized_type_signature(&self) -> Option<&NormalizedTypeSignature<'a>> {
+        match &self.kind {
+            VertexKind::NormalizedTypeSignature(value) => Some(value),
             _ => None,
         }
     }
@@ -490,7 +506,45 @@ impl TargetFeature<'_> {
 }
 
 #[non_exhaustive]
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Method<'a> {
+    pub(crate) function: &'a Item,
+    pub(crate) parent: &'a Item,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct FunctionContext<'a> {
+    pub(crate) function: &'a Item,
+    pub(crate) parent: Option<&'a Item>,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub(crate) struct FunctionParameter<'a> {
+    pub(crate) context: FunctionContext<'a>,
+    pub(crate) position: NonZeroUsize,
+    pub(crate) name: &'a str,
+    pub(crate) type_: &'a rustdoc_types::Type,
+}
+
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct ReturnValue<'a> {
+    pub(crate) context: FunctionContext<'a>,
+    pub(crate) type_: Option<&'a rustdoc_types::Type>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum TypeSignatureComponent {
+    FunctionParameter(NonZeroUsize),
+    ReturnValue,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub(crate) struct NormalizedTypeSignature<'a> {
+    pub(crate) context: FunctionContext<'a>,
+    pub(crate) component: TypeSignatureComponent,
     pub(crate) type_: Option<&'a rustdoc_types::Type>,
 }

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -1556,7 +1556,22 @@ A function parameter.
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.FnDecl.html
 """
 type FunctionParameter {
+  """
+  The 1-based position of this parameter in source order.
+
+  Receiver parameters such as `self` are included in the count when present.
+  """
+  position: Int!
+
+  """
+  The parameter name from the function signature.
+  """
   name: String!
+
+  """
+  Canonical normalized type signature for this parameter.
+  """
+  normalized_type_signature: NormalizedTypeSignature!
 }
 
 """
@@ -2068,6 +2083,52 @@ type ReturnValue {
   ```
   """
   is_unit: Boolean!
+
+  """
+  Canonical normalized type signature for this return value.
+
+  Unit return values are represented as `()`.
+  """
+  normalized_type_signature: NormalizedTypeSignature!
+}
+
+"""
+A normalized signature for a type, such as in a function parameter or return value.
+"""
+type NormalizedTypeSignature {
+  """
+  Canonical normalized string representation of one Rust type.
+
+  The signature is scoped to the item that contains the type.
+  Generic parameter names from that scope are normalized in declaration order:
+  lifetimes become `'a`, `'b`, and so on; non-synthetic type parameters
+  become `T1`, `T2`, and so on; synthetic type parameters from
+  parameter-position `impl Trait` become `IT1`, `IT2`, and so on using that
+  same type-parameter counter; const parameters become `C1`, `C2`, and so on.
+  For example, in
+  `impl<A> Example<A> { fn f<B>(&self, a: A, b: B) }`, parameter `a` has
+  signature `T1` and parameter `b` has signature `T2`.
+
+  Parameter names and patterns are not included. Neither are the containing
+  item's attributes such as ABI, safety, asyncness, constness, generic bounds,
+  and `where` clauses. For example, in
+  `fn f<T: Clone>(value: T) -> T where T: Debug`, the parameter and return
+  value both have signature `T1` since the generic `T` is normalized to `T1`.
+
+  `impl Trait` in parameter position is normalized to the corresponding
+  synthetic type parameter; for example, `impl Into<String>` may become `IT1`
+  or `IT2` depending on where it appears in the type-parameter counter.
+  Return-position `impl Trait` remains an `impl` (opaque) type, such as
+  `impl ::core::iter::traits::iterator::Iterator<Item = u8>`.
+
+  Item paths are canonical absolute paths when available. For example, in a
+  crate named `example_crate`, `PublicType<u8>` becomes
+  `::example_crate::PublicType<u8>`, and `Vec<PublicType<u8>>` becomes
+  `::alloc::vec::Vec<::example_crate::PublicType<u8>>`.
+
+  The unit type is represented as `()`.
+  """
+  signature: String!
 }
 
 """

--- a/test_crates/function_params_and_return_value/src/lib.rs
+++ b/test_crates/function_params_and_return_value/src/lib.rs
@@ -4,6 +4,92 @@ pub fn add(left: u64, right: u64) -> u64 {
 
 pub fn fn_returns_nothing() {}
 
+pub struct PublicType<T>(pub T);
+
+pub fn concrete_types(value: u64) -> bool {
+    value > 0
+}
+
+pub fn generic_identity<T>(value: T) -> T {
+    value
+}
+
+pub fn lifetime_ref<'long>(value: &'long str) -> &'long str {
+    value
+}
+
+pub fn const_array<const N: usize>(value: [u8; N]) -> [u8; N] {
+    value
+}
+
+pub fn path_types(
+    value: PublicType<u8>,
+    values: Vec<PublicType<u8>>,
+) -> Option<PublicType<u8>> {
+    let _ = values;
+    Some(value)
+}
+
+pub fn composite_types<'long, T, const N: usize>(
+    tuple: (&'long [T], *const T, fn(T) -> T, [u8; N]),
+    raw: *mut T,
+) -> (&'long [T], *mut T) {
+    (tuple.0, raw)
+}
+
+pub fn function_pointer(
+    callback: for<'callback> unsafe fn(&'callback u8) -> &'callback u8,
+) -> for<'callback> unsafe fn(&'callback u8) -> &'callback u8 {
+    callback
+}
+
+pub fn function_pointer_nested_generics<'outer, T, const N: usize>(
+    callback: for<'callback> fn(&'outer T, &'callback [T; N]) -> &'callback T,
+) -> for<'callback> fn(&'outer T, &'callback [T; N]) -> &'callback T {
+    callback
+}
+
+pub fn dyn_trait_lifetime<'long>(
+    value: Box<dyn Send + Sync + 'long>,
+) -> Box<dyn Sync + Send + 'long> {
+    value
+}
+
+pub fn impl_trait_param(value: impl Into<String>) -> String {
+    value.into()
+}
+
+pub fn generic_and_impl_trait_params<T>(
+    generic: T,
+    first: impl Into<String>,
+    second: impl Clone,
+) -> (T, String) {
+    let _ = second;
+    (generic, first.into())
+}
+
+pub fn nested_impl_trait_params<T>(
+    generic: T,
+    borrowed: &impl Clone,
+    values: Vec<impl Into<String>>,
+    nested_tuple: (impl Default, T),
+) -> T {
+    let _ = (generic, borrowed, values);
+    nested_tuple.1
+}
+
+pub fn nested_assoc_impl_trait_param(
+    value: impl Iterator<Item = impl Into<String>>,
+    other: impl Clone,
+) -> usize {
+    let _ = other;
+    value.count()
+}
+
+pub fn impl_trait_return() -> impl Iterator<Item = u8> {
+    0u8..=1
+}
+
 pub struct Example;
 
 impl Example {
@@ -19,3 +105,47 @@ pub trait MyTrait {
 
     fn trait_fn_returns_nothing(&self);
 }
+
+pub struct GenericExample<Owner>(pub Owner);
+
+impl<Owner> GenericExample<Owner> {
+    pub fn combine<Method>(&self, owner: Owner, method: Method) -> (Owner, Method) {
+        (owner, method)
+    }
+
+    pub fn pin_box_self(self: std::pin::Pin<Box<Self>>) {}
+}
+
+pub trait GenericTrait<TraitParam> {
+    fn combine_trait<MethodParam>(
+        &self,
+        owner: TraitParam,
+        method: MethodParam,
+    ) -> (TraitParam, MethodParam);
+}
+
+pub struct ImplementsGenericTrait<ImplParam>(pub ImplParam);
+
+impl<ImplParam> GenericTrait<ImplParam> for ImplementsGenericTrait<ImplParam> {
+    fn combine_trait<MethodParam>(
+        &self,
+        owner: ImplParam,
+        method: MethodParam,
+    ) -> (ImplParam, MethodParam) {
+        (owner, method)
+    }
+}
+
+pub trait DefaultGenericTrait<TraitParam> {
+    fn default_combine<MethodParam>(
+        &mut self,
+        owner: TraitParam,
+        method: MethodParam,
+    ) -> (TraitParam, MethodParam) {
+        (owner, method)
+    }
+}
+
+pub struct UsesDefaultGenericTrait<ImplParam>(pub ImplParam);
+
+impl<ImplParam> DefaultGenericTrait<ImplParam> for UsesDefaultGenericTrait<ImplParam> {}

--- a/test_crates/method_lookup_optimization/Cargo.toml
+++ b/test_crates/method_lookup_optimization/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "method_lookup_optimization"
+publish = false
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/test_crates/method_lookup_optimization/src/lib.rs
+++ b/test_crates/method_lookup_optimization/src/lib.rs
@@ -1,0 +1,7 @@
+pub struct MultiMethodOwner;
+
+impl MultiMethodOwner {
+    pub fn first(&self) {}
+
+    pub fn second(&self) {}
+}


### PR DESCRIPTION
Expose normalized representations of the types of function parameter and
return values.

Also fix a bug where lookups based on multiple method names were
producing duplicate values.
