### PR TITLE
Don't return duplicate items when looking up by more than one path. (#1066)

### DIFF
--- a/src/adapter/optimizations/impl_lookup.rs
+++ b/src/adapter/optimizations/impl_lookup.rs
@@ -170,6 +170,7 @@ fn resolve_impls_based_on_any_method_name<'a>(
     // We can't produce it once per method name, because given 2 methods we'll get 4 results not 2:
     // each time the `impl` vertex is produced, it'll in turn produce both method vertices.
     // Hence the need to deduplicate using `produced_impls`.
+    // This is analogous to `resolve_items_by_any_importable_path()` in `item_lookup.rs`.
     Box::new(
         method_names
             .into_iter()

--- a/src/adapter/optimizations/item_lookup.rs
+++ b/src/adapter/optimizations/item_lookup.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use rustdoc_types::Item;
+use rustdoc_types::{Id, Item};
 use trustfall::{
     FieldValue,
     provider::{
@@ -11,7 +11,7 @@ use trustfall::{
 
 use super::super::{RustdocAdapter, origin::Origin, vertex::Vertex};
 
-use crate::IndexedCrate;
+use crate::{IndexedCrate, hashtables::HashSet};
 
 pub(crate) fn resolve_crate_items<'a, V: AsVertex<Vertex<'a>> + 'a>(
     adapter: &'a RustdocAdapter<'a>,
@@ -291,19 +291,47 @@ fn resolve_items_by_importable_path<'a>(
             destination_type.as_deref(),
             &value,
         ),
-        CandidateValue::Multiple(values) => Box::new(values.into_iter().flat_map(move |value| {
-            resolve_items_by_importable_path_field_value(
-                crate_vertex,
-                origin,
-                destination_type.as_deref(),
-                &value,
-            )
-        })),
+        CandidateValue::Multiple(values) => {
+            resolve_items_by_any_importable_path(crate_vertex, origin, destination_type, values)
+        }
         _ => {
             // fall through to slow path
             resolve_items_slow_path(crate_vertex, origin)
         }
     }
+}
+
+fn resolve_items_by_any_importable_path<'a>(
+    crate_vertex: &'a IndexedCrate,
+    origin: Origin,
+    destination_type: Option<Arc<str>>,
+    importable_paths: Vec<FieldValue>,
+) -> VertexIterator<'a, Vertex<'a>> {
+    let mut produced_items: HashSet<&Id> = Default::default();
+
+    // This is the `Crate.item` edge, not the nested `importable_path` edge.
+    // If we're looking up multiple importable paths and they happen to be on the same item,
+    // we must only produce that item's vertex *once*, or else we'll get duplicates.
+    // We need to union the produced item vertices to prevent this.
+    // This is analogous to `resolve_impls_based_on_any_method_name()` in `impl_lookup.rs`.
+    Box::new(
+        importable_paths
+            .into_iter()
+            .flat_map(move |importable_path| {
+                resolve_items_by_importable_path_field_value(
+                    crate_vertex,
+                    origin,
+                    destination_type.as_deref(),
+                    &importable_path,
+                )
+            })
+            .filter(move |vertex| {
+                let item = vertex
+                    .as_item()
+                    .expect("Crate.item optimization produced a non-item vertex");
+                produced_items.insert(&item.id)
+            }),
+    )
 }
 
 /// Resolve public items with importable path `path`, optionally of vertex type `destination_type`.

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -6504,6 +6504,76 @@ fn item_lookup_by_path_optimization() {
 }
 
 #[test]
+fn item_lookup_by_multiple_importable_paths_visits_each_item_once() {
+    get_test_data!(data, item_lookup_optimization);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Struct {
+                name @output
+
+                importable_path {
+                    path @filter(op: "one_of", value: ["$paths"]) @output
+                }
+            }
+        }
+    }
+}
+    "#;
+
+    let variables = btreemap! {
+        "paths" => FieldValue::List(vec![
+            FieldValue::List(vec![
+                FieldValue::String("item_lookup_optimization".into()),
+                FieldValue::String("MultiPathItem".into()),
+            ].into()),
+            FieldValue::List(vec![
+                FieldValue::String("item_lookup_optimization".into()),
+                FieldValue::String("inner".into()),
+                FieldValue::String("MultiPathItem".into()),
+            ].into()),
+        ].into()),
+    };
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        path: Vec<String>,
+    }
+
+    let mut results: Vec<_> = trustfall::execute_query(&schema, adapter.clone(), query, variables)
+        .expect("failed to run query")
+        .map(|row| row.try_into_struct().expect("shape mismatch"))
+        .collect();
+    results.sort_unstable();
+
+    let mut expected_results = vec![
+        Output {
+            name: "MultiPathItem".into(),
+            path: vec!["item_lookup_optimization".into(), "MultiPathItem".into()],
+        },
+        Output {
+            name: "MultiPathItem".into(),
+            path: vec![
+                "item_lookup_optimization".into(),
+                "inner".into(),
+                "MultiPathItem".into(),
+            ],
+        },
+    ];
+    expected_results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
+#[test]
 fn impl_lookup_by_method_name_optimization() {
     // Any test crate that has `impl` blocks without methods would work for this test.
     get_test_data!(data, associated_consts);

--- a/test_crates/item_lookup_optimization/Cargo.toml
+++ b/test_crates/item_lookup_optimization/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "item_lookup_optimization"
+publish = false
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/test_crates/item_lookup_optimization/src/lib.rs
+++ b/test_crates/item_lookup_optimization/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod inner {
+    pub struct MultiPathItem;
+}
+
+pub use inner::MultiPathItem;


### PR DESCRIPTION
Analogous duplication bug as was uncovered and fixed in #1064, just on a
different edge this time.
