### PR TITLE
Normalize `impl Trait` order in associated items of `dyn Trait`.

### DIFF
--- a/src/adapter/normalize/context.rs
+++ b/src/adapter/normalize/context.rs
@@ -321,6 +321,11 @@ fn collect_generic_args_impl_trait_names<'a>(
                     GenericArg::Lifetime(_) | GenericArg::Const(_) | GenericArg::Infer => {}
                 }
             }
+            // The formatter sorts associated-item constraints for canonical output.
+            // Collect nested `impl Trait` names in the same order, otherwise source
+            // order can leak into the synthetic names assigned inside constraints.
+            let mut constraints = constraints.iter().collect::<Vec<_>>();
+            constraints.sort_unstable_by(|a, b| a.name.cmp(&b.name));
             for constraint in constraints {
                 collect_assoc_item_constraint_impl_trait_names(
                     constraint,

--- a/src/adapter/normalize/types.rs
+++ b/src/adapter/normalize/types.rs
@@ -338,31 +338,29 @@ fn format_generic_args<'a>(
                 needs_separator = true;
             }
 
-            let mut constraints = constraints
-                .iter()
-                .map(|constraint| {
-                    let mut formatted = String::new();
-                    format_assoc_item_constraint(
-                        context,
-                        constraint,
-                        parameter_impl_trait_names,
-                        &mut formatted,
-                    );
-                    formatted
-                })
-                .collect::<Vec<_>>();
-            constraints.sort_unstable();
+            let mut constraints = constraints.iter().collect::<Vec<_>>();
+            constraints.sort_unstable_by(|a, b| a.name.cmp(&b.name));
             if !constraints.is_empty() {
                 if needs_separator {
                     output.push_str(", ");
                 }
                 let mut constraints_iter = constraints.iter();
                 if let Some(constraint) = constraints_iter.next() {
-                    output.push_str(constraint);
+                    format_assoc_item_constraint(
+                        context,
+                        constraint,
+                        parameter_impl_trait_names,
+                        output,
+                    );
                 }
                 for constraint in constraints_iter {
                     output.push_str(", ");
-                    output.push_str(constraint);
+                    format_assoc_item_constraint(
+                        context,
+                        constraint,
+                        parameter_impl_trait_names,
+                        output,
+                    );
                 }
             }
             output.push('>');

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -10081,6 +10081,67 @@ fn function_parameter_normalized_type_signatures() {
 }
 
 #[test]
+fn function_parameter_normalized_type_signature_sorts_assoc_constraints_before_impl_trait_names() {
+    get_test_data!(data, assoc_constraint_order);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Function {
+                name @filter(op: "one_of", value: ["$functions"]) @output
+
+                parameter {
+                    normalized_type_signature {
+                        signature @output
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+    let variables = btreemap! {
+        "functions" => FieldValue::List(vec![
+            FieldValue::String("a_then_b".into()),
+            FieldValue::String("b_then_a".into()),
+        ].into()),
+    };
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        signature: String,
+    }
+
+    let mut expected_results = vec![
+        Output {
+            name: "a_then_b".into(),
+            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = IT1, B = IT2>>".into(),
+        },
+        Output {
+            name: "b_then_a".into(),
+            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = IT1, B = IT2>>".into(),
+        },
+    ];
+    expected_results.sort_unstable();
+
+    let mut results: Vec<Output> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables)
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
+#[test]
 fn function_return_normalized_type_signatures() {
     get_test_data!(data, function_params_and_return_value);
     let adapter = RustdocAdapter::new(&data, None);

--- a/test_crates/assoc_constraint_order/Cargo.toml
+++ b/test_crates/assoc_constraint_order/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "assoc_constraint_order"
+publish = false
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/test_crates/assoc_constraint_order/src/lib.rs
+++ b/test_crates/assoc_constraint_order/src/lib.rs
@@ -1,0 +1,12 @@
+pub trait AssocConstraintOrder {
+    type A;
+    type B;
+}
+
+pub fn a_then_b(value: Box<dyn AssocConstraintOrder<A = impl Clone, B = impl Copy>>) {
+    let _ = value;
+}
+
+pub fn b_then_a(value: Box<dyn AssocConstraintOrder<B = impl Copy, A = impl Clone>>) {
+    let _ = value;
+}


### PR DESCRIPTION
Fixes a bug flagged by Codex code review in https://github.com/obi1kenobi/trustfall-rustdoc-adapter/pull/1065#discussion_r3357483740
