### PR TITLE
Normalized paths should prefer public API paths when available. (#1074)

### DIFF
--- a/src/adapter/normalize/paths.rs
+++ b/src/adapter/normalize/paths.rs
@@ -16,7 +16,17 @@ pub(super) fn normalized_path(
             .own_crate
             .visibility_tracker
             .collect_publicly_importable_names(path.id.0);
-        if let Some(importable_path) = importable_paths.first() {
+        // Normalized signatures should use a public API spelling when one exists.
+        // The `importable_path` edge has query-observable order, so choose here
+        // without reordering that edge.
+        let importable_path = importable_paths.iter().min_by_key(|importable_path| {
+            (
+                !importable_path.public_api(),
+                importable_path.modifiers.doc_hidden,
+                importable_path.modifiers.deprecated,
+            )
+        });
+        if let Some(importable_path) = importable_path {
             return absolute_path(importable_path.path.components.iter().copied());
         }
     }

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -2430,6 +2430,27 @@ fn importable_paths() {
             public_api: true,
         },
         Output {
+            name: "HiddenSubmodulePathCanSortFirst".into(),
+            path: vec![
+                "importable_paths".into(),
+                "hidden_glob_path_order_module".into(),
+                "HiddenSubmodulePathCanSortFirst".into(),
+            ],
+            doc_hidden: true,
+            deprecated: false,
+            public_api: false,
+        },
+        Output {
+            name: "HiddenSubmodulePathCanSortFirst".into(),
+            path: vec![
+                "importable_paths".into(),
+                "VisibleHiddenSubmodulePathCanSortFirst".into(),
+            ],
+            doc_hidden: false,
+            deprecated: false,
+            public_api: true,
+        },
+        Output {
             name: "DuplicateGlobHiddenAndVisible".into(),
             path: vec![
                 "importable_paths".into(),
@@ -2545,6 +2566,52 @@ fn importable_paths() {
     expected_results.sort_unstable();
 
     similar_asserts::assert_eq!(expected_results, results);
+}
+
+#[test]
+fn normalized_paths_prefer_public_api_importable_path() {
+    get_test_data!(data, importable_paths);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Function {
+                name @filter(op: "=", value: ["$name"])
+
+                return_value {
+                    normalized_type_signature {
+                        signature @output
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+    let variables = BTreeMap::from([("name", "hidden_glob_path_order_return")]);
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        signature: String,
+    }
+
+    let results: Vec<Output> = trustfall::execute_query(&schema, adapter.clone(), query, variables)
+        .expect("failed to run query")
+        .map(|row| row.try_into_struct().expect("shape mismatch"))
+        .collect();
+
+    similar_asserts::assert_eq!(
+        vec![Output {
+            signature: "::importable_paths::VisibleHiddenSubmodulePathCanSortFirst".into(),
+        }],
+        results,
+    );
 }
 
 #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
@@ -3470,6 +3537,12 @@ fn item_own_public_api_properties() {
         },
         Output {
             name: "BothHiddenAndVisibleSameName".into(),
+            doc_hidden: false,
+            deprecated: false,
+            public_api_eligible: true,
+        },
+        Output {
+            name: "HiddenSubmodulePathCanSortFirst".into(),
             doc_hidden: false,
             deprecated: false,
             public_api_eligible: true,

--- a/test_crates/importable_paths/src/lib.rs
+++ b/test_crates/importable_paths/src/lib.rs
@@ -113,6 +113,24 @@ pub use hidden_glob_source::BothHiddenAndVisible as VisibleBothHiddenAndVisible;
 // as the one from the `doc(hidden)` glob re-export.
 pub use hidden_glob_source::BothHiddenAndVisibleSameName;
 
+mod hidden_glob_path_order_source {
+    pub struct HiddenSubmodulePathCanSortFirst;
+}
+
+pub mod hidden_glob_path_order_module {
+    #[doc(hidden)]
+    pub use super::hidden_glob_path_order_source::*;
+}
+
+// A hidden glob inside a public module can sort before a visible root re-export.
+// Normalized signatures must still choose the visible root path instead of the
+// first path discovered by visibility traversal.
+pub use hidden_glob_path_order_source::HiddenSubmodulePathCanSortFirst as VisibleHiddenSubmodulePathCanSortFirst;
+
+pub fn hidden_glob_path_order_return() -> VisibleHiddenSubmodulePathCanSortFirst {
+    hidden_glob_path_order_source::HiddenSubmodulePathCanSortFirst
+}
+
 mod duplicate_glob_source {
     pub struct DuplicateGlobHiddenAndVisible;
 }


### PR DESCRIPTION
Fixes a bug Codex spotted here:
https://github.com/obi1kenobi/trustfall-rustdoc-adapter/pull/1073#discussion_r3401092762
