### PR TITLE
Normalize associated item order to avoid wrong synthetic bound order.

### DIFF
--- a/src/adapter/normalize/context.rs
+++ b/src/adapter/normalize/context.rs
@@ -1,13 +1,11 @@
-use std::{borrow::Cow, num::NonZeroUsize};
-
-use rustdoc_types::{
-    AssocItemConstraint, AssocItemConstraintKind, FunctionSignature, GenericArg, GenericArgs,
-    GenericBound, GenericParamDef, GenericParamDefKind, ItemEnum, Path, Term, Type,
-};
+use rustdoc_types::{GenericParamDef, ItemEnum};
 
 use crate::{PackageIndex, adapter::vertex::FunctionContext};
 
-use super::names::Names;
+use super::{
+    names::{Names, is_synthetic_type_param},
+    parameter_impl_trait::{self, FnParameterImplTraits, ParameterImplTraitCursor},
+};
 
 /// Per-function state used while rendering one normalized signature.
 ///
@@ -20,67 +18,7 @@ use super::names::Names;
 pub(super) struct FnNormalizationContext<'a> {
     crate_: &'a PackageIndex<'a>,
     names: Names<'a>,
-
-    /// Outer vec: one slot per function parameter, indexed by 0-based parameter.
-    /// Inner vec: the normalized names for the visible parameter-position
-    /// `impl Trait` nodes inside that parameter's type, in the
-    /// same preorder recursive traversal the type formatter walks them.
-    ///
-    /// For example, in `fn f<T>(a: T, b: &impl Clone, c: (impl Default, Vec<impl Into<String>>))`,
-    /// the function-level type counter assigns `T1`, `IT2`, `IT3`, and `IT4`.
-    /// This field then holds `[[], [IT2], [IT3, IT4]]`: parameter `a` has no
-    /// `impl Trait`, parameter `b` has one, and parameter `c` has two.
-    ///
-    /// Bounds inside an `impl Trait` belong to that synthetic type parameter, not
-    /// to the normalized signature of the containing parameter type. In
-    /// `fn g(value: impl Iterator<Item = impl Into<String>>)`, we create
-    /// `IT1` for the nested `impl Into<String>` and `IT2` for the outer
-    /// `impl Iterator<...>`. However, `value`'s type signature is just `IT2`.
-    ///
-    /// Rustdoc represents parameter-position `impl Trait` in two separate places:
-    /// the parameter type tree contains `Type::ImplTrait`, while the function's
-    /// generic parameter list contains the corresponding synthetic type params.
-    /// There is no ID or reference connecting those two representations. The
-    /// shared invariant we can rely on is rustdoc's traversal order, so we
-    /// pre-partition the synthetic names by parameter and give the formatter a
-    /// cursor over the relevant inner vec.
-    ///
-    /// The values are `Cow<'static, str>` because common names such as `IT1`
-    /// through `IT8` are borrowed statics; larger counters fall back to owned
-    /// strings.
-    parameter_impl_trait_names: Vec<Vec<Cow<'static, str>>>,
-}
-
-/// Cursor over the synthetic type-param names for one function parameter.
-///
-/// A parameter may contain multiple `impl Trait` occurrences, such as
-/// `(&impl Clone, Vec<impl Into<String>>)`. During parameter formatting, each
-/// `Type::ImplTrait` consumes the next name from this cursor. Return-position
-/// `impl Trait` formatting does not use this cursor, so it remains an opaque
-/// `impl` type rather than becoming `ITn`.
-pub(super) struct ParameterImplTraitNames<'a> {
-    names: &'a [Cow<'static, str>],
-    next: usize,
-}
-
-impl<'a> ParameterImplTraitNames<'a> {
-    pub(super) fn next(&mut self) -> &str {
-        let name = self.names.get(self.next).unwrap_or_else(|| {
-            unreachable!(
-                "parameter-position impl Trait had no matching synthetic generic parameter"
-            )
-        });
-        self.next += 1;
-        name.as_ref()
-    }
-
-    pub(super) fn assert_finished(&self) {
-        assert_eq!(
-            self.next,
-            self.names.len(),
-            "not all parameter-position impl Trait synthetic generic parameters were used",
-        );
-    }
+    parameter_impl_traits: FnParameterImplTraits,
 }
 
 impl<'a> FnNormalizationContext<'a> {
@@ -92,40 +30,55 @@ impl<'a> FnNormalizationContext<'a> {
         if let Some(item) = fn_ctx.parent {
             match &item.inner {
                 ItemEnum::Trait(trait_) => {
-                    names.add_params(&trait_.generics.params);
+                    for param in &trait_.generics.params {
+                        names.add_param(param);
+                    }
                 }
                 ItemEnum::Impl(impl_) => {
-                    names.add_params(&impl_.generics.params);
+                    for param in &impl_.generics.params {
+                        names.add_param(param);
+                    }
                 }
                 _ => unreachable!("function parent was not a trait or impl: {item:?}"),
             }
         }
 
         let ItemEnum::Function(function_inner) = &fn_ctx.function.inner else {
-            unreachable!("normalized type signatures require a function item");
+            unreachable!(
+                "normalized type signatures require a function item: {:?}",
+                fn_ctx.function.inner,
+            );
         };
-        names.add_params(&function_inner.generics.params);
-        let parameter_impl_trait_names = parameter_impl_trait_names(
-            &function_inner.sig.inputs,
-            &function_inner.generics.params,
-            &names,
-        );
+        for param in &function_inner.generics.params {
+            if is_synthetic_type_param(param) {
+                // Parameter-position `impl Trait` params are named by
+                // `parameter_impl_trait` because their placeholders are scoped to
+                // their containing function parameter, not to the generic
+                // parameter list as a whole.
+                continue;
+            }
+            names.add_param(param);
+        }
+        let parameter_impl_traits =
+            parameter_impl_trait::compute_for_function(crate_, function_inner, &names);
 
         Self {
             crate_,
             names,
-            parameter_impl_trait_names,
+            parameter_impl_traits,
         }
     }
 
-    pub(super) fn with_params(&self, params: &'a [rustdoc_types::GenericParamDef]) -> Self {
+    pub(super) fn with_params(&self, params: &'a [GenericParamDef]) -> Self {
         // HRTB and function-pointer binders add a nested scope. Clone the
         // context so outer generic mappings remain available while nested
         // parameters get fresh canonical names.
         // TODO: If this cloning becomes a bottleneck, we can probably design
         // a hierarchical name structure, since we don't expect deep levels of nesting.
         let mut value = self.clone();
-        value.names.add_params(params);
+        for param in params {
+            value.names.add_param(param);
+        }
         value
     }
 
@@ -137,305 +90,10 @@ impl<'a> FnNormalizationContext<'a> {
         &self.names
     }
 
-    /// Get the synthetic generic names for a parameter's `impl Trait` nodes.
-    ///
-    /// Rustdoc stores each argument-position `impl Trait` occurrence twice: as a
-    /// `Type::ImplTrait` node at its input position, and as a synthetic generic
-    /// parameter in the containing function's generics. Rustdoc does not link
-    /// those two representations directly, so we rely on their shared traversal
-    /// order within function inputs. Return-position `impl Trait` is formatted
-    /// without this cursor and therefore remains an opaque `impl` type.
-    pub(super) fn parameter_impl_trait_names(
+    pub(super) fn impl_trait_cursor_for_parameter(
         &self,
-        position: NonZeroUsize,
-    ) -> ParameterImplTraitNames<'_> {
-        let index = position.get() - 1;
-        let names = self
-            .parameter_impl_trait_names
-            .get(index)
-            .expect("function parameter position was out of bounds");
-        ParameterImplTraitNames { names, next: 0 }
+        position: std::num::NonZeroUsize,
+    ) -> ParameterImplTraitCursor<'_> {
+        self.parameter_impl_traits.cursor_for_parameter(position)
     }
-}
-
-/// Build the per-parameter cursor data from rustdoc's synthetic generics.
-fn parameter_impl_trait_names<'a>(
-    inputs: &'a [(String, Type)],
-    params: &'a [GenericParamDef],
-    names: &Names<'a>,
-) -> Vec<Vec<Cow<'static, str>>> {
-    let mut synthetic_params = params.iter().filter(|param| {
-        matches!(
-            param.kind,
-            GenericParamDefKind::Type {
-                is_synthetic: true,
-                ..
-            }
-        )
-    });
-
-    let mut output = Vec::with_capacity(inputs.len());
-    for (_, type_) in inputs {
-        let mut parameter_names = Vec::new();
-        collect_type_impl_trait_names(
-            type_,
-            &mut synthetic_params,
-            names,
-            &mut parameter_names,
-            true,
-        );
-        output.push(parameter_names);
-    }
-
-    assert!(
-        synthetic_params.next().is_none(),
-        "rustdoc synthetic generic parameters outnumbered parameter-position impl Trait occurrences",
-    );
-    output
-}
-
-fn collect_type_impl_trait_names<'a>(
-    type_: &'a Type,
-    synthetic_params: &mut impl Iterator<Item = &'a GenericParamDef>,
-    names: &Names<'a>,
-    output: &mut Vec<Cow<'static, str>>,
-    emit: bool,
-) {
-    match type_ {
-        Type::ResolvedPath(path) => {
-            collect_path_impl_trait_names(path, synthetic_params, names, output, emit);
-        }
-        Type::DynTrait(dyn_trait) => {
-            for trait_ in &dyn_trait.traits {
-                collect_generic_params_impl_trait_names(
-                    &trait_.generic_params,
-                    synthetic_params,
-                    names,
-                    output,
-                    emit,
-                );
-                collect_path_impl_trait_names(
-                    &trait_.trait_,
-                    synthetic_params,
-                    names,
-                    output,
-                    emit,
-                );
-            }
-        }
-        Type::Generic(_) | Type::Primitive(_) | Type::Infer | Type::Pat { .. } => {}
-        Type::FunctionPointer(pointer) => {
-            collect_generic_params_impl_trait_names(
-                &pointer.generic_params,
-                synthetic_params,
-                names,
-                output,
-                emit,
-            );
-            collect_function_signature_impl_trait_names(
-                &pointer.sig,
-                synthetic_params,
-                names,
-                output,
-                emit,
-            );
-        }
-        Type::Tuple(types) => {
-            for type_ in types {
-                collect_type_impl_trait_names(type_, synthetic_params, names, output, emit);
-            }
-        }
-        Type::Slice(type_) | Type::Array { type_, .. } => {
-            collect_type_impl_trait_names(type_, synthetic_params, names, output, emit);
-        }
-        Type::ImplTrait(bounds) => {
-            collect_bounds_impl_trait_names(bounds, synthetic_params, names, output, false);
-            let name = next_synthetic_impl_trait_name(synthetic_params, names);
-            if emit {
-                output.push(name);
-            }
-        }
-        Type::RawPointer { type_, .. } | Type::BorrowedRef { type_, .. } => {
-            collect_type_impl_trait_names(type_, synthetic_params, names, output, emit);
-        }
-        Type::QualifiedPath {
-            args,
-            self_type,
-            trait_,
-            ..
-        } => {
-            collect_type_impl_trait_names(self_type, synthetic_params, names, output, emit);
-            if let Some(trait_) = trait_ {
-                collect_path_impl_trait_names(trait_, synthetic_params, names, output, emit);
-            }
-            if let Some(args) = args.as_deref() {
-                collect_generic_args_impl_trait_names(args, synthetic_params, names, output, emit);
-            }
-        }
-    }
-}
-
-fn collect_generic_params_impl_trait_names<'a>(
-    params: &'a [GenericParamDef],
-    synthetic_params: &mut impl Iterator<Item = &'a GenericParamDef>,
-    names: &Names<'a>,
-    output: &mut Vec<Cow<'static, str>>,
-    emit: bool,
-) {
-    for param in params {
-        match &param.kind {
-            GenericParamDefKind::Const { type_, .. } => {
-                collect_type_impl_trait_names(type_, synthetic_params, names, output, emit);
-            }
-            GenericParamDefKind::Lifetime { .. } | GenericParamDefKind::Type { .. } => {}
-        }
-    }
-}
-
-fn collect_path_impl_trait_names<'a>(
-    path: &'a Path,
-    synthetic_params: &mut impl Iterator<Item = &'a GenericParamDef>,
-    names: &Names<'a>,
-    output: &mut Vec<Cow<'static, str>>,
-    emit: bool,
-) {
-    if let Some(args) = path.args.as_deref() {
-        collect_generic_args_impl_trait_names(args, synthetic_params, names, output, emit);
-    }
-}
-
-fn collect_generic_args_impl_trait_names<'a>(
-    args: &'a GenericArgs,
-    synthetic_params: &mut impl Iterator<Item = &'a GenericParamDef>,
-    names: &Names<'a>,
-    output: &mut Vec<Cow<'static, str>>,
-    emit: bool,
-) {
-    match args {
-        GenericArgs::AngleBracketed { args, constraints } => {
-            for arg in args {
-                match arg {
-                    GenericArg::Type(type_) => {
-                        collect_type_impl_trait_names(type_, synthetic_params, names, output, emit);
-                    }
-                    GenericArg::Lifetime(_) | GenericArg::Const(_) | GenericArg::Infer => {}
-                }
-            }
-            // The formatter sorts associated-item constraints for canonical output.
-            // Collect nested `impl Trait` names in the same order, otherwise source
-            // order can leak into the synthetic names assigned inside constraints.
-            let mut constraints = constraints.iter().collect::<Vec<_>>();
-            constraints.sort_unstable_by(|a, b| a.name.cmp(&b.name));
-            for constraint in constraints {
-                collect_assoc_item_constraint_impl_trait_names(
-                    constraint,
-                    synthetic_params,
-                    names,
-                    output,
-                    emit,
-                );
-            }
-        }
-        GenericArgs::Parenthesized {
-            inputs,
-            output: return_type,
-        } => {
-            for type_ in inputs {
-                collect_type_impl_trait_names(type_, synthetic_params, names, output, emit);
-            }
-            if let Some(return_type) = return_type {
-                collect_type_impl_trait_names(return_type, synthetic_params, names, output, emit);
-            }
-        }
-        GenericArgs::ReturnTypeNotation => {}
-    }
-}
-
-fn collect_assoc_item_constraint_impl_trait_names<'a>(
-    constraint: &'a AssocItemConstraint,
-    synthetic_params: &mut impl Iterator<Item = &'a GenericParamDef>,
-    names: &Names<'a>,
-    output: &mut Vec<Cow<'static, str>>,
-    emit: bool,
-) {
-    if let Some(args) = constraint.args.as_deref() {
-        collect_generic_args_impl_trait_names(args, synthetic_params, names, output, emit);
-    }
-
-    match &constraint.binding {
-        AssocItemConstraintKind::Constraint(bounds) => {
-            collect_bounds_impl_trait_names(bounds, synthetic_params, names, output, emit);
-        }
-        AssocItemConstraintKind::Equality(term) => {
-            collect_term_impl_trait_names(term, synthetic_params, names, output, emit);
-        }
-    }
-}
-
-fn collect_bounds_impl_trait_names<'a>(
-    bounds: &'a [GenericBound],
-    synthetic_params: &mut impl Iterator<Item = &'a GenericParamDef>,
-    names: &Names<'a>,
-    output: &mut Vec<Cow<'static, str>>,
-    emit: bool,
-) {
-    for bound in bounds {
-        match bound {
-            GenericBound::TraitBound {
-                trait_,
-                generic_params,
-                ..
-            } => {
-                collect_generic_params_impl_trait_names(
-                    generic_params,
-                    synthetic_params,
-                    names,
-                    output,
-                    emit,
-                );
-                collect_path_impl_trait_names(trait_, synthetic_params, names, output, emit);
-            }
-            GenericBound::Outlives(_) | GenericBound::Use(_) => {}
-        }
-    }
-}
-
-fn collect_term_impl_trait_names<'a>(
-    term: &'a Term,
-    synthetic_params: &mut impl Iterator<Item = &'a GenericParamDef>,
-    names: &Names<'a>,
-    output: &mut Vec<Cow<'static, str>>,
-    emit: bool,
-) {
-    match term {
-        Term::Type(type_) => {
-            collect_type_impl_trait_names(type_, synthetic_params, names, output, emit);
-        }
-        Term::Constant(_) => {}
-    }
-}
-
-fn collect_function_signature_impl_trait_names<'a>(
-    signature: &'a FunctionSignature,
-    synthetic_params: &mut impl Iterator<Item = &'a GenericParamDef>,
-    names: &Names<'a>,
-    output: &mut Vec<Cow<'static, str>>,
-    emit: bool,
-) {
-    for (_, type_) in &signature.inputs {
-        collect_type_impl_trait_names(type_, synthetic_params, names, output, emit);
-    }
-    if let Some(return_type) = &signature.output {
-        collect_type_impl_trait_names(return_type, synthetic_params, names, output, emit);
-    }
-}
-
-fn next_synthetic_impl_trait_name<'a>(
-    synthetic_params: &mut impl Iterator<Item = &'a GenericParamDef>,
-    names: &Names<'a>,
-) -> Cow<'static, str> {
-    let param = synthetic_params
-        .next()
-        .expect("parameter-position impl Trait had no matching synthetic generic parameter");
-    names.type_name(&param.name)
 }

--- a/src/adapter/normalize/mod.rs
+++ b/src/adapter/normalize/mod.rs
@@ -9,7 +9,9 @@
 
 mod context;
 mod names;
+mod parameter_impl_trait;
 mod paths;
+mod sort_key;
 mod types;
 
 use crate::PackageIndex;

--- a/src/adapter/normalize/names.rs
+++ b/src/adapter/normalize/names.rs
@@ -5,14 +5,17 @@ use rustdoc_types::{GenericParamDef, GenericParamDefKind};
 // Avoid allocations for common amounts of generics: 8 of each kind.
 const LIFETIME_NAMES: [&str; 8] = ["'a", "'b", "'c", "'d", "'e", "'f", "'g", "'h"];
 const TYPE_NAMES: [&str; 8] = ["T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8"];
-const IMPL_TRAIT_TYPE_NAMES: [&str; 8] = ["IT1", "IT2", "IT3", "IT4", "IT5", "IT6", "IT7", "IT8"];
 const CONST_NAMES: [&str; 8] = ["C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8"];
+const FIRST_IMPL_TRAIT_PLACEHOLDER_BY_PARAMETER: [&str; 8] = [
+    "IT1_1", "IT2_1", "IT3_1", "IT4_1", "IT5_1", "IT6_1", "IT7_1", "IT8_1",
+];
 
 /// Canonical names for generics visible in the current normalized signature.
 ///
-/// Keys borrow generic parameter names from rustdoc data. Map values are
-/// generated canonical spellings such as `T1`, `IT2`, `C1`, and `'a`; lookup
-/// methods can also return borrowed special names such as `Self` and `'static`.
+/// Keys for source-named generics borrow generic parameter names from rustdoc
+/// data. Map values are generated canonical spellings such as `T1`, `C1`, and
+/// `'a`; lookup methods can also return borrowed special names such as `Self`
+/// and `'static`.
 ///
 /// A missing lookup for a named generic is a bug in scope construction, not a
 /// cue to preserve the source spelling. Arbitrary const expressions are the
@@ -26,62 +29,61 @@ pub(super) struct Names<'a> {
 }
 
 impl<'a> Names<'a> {
-    pub(super) fn add_params(&mut self, params: &'a [GenericParamDef]) {
-        for param in params {
-            match param.kind {
-                GenericParamDefKind::Lifetime { .. } => {
-                    let index = self.lifetimes.len();
-                    let normalized = LIFETIME_NAMES
-                        .get(index)
-                        .copied()
-                        .map(Cow::Borrowed)
-                        .unwrap_or_else(|| Cow::Owned(format!("'{}", letter_name(index))));
-                    assert!(
-                        self.lifetimes
-                            .insert(lifetime_key(&param.name), normalized)
-                            .is_none(),
-                        "duplicate lifetime parameter `{}`",
-                        param.name,
-                    );
-                }
-                GenericParamDefKind::Type { is_synthetic, .. } => {
-                    // Non-synthetic type parameters and parameter-position
-                    // `impl Trait` share one normalized type-parameter counter.
-                    let index = self.types.len();
-                    let number = index + 1;
-                    let predefined_names = if is_synthetic {
-                        &IMPL_TRAIT_TYPE_NAMES
-                    } else {
-                        &TYPE_NAMES
-                    };
-                    let prefix = if is_synthetic { "IT" } else { "T" };
-                    let normalized = predefined_names
-                        .get(index)
-                        .copied()
-                        .map(Cow::Borrowed)
-                        .unwrap_or_else(|| Cow::Owned(format!("{prefix}{number}")));
-                    assert!(
-                        self.types.insert(param.name.as_str(), normalized).is_none(),
-                        "duplicate type parameter `{}`",
-                        param.name,
-                    );
-                }
-                GenericParamDefKind::Const { .. } => {
-                    let index = self.consts.len();
-                    let number = index + 1;
-                    let normalized = CONST_NAMES
-                        .get(index)
-                        .copied()
-                        .map(Cow::Borrowed)
-                        .unwrap_or_else(|| Cow::Owned(format!("C{number}")));
-                    assert!(
-                        self.consts
-                            .insert(param.name.as_str(), normalized)
-                            .is_none(),
-                        "duplicate const parameter `{}`",
-                        param.name,
-                    );
-                }
+    /// Adds one source-visible generic parameter to this normalized name scope.
+    ///
+    /// Rustdoc also creates synthetic function-level type params for
+    /// parameter-position `impl Trait`. Those params are intentionally rejected
+    /// here because their placeholders are scoped to the containing function
+    /// parameter and are assigned by `parameter_impl_trait` instead.
+    pub(super) fn add_param(&mut self, param: &'a GenericParamDef) {
+        match param.kind {
+            GenericParamDefKind::Lifetime { .. } => {
+                let index = self.lifetimes.len();
+                let normalized = LIFETIME_NAMES
+                    .get(index)
+                    .copied()
+                    .map(Cow::Borrowed)
+                    .unwrap_or_else(|| Cow::Owned(format!("'{}", letter_name(index))));
+                let existing = self.lifetimes.insert(lifetime_key(&param.name), normalized);
+                assert!(
+                    existing.is_none(),
+                    "duplicate lifetime parameter `{}`",
+                    param.name,
+                );
+            }
+            GenericParamDefKind::Type { is_synthetic, .. } => {
+                assert!(
+                    !is_synthetic,
+                    "parameter-position impl Trait params must be handled by parameter_impl_trait",
+                );
+                let index = self.types.len();
+                let number = index + 1;
+                let normalized = TYPE_NAMES
+                    .get(index)
+                    .copied()
+                    .map(Cow::Borrowed)
+                    .unwrap_or_else(|| Cow::Owned(format!("T{number}")));
+                let existing = self.types.insert(param.name.as_str(), normalized);
+                assert!(
+                    existing.is_none(),
+                    "duplicate type parameter `{}`",
+                    param.name,
+                );
+            }
+            GenericParamDefKind::Const { .. } => {
+                let index = self.consts.len();
+                let number = index + 1;
+                let normalized = CONST_NAMES
+                    .get(index)
+                    .copied()
+                    .map(Cow::Borrowed)
+                    .unwrap_or_else(|| Cow::Owned(format!("C{number}")));
+                let existing = self.consts.insert(param.name.as_str(), normalized);
+                assert!(
+                    existing.is_none(),
+                    "duplicate const parameter `{}`",
+                    param.name,
+                );
             }
         }
     }
@@ -110,13 +112,6 @@ impl<'a> Names<'a> {
         }
     }
 
-    pub(super) fn const_name(&self, name: &str) -> Cow<'static, str> {
-        self.consts
-            .get(name)
-            .cloned()
-            .unwrap_or_else(|| unreachable!("unmapped const parameter `{name}`"))
-    }
-
     pub(super) fn type_or_const_name(&self, name: &str) -> Cow<'static, str> {
         self.types
             .get(name)
@@ -132,6 +127,38 @@ impl<'a> Names<'a> {
             None => Cow::Borrowed(expr),
         }
     }
+}
+
+pub(super) fn parameter_impl_trait_placeholder(
+    parameter_position: usize,
+    occurrence_position: usize,
+) -> Cow<'static, str> {
+    assert!(
+        parameter_position > 0,
+        "function parameter positions are 1-based"
+    );
+    assert!(
+        occurrence_position > 0,
+        "impl Trait positions within a parameter are 1-based"
+    );
+
+    if occurrence_position == 1 {
+        if let Some(name) = FIRST_IMPL_TRAIT_PLACEHOLDER_BY_PARAMETER.get(parameter_position - 1) {
+            return Cow::Borrowed(name);
+        }
+    }
+
+    Cow::Owned(format!("IT{parameter_position}_{occurrence_position}"))
+}
+
+pub(super) fn is_synthetic_type_param(param: &GenericParamDef) -> bool {
+    matches!(
+        param.kind,
+        GenericParamDefKind::Type {
+            is_synthetic: true,
+            ..
+        }
+    )
 }
 
 fn lifetime_key(name: &str) -> &str {
@@ -162,33 +189,18 @@ mod tests {
     use super::Names;
 
     #[test]
-    fn type_param_names_use_one_counter_with_static_prefix() {
+    fn type_param_names_use_static_prefix() {
         let params = (0..9)
-            .flat_map(|index| {
-                [
-                    type_param(format!("T{index}"), false),
-                    type_param(format!("impl Trait {index}"), true),
-                ]
-            })
+            .map(|index| type_param(format!("InputT{index}")))
             .collect::<Vec<_>>();
         let mut names = Names::default();
-        names.add_params(&params);
+        for param in &params {
+            names.add_param(param);
+        }
 
-        assert!(matches!(names.type_name("T0"), Cow::Borrowed("T1")));
-        assert!(matches!(
-            names.type_name("impl Trait 0"),
-            Cow::Borrowed("IT2")
-        ));
-        assert!(matches!(names.type_name("T3"), Cow::Borrowed("T7")));
-        assert!(matches!(
-            names.type_name("impl Trait 3"),
-            Cow::Borrowed("IT8")
-        ));
-        assert!(matches!(names.type_name("T4"), Cow::Owned(value) if value == "T9"));
-        assert!(matches!(
-            names.type_name("impl Trait 4"),
-            Cow::Owned(value) if value == "IT10"
-        ));
+        assert!(matches!(names.type_name("InputT0"), Cow::Borrowed("T1")));
+        assert!(matches!(names.type_name("InputT7"), Cow::Borrowed("T8")));
+        assert!(matches!(names.type_name("InputT8"), Cow::Owned(value) if value == "T9"));
     }
 
     #[test]
@@ -198,14 +210,22 @@ mod tests {
             .chain((0..9).map(|index| const_param(format!("N{index}"))))
             .collect::<Vec<_>>();
         let mut names = Names::default();
-        names.add_params(&params);
+        for param in &params {
+            names.add_param(param);
+        }
 
         assert!(matches!(names.lifetime("'lt0"), Cow::Borrowed("'a")));
         assert!(matches!(names.lifetime("'lt7"), Cow::Borrowed("'h")));
         assert!(matches!(names.lifetime("'lt8"), Cow::Owned(value) if value == "'i"));
-        assert!(matches!(names.const_name("N0"), Cow::Borrowed("C1")));
-        assert!(matches!(names.const_name("N7"), Cow::Borrowed("C8")));
-        assert!(matches!(names.const_name("N8"), Cow::Owned(value) if value == "C9"));
+        assert!(matches!(
+            names.type_or_const_name("N0"),
+            Cow::Borrowed("C1")
+        ));
+        assert!(matches!(
+            names.type_or_const_name("N7"),
+            Cow::Borrowed("C8")
+        ));
+        assert!(matches!(names.type_or_const_name("N8"), Cow::Owned(value) if value == "C9"));
         assert!(matches!(names.const_expr("N0"), Cow::Borrowed("C1")));
         assert!(matches!(names.const_expr("N8"), Cow::Owned(value) if value == "C9"));
 
@@ -223,13 +243,13 @@ mod tests {
         }
     }
 
-    fn type_param(name: String, is_synthetic: bool) -> GenericParamDef {
+    fn type_param(name: String) -> GenericParamDef {
         GenericParamDef {
             name,
             kind: GenericParamDefKind::Type {
                 bounds: vec![],
                 default: None,
-                is_synthetic,
+                is_synthetic: false,
             },
         }
     }

--- a/src/adapter/normalize/parameter_impl_trait.rs
+++ b/src/adapter/normalize/parameter_impl_trait.rs
@@ -1,0 +1,907 @@
+//! Placeholder assignment for parameter-position `impl Trait`.
+//!
+//! Rustdoc splits each parameter-position `impl Trait` across two places: the
+//! parameter type contains a `Type::ImplTrait` use site, while
+//! `Function::generics.params` contains the corresponding synthetic generic
+//! param and its bounds. Bounds and associated-item constraints are
+//! semantically unordered, so equivalent source can appear in different rustdoc
+//! orders.
+//!
+//! Canonical order is the deterministic order produced by sorting those
+//! unordered pieces by normalized sort key. Formatter order is the order in
+//! which `types.rs` encounters `Type::ImplTrait` nodes while rendering the raw
+//! rustdoc type tree.
+//!
+//! This module uses both orders: a raw rustdoc-order walk pairs each use site
+//! with the next synthetic generic param, while a canonical-order walk assigns
+//! stable `IT<parameter>_<n>` placeholders. For example, in
+//! `impl Trait<B = impl Copy, A = impl Clone>`, canonical order names `A`'s
+//! `impl Clone` as `IT1_1` and `B`'s `impl Copy` as `IT1_2`, but the formatter
+//! cursor yields `IT1_2` before `IT1_1` because it visits `B` before `A`.
+
+use std::{borrow::Cow, collections::BTreeMap, num::NonZeroUsize};
+
+use rustdoc_types::{
+    AssocItemConstraint, AssocItemConstraintKind, GenericArg, GenericArgs, GenericBound,
+    GenericParamDef, GenericParamDefKind, Generics, Path, Term, Type, WherePredicate,
+};
+
+use crate::PackageIndex;
+
+use super::{
+    names::{Names, is_synthetic_type_param, parameter_impl_trait_placeholder},
+    paths, sort_key,
+};
+
+#[derive(Clone, Copy, Debug)]
+struct SyntheticTypeParam {
+    index: usize,
+}
+
+/// The `impl Trait` uses inside a function's parameters.
+///
+/// Each item inside `by_parameter` describes the `impl Trait` uses in
+/// the corresponding parameter, matched positionally (by index).
+/// When formatting, each parameter's data is consumed via [`ParameterImplTraitCursor`].
+#[derive(Clone, Debug)]
+pub(super) struct FnParameterImplTraits {
+    by_parameter: Vec<Vec<Cow<'static, str>>>,
+}
+
+/// Cursor over the synthetic type-param names for one function parameter.
+///
+/// A parameter may contain multiple `impl Trait` occurrences, such as
+/// `(&impl Clone, Vec<impl Into<String>>)`. During parameter formatting, each
+/// `Type::ImplTrait` consumes the next name from this cursor. Return-position
+/// `impl Trait` formatting does not use this cursor, so it remains an opaque
+/// `impl` type rather than becoming a synthetic generic placeholder.
+pub(super) struct ParameterImplTraitCursor<'a> {
+    names: &'a [Cow<'static, str>],
+    next: usize,
+}
+
+impl FnParameterImplTraits {
+    /// Returns a cursor over placeholders consumed while formatting `position`.
+    ///
+    /// The cursor order matches the formatter traversal order of `Type::ImplTrait`
+    /// nodes in that parameter. Placeholder assignment itself may have used a
+    /// canonical ordering first, so callers should not index into
+    /// `by_parameter` directly.
+    pub(super) fn cursor_for_parameter(
+        &self,
+        position: NonZeroUsize,
+    ) -> ParameterImplTraitCursor<'_> {
+        let index = position.get() - 1;
+        let names = self
+            .by_parameter
+            .get(index)
+            .expect("function parameter position was out of bounds");
+        ParameterImplTraitCursor { names, next: 0 }
+    }
+}
+
+impl<'a> ParameterImplTraitCursor<'a> {
+    pub(super) fn next(&mut self) -> &str {
+        let name = self.names.get(self.next).unwrap_or_else(|| {
+            unreachable!(
+                "parameter-position impl Trait had no matching synthetic generic parameter: \
+                next={}, names={:?}",
+                self.next, self.names,
+            )
+        });
+        self.next += 1;
+        name.as_ref()
+    }
+
+    pub(super) fn assert_finished(&self) {
+        assert_eq!(
+            self.next,
+            self.names.len(),
+            "not all parameter-position impl Trait synthetic generic parameters were used",
+        );
+    }
+}
+
+fn collect_type_impl_trait_params<'a>(
+    type_: &'a Type,
+    names: &Names<'a>,
+    normalize_path: &impl Fn(&Path) -> String,
+    synthetic_params: &mut impl Iterator<Item = SyntheticTypeParam>,
+    output: &mut Vec<SyntheticTypeParam>,
+) {
+    match type_ {
+        Type::ResolvedPath(path) => {
+            collect_path_impl_trait_params(path, names, normalize_path, synthetic_params, output);
+        }
+        Type::DynTrait(dyn_trait) => {
+            let mut traits = Vec::new();
+            for trait_ in &dyn_trait.traits {
+                assert_supported_hrtb_generic_params(&trait_.generic_params);
+                // TODO: If this cloning ends up being expensive,
+                // we can look to replace it with an immutable hierarchical design instead.
+                let mut scoped_names = names.clone();
+                for param in &trait_.generic_params {
+                    scoped_names.add_param(param);
+                }
+                let mut params = Vec::new();
+                collect_path_impl_trait_params(
+                    &trait_.trait_,
+                    &scoped_names,
+                    normalize_path,
+                    synthetic_params,
+                    &mut params,
+                );
+                traits.push((sort_key::poly_trait(names, trait_, normalize_path), params));
+            }
+            traits.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+            for (_, params) in traits {
+                output.extend(params);
+            }
+        }
+        Type::Generic(_) | Type::Primitive(_) | Type::Infer | Type::Pat { .. } => {
+            // No `impl Trait` uses here.
+        }
+        Type::FunctionPointer(pointer) => {
+            assert_supported_hrtb_generic_params(&pointer.generic_params);
+            // TODO: If this cloning ends up being expensive,
+            // we can look to replace it with an immutable hierarchical design instead.
+            let mut scoped_names = names.clone();
+            for param in &pointer.generic_params {
+                scoped_names.add_param(param);
+            }
+
+            // As of Rust 1.96, `impl Trait` nested in `fn` pointer signatures is
+            // rejected, so there are no parameter-position synthetic params to
+            // collect inside `pointer.sig`.
+        }
+        Type::Tuple(types) => {
+            for type_ in types {
+                collect_type_impl_trait_params(
+                    type_,
+                    names,
+                    normalize_path,
+                    synthetic_params,
+                    output,
+                );
+            }
+        }
+        Type::Slice(type_) | Type::Array { type_, .. } => {
+            collect_type_impl_trait_params(type_, names, normalize_path, synthetic_params, output);
+        }
+        Type::ImplTrait(bounds) => {
+            collect_bounds_impl_trait_params(
+                bounds,
+                names,
+                normalize_path,
+                synthetic_params,
+                output,
+            );
+            output.push(next_synthetic_impl_trait_param(synthetic_params));
+        }
+        Type::RawPointer { type_, .. } | Type::BorrowedRef { type_, .. } => {
+            collect_type_impl_trait_params(type_, names, normalize_path, synthetic_params, output);
+        }
+        Type::QualifiedPath {
+            args,
+            self_type,
+            trait_,
+            ..
+        } => {
+            collect_type_impl_trait_params(
+                self_type,
+                names,
+                normalize_path,
+                synthetic_params,
+                output,
+            );
+            if let Some(trait_) = trait_ {
+                collect_path_impl_trait_params(
+                    trait_,
+                    names,
+                    normalize_path,
+                    synthetic_params,
+                    output,
+                );
+            }
+            if let Some(args) = args.as_deref() {
+                collect_generic_args_impl_trait_params(
+                    args,
+                    names,
+                    normalize_path,
+                    synthetic_params,
+                    output,
+                );
+            }
+        }
+    }
+}
+
+fn assert_supported_hrtb_generic_params(params: &[GenericParamDef]) {
+    for param in params {
+        match &param.kind {
+            GenericParamDefKind::Lifetime { .. } => {}
+            GenericParamDefKind::Type { .. } => {
+                // These generic params come from higher-ranked `for<...>`
+                // binders on `fn` pointers or trait bounds. As of Rust 1.96,
+                // hypothetical `for<T>` binders are rejected, so there are no
+                // parameter-position synthetic params to collect here.
+                unreachable!("found type generic param definition in HRTB position: {param:?}");
+            }
+            GenericParamDefKind::Const { .. } => {
+                // These generic params come from higher-ranked `for<...>`
+                // binders on `fn` pointers or trait bounds. As of Rust 1.96,
+                // hypothetical `for<const N: usize>` binders are rejected, so
+                // there are no parameter-position synthetic params to collect here.
+                unreachable!("found const generic param definition in HRTB position: {param:?}");
+            }
+        }
+    }
+}
+
+fn collect_path_impl_trait_params<'a>(
+    path: &'a Path,
+    names: &Names<'a>,
+    normalize_path: &impl Fn(&Path) -> String,
+    synthetic_params: &mut impl Iterator<Item = SyntheticTypeParam>,
+    output: &mut Vec<SyntheticTypeParam>,
+) {
+    if let Some(args) = path.args.as_deref() {
+        collect_generic_args_impl_trait_params(
+            args,
+            names,
+            normalize_path,
+            synthetic_params,
+            output,
+        );
+    }
+}
+
+fn collect_generic_args_impl_trait_params<'a>(
+    args: &'a GenericArgs,
+    names: &Names<'a>,
+    normalize_path: &impl Fn(&Path) -> String,
+    synthetic_params: &mut impl Iterator<Item = SyntheticTypeParam>,
+    output: &mut Vec<SyntheticTypeParam>,
+) {
+    match args {
+        GenericArgs::AngleBracketed { args, constraints } => {
+            for arg in args {
+                match arg {
+                    GenericArg::Type(type_) => {
+                        collect_type_impl_trait_params(
+                            type_,
+                            names,
+                            normalize_path,
+                            synthetic_params,
+                            output,
+                        );
+                    }
+                    GenericArg::Lifetime(_) | GenericArg::Const(_) | GenericArg::Infer => {}
+                }
+            }
+
+            let mut constraint_params = Vec::new();
+            for constraint in constraints {
+                let mut params = Vec::new();
+                collect_assoc_item_constraint_impl_trait_params_raw(
+                    constraint,
+                    names,
+                    normalize_path,
+                    synthetic_params,
+                    &mut params,
+                );
+                constraint_params.push((
+                    sort_key::assoc_item_constraint(names, constraint, normalize_path),
+                    params,
+                ));
+            }
+            constraint_params.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+            for (_, params) in constraint_params {
+                output.extend(params);
+            }
+        }
+        GenericArgs::Parenthesized { .. } => {
+            // Parenthesized args represent `Fn`-trait signatures.
+            // As of Rust 1.96, `impl Trait` nested in `Fn`-trait signatures is rejected,
+            // so there are no parameter-position synthetic params to collect here.
+        }
+        GenericArgs::ReturnTypeNotation => {}
+    }
+}
+
+fn collect_assoc_item_constraint_impl_trait_params_raw<'a>(
+    constraint: &'a AssocItemConstraint,
+    names: &Names<'a>,
+    normalize_path: &impl Fn(&Path) -> String,
+    synthetic_params: &mut impl Iterator<Item = SyntheticTypeParam>,
+    output: &mut Vec<SyntheticTypeParam>,
+) {
+    if let Some(args) = constraint.args.as_deref() {
+        collect_generic_args_impl_trait_params(
+            args,
+            names,
+            normalize_path,
+            synthetic_params,
+            output,
+        );
+    }
+
+    match &constraint.binding {
+        AssocItemConstraintKind::Constraint(bounds) => {
+            collect_bounds_impl_trait_params(
+                bounds,
+                names,
+                normalize_path,
+                synthetic_params,
+                output,
+            );
+        }
+        AssocItemConstraintKind::Equality(term) => {
+            collect_term_impl_trait_params(term, names, normalize_path, synthetic_params, output);
+        }
+    }
+}
+
+fn collect_bounds_impl_trait_params<'a>(
+    bounds: &'a [GenericBound],
+    names: &Names<'a>,
+    normalize_path: &impl Fn(&Path) -> String,
+    synthetic_params: &mut impl Iterator<Item = SyntheticTypeParam>,
+    output: &mut Vec<SyntheticTypeParam>,
+) {
+    let mut bound_params = Vec::new();
+    for bound in bounds {
+        let mut params = Vec::new();
+        match bound {
+            GenericBound::TraitBound {
+                trait_,
+                generic_params,
+                ..
+            } => {
+                assert_supported_hrtb_generic_params(generic_params);
+                // TODO: If this cloning ends up being expensive,
+                // we can look to replace it with an immutable hierarchical design instead.
+                let mut scoped_names = names.clone();
+                for param in generic_params {
+                    scoped_names.add_param(param);
+                }
+                collect_path_impl_trait_params(
+                    trait_,
+                    &scoped_names,
+                    normalize_path,
+                    synthetic_params,
+                    &mut params,
+                );
+            }
+            GenericBound::Outlives(_) | GenericBound::Use(_) => {}
+        }
+        bound_params.push((
+            sort_key::generic_bound(names, bound, normalize_path),
+            params,
+        ));
+    }
+
+    bound_params.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+    for (_, params) in bound_params {
+        output.extend(params);
+    }
+}
+
+fn collect_term_impl_trait_params<'a>(
+    term: &'a Term,
+    names: &Names<'a>,
+    normalize_path: &impl Fn(&Path) -> String,
+    synthetic_params: &mut impl Iterator<Item = SyntheticTypeParam>,
+    output: &mut Vec<SyntheticTypeParam>,
+) {
+    match term {
+        Term::Type(type_) => {
+            collect_type_impl_trait_params(type_, names, normalize_path, synthetic_params, output);
+        }
+        Term::Constant(constant) => {
+            // As of Rust 1.96, associated const equality constraints such as
+            // `T: Trait<N = 3>` are incomplete and rejected, so there are no
+            // parameter-position synthetic params to collect here.
+            unreachable!("found associated const equality constraint term: {constant:?}");
+        }
+    }
+}
+
+fn next_synthetic_impl_trait_param(
+    synthetic_params: &mut impl Iterator<Item = SyntheticTypeParam>,
+) -> SyntheticTypeParam {
+    synthetic_params
+        .next()
+        .expect("parameter-position impl Trait had no matching synthetic generic parameter")
+}
+
+/// Computes the parameter-position `impl Trait` placeholders for one function.
+///
+/// Placeholder assignment is scoped to each containing function parameter:
+/// `impl Trait` in the first parameter is named `IT1_1`, `IT1_2`, and so on,
+/// while `impl Trait` in the second parameter is named `IT2_1`, `IT2_2`, and so
+/// on. This keeps unrelated parameter positions from being renumbered when a
+/// new `impl Trait` is added elsewhere in the same function signature.
+pub(super) fn compute_for_function<'a>(
+    crate_: &'a PackageIndex<'a>,
+    function: &'a rustdoc_types::Function,
+    names: &Names<'a>,
+) -> FnParameterImplTraits {
+    let normalize_path = |path: &Path| paths::normalized_path(crate_, path);
+    compute_for_function_with_path_normalizer(function, names, &normalize_path)
+}
+
+fn compute_for_function_with_path_normalizer<'a>(
+    function: &'a rustdoc_types::Function,
+    names: &Names<'a>,
+    normalize_path: &impl Fn(&Path) -> String,
+) -> FnParameterImplTraits {
+    let synthetic_params = function
+        .generics
+        .params
+        .iter()
+        .enumerate()
+        .filter(|(_, param)| is_synthetic_type_param(param))
+        .map(|(index, _)| SyntheticTypeParam { index })
+        .collect::<Vec<_>>();
+    let mut synthetic_params = synthetic_params.iter().copied();
+    let mut sink = Vec::new();
+
+    collect_generics_impl_trait_names(
+        &function.generics,
+        &mut synthetic_params,
+        None,
+        &mut sink,
+        false,
+    );
+
+    let mut output = Vec::with_capacity(function.sig.inputs.len());
+    for (index, (_, type_)) in function.sig.inputs.iter().enumerate() {
+        let parameter_position = index + 1;
+        // Assign each parameter's suffixes in canonical order, but leave the
+        // real cursor untouched. The formatter walks raw rustdoc nodes while
+        // building strings that may later be sorted, so the cursor it receives
+        // must remain in formatter traversal order.
+        let mut canonical_synthetic_params = synthetic_params.clone();
+        let mut canonical_params = Vec::new();
+        collect_type_impl_trait_params(
+            type_,
+            names,
+            normalize_path,
+            &mut canonical_synthetic_params,
+            &mut canonical_params,
+        );
+
+        let mut synthetic_names_by_index = BTreeMap::new();
+        for (local_index, param) in canonical_params.iter().enumerate() {
+            let existing = synthetic_names_by_index.insert(
+                param.index,
+                parameter_impl_trait_placeholder(parameter_position, local_index + 1),
+            );
+            assert!(
+                existing.is_none(),
+                "duplicate synthetic type parameter index `{}` in parameter {parameter_position}",
+                param.index,
+            );
+        }
+
+        let mut parameter_names = Vec::new();
+        collect_type_impl_trait_names(
+            type_,
+            &mut synthetic_params,
+            Some(&synthetic_names_by_index),
+            &mut parameter_names,
+            true,
+        );
+        output.push(parameter_names);
+    }
+
+    collect_where_predicates_impl_trait_names(
+        &function.generics.where_predicates,
+        &mut synthetic_params,
+        None,
+        &mut sink,
+        false,
+    );
+
+    assert!(
+        synthetic_params.next().is_none(),
+        "rustdoc synthetic generics outnumbered parameter-position impl Trait occurrences",
+    );
+    FnParameterImplTraits {
+        by_parameter: output,
+    }
+}
+
+fn collect_generics_impl_trait_names(
+    generics: &Generics,
+    synthetic_params: &mut impl Iterator<Item = SyntheticTypeParam>,
+    synthetic_names_by_index: Option<&BTreeMap<usize, Cow<'static, str>>>,
+    output: &mut Vec<Cow<'static, str>>,
+    emit: bool,
+) {
+    for param in &generics.params {
+        match &param.kind {
+            GenericParamDefKind::Type {
+                bounds,
+                default,
+                is_synthetic: false,
+            } => {
+                collect_bounds_impl_trait_names(
+                    bounds,
+                    synthetic_params,
+                    synthetic_names_by_index,
+                    output,
+                    emit,
+                );
+                if let Some(default) = default {
+                    collect_type_impl_trait_names(
+                        default,
+                        synthetic_params,
+                        synthetic_names_by_index,
+                        output,
+                        emit,
+                    );
+                }
+            }
+            GenericParamDefKind::Type {
+                is_synthetic: true, ..
+            }
+            | GenericParamDefKind::Lifetime { .. } => {}
+            GenericParamDefKind::Const { type_, .. } => {
+                collect_type_impl_trait_names(
+                    type_,
+                    synthetic_params,
+                    synthetic_names_by_index,
+                    output,
+                    emit,
+                );
+            }
+        }
+    }
+}
+
+fn collect_type_impl_trait_names(
+    type_: &Type,
+    synthetic_params: &mut impl Iterator<Item = SyntheticTypeParam>,
+    synthetic_names_by_index: Option<&BTreeMap<usize, Cow<'static, str>>>,
+    output: &mut Vec<Cow<'static, str>>,
+    emit: bool,
+) {
+    match type_ {
+        Type::ResolvedPath(path) => {
+            collect_path_impl_trait_names(
+                path,
+                synthetic_params,
+                synthetic_names_by_index,
+                output,
+                emit,
+            );
+        }
+        Type::DynTrait(dyn_trait) => {
+            for trait_ in &dyn_trait.traits {
+                assert_supported_hrtb_generic_params(&trait_.generic_params);
+                collect_path_impl_trait_names(
+                    &trait_.trait_,
+                    synthetic_params,
+                    synthetic_names_by_index,
+                    output,
+                    emit,
+                );
+            }
+        }
+        Type::Generic(_) | Type::Primitive(_) | Type::Infer | Type::Pat { .. } => {}
+        Type::FunctionPointer(pointer) => {
+            assert_supported_hrtb_generic_params(&pointer.generic_params);
+            // As of Rust 1.96, `impl Trait` nested in `fn` pointer signatures is
+            // rejected, so there are no parameter-position synthetic params to
+            // collect inside `pointer.sig`.
+        }
+        Type::Tuple(types) => {
+            for type_ in types {
+                collect_type_impl_trait_names(
+                    type_,
+                    synthetic_params,
+                    synthetic_names_by_index,
+                    output,
+                    emit,
+                );
+            }
+        }
+        Type::Slice(type_) | Type::Array { type_, .. } => {
+            collect_type_impl_trait_names(
+                type_,
+                synthetic_params,
+                synthetic_names_by_index,
+                output,
+                emit,
+            );
+        }
+        Type::ImplTrait(bounds) => {
+            collect_bounds_impl_trait_names(
+                bounds,
+                synthetic_params,
+                synthetic_names_by_index,
+                output,
+                false,
+            );
+            let param = next_synthetic_impl_trait_param(synthetic_params);
+            if emit {
+                let names = synthetic_names_by_index.expect(
+                    "parameter-position impl Trait name emission requires precomputed names",
+                );
+                output.push(names.get(&param.index).cloned().unwrap_or_else(|| {
+                    unreachable!(
+                        "missing normalized name for synthetic type parameter index `{}`",
+                        param.index,
+                    )
+                }));
+            }
+        }
+        Type::RawPointer { type_, .. } | Type::BorrowedRef { type_, .. } => {
+            collect_type_impl_trait_names(
+                type_,
+                synthetic_params,
+                synthetic_names_by_index,
+                output,
+                emit,
+            );
+        }
+        Type::QualifiedPath {
+            args,
+            self_type,
+            trait_,
+            ..
+        } => {
+            collect_type_impl_trait_names(
+                self_type,
+                synthetic_params,
+                synthetic_names_by_index,
+                output,
+                emit,
+            );
+            if let Some(trait_) = trait_ {
+                collect_path_impl_trait_names(
+                    trait_,
+                    synthetic_params,
+                    synthetic_names_by_index,
+                    output,
+                    emit,
+                );
+            }
+            if let Some(args) = args.as_deref() {
+                collect_generic_args_impl_trait_names(
+                    args,
+                    synthetic_params,
+                    synthetic_names_by_index,
+                    output,
+                    emit,
+                );
+            }
+        }
+    }
+}
+
+fn collect_path_impl_trait_names(
+    path: &Path,
+    synthetic_params: &mut impl Iterator<Item = SyntheticTypeParam>,
+    synthetic_names_by_index: Option<&BTreeMap<usize, Cow<'static, str>>>,
+    output: &mut Vec<Cow<'static, str>>,
+    emit: bool,
+) {
+    if let Some(args) = path.args.as_deref() {
+        collect_generic_args_impl_trait_names(
+            args,
+            synthetic_params,
+            synthetic_names_by_index,
+            output,
+            emit,
+        );
+    }
+}
+
+fn collect_generic_args_impl_trait_names(
+    args: &GenericArgs,
+    synthetic_params: &mut impl Iterator<Item = SyntheticTypeParam>,
+    synthetic_names_by_index: Option<&BTreeMap<usize, Cow<'static, str>>>,
+    output: &mut Vec<Cow<'static, str>>,
+    emit: bool,
+) {
+    match args {
+        GenericArgs::AngleBracketed { args, constraints } => {
+            for arg in args {
+                match arg {
+                    GenericArg::Type(type_) => {
+                        collect_type_impl_trait_names(
+                            type_,
+                            synthetic_params,
+                            synthetic_names_by_index,
+                            output,
+                            emit,
+                        );
+                    }
+                    GenericArg::Lifetime(_) | GenericArg::Const(_) | GenericArg::Infer => {}
+                }
+            }
+            for constraint in constraints {
+                collect_assoc_item_constraint_impl_trait_names(
+                    constraint,
+                    synthetic_params,
+                    synthetic_names_by_index,
+                    output,
+                    emit,
+                );
+            }
+        }
+        GenericArgs::Parenthesized { .. } => {
+            // Parenthesized args represent `Fn`-trait signatures.
+            // As of Rust 1.96, `impl Trait` nested in those input or output
+            // types is rejected, so there are no parameter-position synthetic
+            // params to collect here.
+        }
+        GenericArgs::ReturnTypeNotation => {}
+    }
+}
+
+fn collect_assoc_item_constraint_impl_trait_names(
+    constraint: &AssocItemConstraint,
+    synthetic_params: &mut impl Iterator<Item = SyntheticTypeParam>,
+    synthetic_names_by_index: Option<&BTreeMap<usize, Cow<'static, str>>>,
+    output: &mut Vec<Cow<'static, str>>,
+    emit: bool,
+) {
+    if let Some(args) = constraint.args.as_deref() {
+        collect_generic_args_impl_trait_names(
+            args,
+            synthetic_params,
+            synthetic_names_by_index,
+            output,
+            emit,
+        );
+    }
+
+    match &constraint.binding {
+        AssocItemConstraintKind::Constraint(bounds) => {
+            collect_bounds_impl_trait_names(
+                bounds,
+                synthetic_params,
+                synthetic_names_by_index,
+                output,
+                emit,
+            );
+        }
+        AssocItemConstraintKind::Equality(term) => {
+            collect_term_impl_trait_names(
+                term,
+                synthetic_params,
+                synthetic_names_by_index,
+                output,
+                emit,
+            );
+        }
+    }
+}
+
+fn collect_bounds_impl_trait_names(
+    bounds: &[GenericBound],
+    synthetic_params: &mut impl Iterator<Item = SyntheticTypeParam>,
+    synthetic_names_by_index: Option<&BTreeMap<usize, Cow<'static, str>>>,
+    output: &mut Vec<Cow<'static, str>>,
+    emit: bool,
+) {
+    for bound in bounds {
+        match bound {
+            GenericBound::TraitBound {
+                trait_,
+                generic_params,
+                ..
+            } => {
+                assert_supported_hrtb_generic_params(generic_params);
+                collect_path_impl_trait_names(
+                    trait_,
+                    synthetic_params,
+                    synthetic_names_by_index,
+                    output,
+                    emit,
+                );
+            }
+            GenericBound::Outlives(_) | GenericBound::Use(_) => {}
+        }
+    }
+}
+
+fn collect_term_impl_trait_names(
+    term: &Term,
+    synthetic_params: &mut impl Iterator<Item = SyntheticTypeParam>,
+    synthetic_names_by_index: Option<&BTreeMap<usize, Cow<'static, str>>>,
+    output: &mut Vec<Cow<'static, str>>,
+    emit: bool,
+) {
+    match term {
+        Term::Type(type_) => {
+            collect_type_impl_trait_names(
+                type_,
+                synthetic_params,
+                synthetic_names_by_index,
+                output,
+                emit,
+            );
+        }
+        Term::Constant(constant) => {
+            // As of Rust 1.96, associated const equality constraints such as
+            // `T: Trait<N = 3>` are incomplete and rejected, so there are no
+            // parameter-position synthetic params to collect here.
+            unreachable!("found associated const equality constraint term: {constant:?}");
+        }
+    }
+}
+
+fn collect_where_predicates_impl_trait_names(
+    predicates: &[WherePredicate],
+    synthetic_params: &mut impl Iterator<Item = SyntheticTypeParam>,
+    synthetic_names_by_index: Option<&BTreeMap<usize, Cow<'static, str>>>,
+    output: &mut Vec<Cow<'static, str>>,
+    emit: bool,
+) {
+    for predicate in predicates {
+        match predicate {
+            WherePredicate::BoundPredicate {
+                type_,
+                bounds,
+                generic_params,
+            } => {
+                assert_supported_hrtb_generic_params(generic_params);
+                collect_type_impl_trait_names(
+                    type_,
+                    synthetic_params,
+                    synthetic_names_by_index,
+                    output,
+                    emit,
+                );
+                collect_bounds_impl_trait_names(
+                    bounds,
+                    synthetic_params,
+                    synthetic_names_by_index,
+                    output,
+                    emit,
+                );
+            }
+            WherePredicate::LifetimePredicate { .. } => {}
+            WherePredicate::EqPredicate { .. } => {
+                // As of Rust 1.96, general equality constraints such as
+                // `where T::Assoc = U` are rejected. Associated-item
+                // constraints such as `where T: Trait<Assoc = U>` are represented
+                // as `BoundPredicate` instead, so there are no
+                // parameter-position synthetic params to collect here.
+                unreachable!(
+                    "found general equality predicate in function generics: {predicate:?}"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use crate::adapter::normalize::names::parameter_impl_trait_placeholder;
+
+    #[test]
+    fn first_impl_trait_names_use_requested_static_prefix() {
+        assert!(matches!(
+            parameter_impl_trait_placeholder(1, 1),
+            Cow::Borrowed("IT1_1")
+        ));
+        assert!(matches!(
+            parameter_impl_trait_placeholder(8, 1),
+            Cow::Borrowed("IT8_1")
+        ));
+        assert!(
+            matches!(parameter_impl_trait_placeholder(9, 1), Cow::Owned(value) if value == "IT9_1")
+        );
+        assert!(
+            matches!(parameter_impl_trait_placeholder(1, 2), Cow::Owned(value) if value == "IT1_2")
+        );
+    }
+}

--- a/src/adapter/normalize/paths.rs
+++ b/src/adapter/normalize/paths.rs
@@ -1,4 +1,4 @@
-use super::context::FnNormalizationContext;
+use crate::PackageIndex;
 
 /// Return a normalized representation of the given rustdoc path.
 ///
@@ -6,11 +6,7 @@ use super::context::FnNormalizationContext;
 /// available so reexports normalize to the spelling downstream users can name.
 /// For other resolved items, fall back to rustdoc's path summary. The raw path
 /// fallback is only for rustdoc data that did not resolve to either source.
-pub(super) fn normalized_path(
-    context: &FnNormalizationContext<'_>,
-    path: &rustdoc_types::Path,
-) -> String {
-    let crate_ = context.crate_();
+pub(super) fn normalized_path(crate_: &PackageIndex<'_>, path: &rustdoc_types::Path) -> String {
     if crate_.own_crate.inner.index.contains_key(&path.id) {
         let importable_paths = crate_
             .own_crate

--- a/src/adapter/normalize/sort_key.rs
+++ b/src/adapter/normalize/sort_key.rs
@@ -1,0 +1,458 @@
+//! Temporary canonical sort keys for rustdoc type subtrees.
+//!
+//! Parameter-position `impl Trait` placeholders are assigned before final type
+//! formatting is possible. These helpers render enough of the relevant rustdoc
+//! subtrees to sort bounds and constraints deterministically during that
+//! precomputation. They are not user-facing normalized signatures.
+//!
+//! Sort keys deliberately use the same path and generic-name normalization as
+//! final formatting. `Type::ImplTrait` nodes still render as `impl _` markers
+//! because the enclosing associated item, generic arg, or bound determines
+//! sort order; the nested `impl Trait` bounds are consumed separately for
+//! placeholder assignment and do not affect that enclosing sort key. Skipping
+//! those bounds here is a small optimization based on that invariant.
+
+use rustdoc_types::{
+    AssocItemConstraint, AssocItemConstraintKind, FunctionSignature, GenericArg, GenericArgs,
+    GenericBound, GenericParamDef, GenericParamDefKind, Path, Term, TraitBoundModifier, Type,
+};
+
+use super::names::Names;
+
+/// Returns the canonical sort key for a poly-trait bound.
+pub(super) fn poly_trait<'a>(
+    names: &Names<'a>,
+    poly_trait: &'a rustdoc_types::PolyTrait,
+    normalize_path: &impl Fn(&Path) -> String,
+) -> String {
+    let mut output = String::new();
+    // TODO: If this cloning ends up being expensive,
+    // we can look to replace it with an immutable hierarchical design instead.
+    let mut scoped_names = names.clone();
+    for param in &poly_trait.generic_params {
+        scoped_names.add_param(param);
+    }
+    format_generic_params(&scoped_names, &poly_trait.generic_params, &mut output);
+    format_path(
+        &scoped_names,
+        &poly_trait.trait_,
+        normalize_path,
+        &mut output,
+    );
+    output
+}
+
+/// Returns the canonical sort key for an associated item constraint.
+pub(super) fn assoc_item_constraint<'a>(
+    names: &Names<'a>,
+    constraint: &'a AssocItemConstraint,
+    normalize_path: &impl Fn(&Path) -> String,
+) -> String {
+    let mut output = String::new();
+    format_assoc_item_constraint(names, constraint, normalize_path, &mut output);
+    output
+}
+
+/// Returns the canonical sort key for a generic bound.
+pub(super) fn generic_bound<'a>(
+    names: &Names<'a>,
+    bound: &'a GenericBound,
+    normalize_path: &impl Fn(&Path) -> String,
+) -> String {
+    let mut output = String::new();
+    format_generic_bound(names, bound, normalize_path, &mut output);
+    output
+}
+
+fn format_assoc_item_constraint<'a>(
+    names: &Names<'a>,
+    constraint: &'a AssocItemConstraint,
+    normalize_path: &impl Fn(&Path) -> String,
+    output: &mut String,
+) {
+    output.push_str(&constraint.name);
+    if let Some(args) = constraint.args.as_deref() {
+        format_generic_args(names, args, normalize_path, output);
+    }
+
+    match &constraint.binding {
+        AssocItemConstraintKind::Constraint(bounds) => {
+            output.push_str(": ");
+            format_bounds(names, bounds, normalize_path, output);
+        }
+        AssocItemConstraintKind::Equality(term) => {
+            output.push_str(" = ");
+            format_term(names, term, normalize_path, output);
+        }
+    }
+}
+
+fn format_bounds<'a>(
+    names: &Names<'a>,
+    bounds: &'a [GenericBound],
+    normalize_path: &impl Fn(&Path) -> String,
+    output: &mut String,
+) {
+    let mut bounds = bounds
+        .iter()
+        .map(|bound| generic_bound(names, bound, normalize_path))
+        .collect::<Vec<_>>();
+    bounds.sort_unstable();
+    let mut bounds_iter = bounds.iter();
+    if let Some(bound) = bounds_iter.next() {
+        output.push_str(bound);
+    }
+    for bound in bounds_iter {
+        output.push_str(" + ");
+        output.push_str(bound);
+    }
+}
+
+fn format_generic_bound<'a>(
+    names: &Names<'a>,
+    bound: &'a GenericBound,
+    normalize_path: &impl Fn(&Path) -> String,
+    output: &mut String,
+) {
+    match bound {
+        GenericBound::TraitBound {
+            trait_,
+            generic_params,
+            modifier,
+        } => {
+            // TODO: If this cloning ends up being expensive,
+            // we can look to replace it with an immutable hierarchical design instead.
+            let mut scoped_names = names.clone();
+            for param in generic_params {
+                scoped_names.add_param(param);
+            }
+            format_generic_params(&scoped_names, generic_params, output);
+            match modifier {
+                TraitBoundModifier::None => {}
+                TraitBoundModifier::Maybe => output.push('?'),
+                TraitBoundModifier::MaybeConst => output.push_str("~const "),
+            }
+            format_path(&scoped_names, trait_, normalize_path, output);
+        }
+        GenericBound::Outlives(lifetime) => {
+            let lifetime = names.lifetime(lifetime);
+            output.push_str(lifetime.as_ref());
+        }
+        GenericBound::Use(args) => {
+            // Sort keys are used only while assigning parameter-position
+            // `impl Trait` placeholders. As of Rust 1.96, hypothetical
+            // `fn f(_: impl Trait + use<T>)` syntax is rejected, so precise
+            // capture bounds cannot appear here.
+            unreachable!(
+                "found precise-capture `use<...>` bound in parameter-position impl Trait: {args:?}"
+            );
+        }
+    }
+}
+
+fn format_path<'a>(
+    names: &Names<'a>,
+    path: &'a Path,
+    normalize_path: &impl Fn(&Path) -> String,
+    output: &mut String,
+) {
+    output.push_str(&normalize_path(path));
+    if let Some(args) = path.args.as_deref() {
+        format_generic_args(names, args, normalize_path, output);
+    }
+}
+
+fn format_generic_args<'a>(
+    names: &Names<'a>,
+    args: &'a GenericArgs,
+    normalize_path: &impl Fn(&Path) -> String,
+    output: &mut String,
+) {
+    match args {
+        GenericArgs::AngleBracketed { args, constraints } => {
+            if args.is_empty() && constraints.is_empty() {
+                return;
+            }
+
+            output.push('<');
+            let mut needs_separator = false;
+            for arg in args {
+                if needs_separator {
+                    output.push_str(", ");
+                }
+                format_generic_arg(names, arg, normalize_path, output);
+                needs_separator = true;
+            }
+
+            let mut constraints = constraints
+                .iter()
+                .map(|constraint| assoc_item_constraint(names, constraint, normalize_path))
+                .collect::<Vec<_>>();
+            constraints.sort_unstable();
+            for constraint in constraints {
+                if needs_separator {
+                    output.push_str(", ");
+                }
+                output.push_str(&constraint);
+                needs_separator = true;
+            }
+            output.push('>');
+        }
+        GenericArgs::Parenthesized {
+            inputs,
+            output: return_type,
+        } => {
+            output.push('(');
+            for (index, type_) in inputs.iter().enumerate() {
+                if index != 0 {
+                    output.push_str(", ");
+                }
+                format_type(names, type_, normalize_path, output);
+            }
+            output.push(')');
+            if let Some(return_type) = return_type {
+                output.push_str(" -> ");
+                format_type(names, return_type, normalize_path, output);
+            }
+        }
+        GenericArgs::ReturnTypeNotation => output.push_str("(..)"),
+    }
+}
+
+fn format_generic_arg<'a>(
+    names: &Names<'a>,
+    arg: &'a GenericArg,
+    normalize_path: &impl Fn(&Path) -> String,
+    output: &mut String,
+) {
+    match arg {
+        GenericArg::Lifetime(lifetime) => {
+            let lifetime = names.lifetime(lifetime);
+            output.push_str(lifetime.as_ref());
+        }
+        GenericArg::Type(type_) => format_type(names, type_, normalize_path, output),
+        GenericArg::Const(constant) => format_constant(names, constant, output),
+        GenericArg::Infer => output.push('_'),
+    }
+}
+
+fn format_term<'a>(
+    names: &Names<'a>,
+    term: &'a Term,
+    normalize_path: &impl Fn(&Path) -> String,
+    output: &mut String,
+) {
+    match term {
+        Term::Type(type_) => format_type(names, type_, normalize_path, output),
+        Term::Constant(constant) => {
+            // As of Rust 1.96, associated const equality constraints such as
+            // `T: Trait<N = 3>` are incomplete and rejected, so there is no sort
+            // key to compute for such a term.
+            unreachable!("found associated const equality constraint term: {constant:?}");
+        }
+    }
+}
+
+fn format_constant<'a>(
+    names: &Names<'a>,
+    constant: &'a rustdoc_types::Constant,
+    output: &mut String,
+) {
+    let value = constant.value.as_deref().unwrap_or(&constant.expr);
+    let value = names.const_expr(value);
+    output.push_str(value.as_ref());
+}
+
+fn format_type<'a>(
+    names: &Names<'a>,
+    type_: &'a Type,
+    normalize_path: &impl Fn(&Path) -> String,
+    output: &mut String,
+) {
+    match type_ {
+        Type::ResolvedPath(path) => format_path(names, path, normalize_path, output),
+        Type::DynTrait(dyn_trait) => {
+            output.push_str("dyn ");
+            let mut traits = dyn_trait
+                .traits
+                .iter()
+                .map(|trait_| poly_trait(names, trait_, normalize_path))
+                .collect::<Vec<_>>();
+            traits.sort_unstable();
+            let mut traits_iter = traits.iter();
+            if let Some(trait_) = traits_iter.next() {
+                output.push_str(trait_);
+            }
+            for trait_ in traits_iter {
+                output.push_str(" + ");
+                output.push_str(trait_);
+            }
+            if let Some(lifetime) = &dyn_trait.lifetime {
+                assert!(
+                    !traits.is_empty(),
+                    "trait object lifetime bound cannot appear without a trait bound",
+                );
+                output.push_str(" + ");
+                let lifetime = names.lifetime(lifetime);
+                output.push_str(lifetime.as_ref());
+            }
+        }
+        Type::Generic(name) => {
+            let name = names.type_name(name);
+            output.push_str(name.as_ref());
+        }
+        Type::Primitive(name) => output.push_str(name),
+        Type::FunctionPointer(pointer) => {
+            let mut scoped_names = names.clone();
+            for param in &pointer.generic_params {
+                scoped_names.add_param(param);
+            }
+            format_generic_params(&scoped_names, &pointer.generic_params, output);
+            output.push_str("fn");
+            format_function_signature(&scoped_names, &pointer.sig, normalize_path, output);
+        }
+        Type::Tuple(types) => {
+            output.push('(');
+            for (index, type_) in types.iter().enumerate() {
+                if index != 0 {
+                    output.push_str(", ");
+                }
+                format_type(names, type_, normalize_path, output);
+            }
+            if types.len() == 1 {
+                output.push(',');
+            }
+            output.push(')');
+        }
+        Type::Slice(type_) => {
+            output.push('[');
+            format_type(names, type_, normalize_path, output);
+            output.push(']');
+        }
+        Type::Array { type_, len } => {
+            output.push('[');
+            format_type(names, type_, normalize_path, output);
+            output.push_str("; ");
+            let len = names.const_expr(len);
+            output.push_str(len.as_ref());
+            output.push(']');
+        }
+        Type::ImplTrait(_) => {
+            // Nested `impl Trait` bounds are consumed separately and receive
+            // placeholders after the enclosing associated item, generic arg, or
+            // bound has been placed in canonical order. Including those bounds
+            // here would make sort order depend on details that are erased from
+            // the containing parameter type signature, so `impl _` also avoids
+            // formatting data that cannot affect ordering.
+            output.push_str("impl _");
+        }
+        Type::Infer => output.push('_'),
+        Type::RawPointer { is_mutable, type_ } => {
+            if *is_mutable {
+                output.push_str("*mut ");
+            } else {
+                output.push_str("*const ");
+            }
+            format_type(names, type_, normalize_path, output);
+        }
+        Type::BorrowedRef {
+            lifetime,
+            is_mutable,
+            type_,
+        } => {
+            output.push('&');
+            if let Some(lifetime) = lifetime {
+                let lifetime = names.lifetime(lifetime);
+                output.push_str(lifetime.as_ref());
+                output.push(' ');
+            }
+            if *is_mutable {
+                output.push_str("mut ");
+            }
+            format_type(names, type_, normalize_path, output);
+        }
+        Type::QualifiedPath {
+            name,
+            args,
+            self_type,
+            trait_,
+        } => {
+            output.push('<');
+            format_type(names, self_type, normalize_path, output);
+            if let Some(trait_) = trait_ {
+                output.push_str(" as ");
+                format_path(names, trait_, normalize_path, output);
+            }
+            output.push_str(">::");
+            output.push_str(name);
+            if let Some(args) = args.as_deref() {
+                format_generic_args(names, args, normalize_path, output);
+            }
+        }
+        Type::Pat { type_, .. } => format_type(names, type_, normalize_path, output),
+    }
+}
+
+fn format_function_signature<'a>(
+    names: &Names<'a>,
+    signature: &'a FunctionSignature,
+    normalize_path: &impl Fn(&Path) -> String,
+    output: &mut String,
+) {
+    output.push('(');
+    for (index, (_, type_)) in signature.inputs.iter().enumerate() {
+        if index != 0 {
+            output.push_str(", ");
+        }
+        format_type(names, type_, normalize_path, output);
+    }
+    output.push(')');
+    if let Some(return_type) = &signature.output {
+        output.push_str(" -> ");
+        format_type(names, return_type, normalize_path, output);
+    }
+}
+
+fn format_generic_params<'a>(
+    names: &Names<'a>,
+    params: &'a [GenericParamDef],
+    output: &mut String,
+) {
+    if params.is_empty() {
+        return;
+    }
+
+    output.push_str("for<");
+    for (index, param) in params.iter().enumerate() {
+        if index != 0 {
+            output.push_str(", ");
+        }
+        format_hrtb_generic_param_def(names, param, output);
+    }
+    output.push_str("> ");
+}
+
+fn format_hrtb_generic_param_def<'a>(
+    names: &Names<'a>,
+    param: &'a GenericParamDef,
+    output: &mut String,
+) {
+    match &param.kind {
+        GenericParamDefKind::Lifetime { .. } => {
+            let lifetime = names.lifetime(&param.name);
+            output.push_str(lifetime.as_ref());
+        }
+        GenericParamDefKind::Type { .. } => {
+            // HRTB generic params model `for<...>` binders. As of Rust 1.96,
+            // hypothetical `for<T>` binders are rejected, so there is no sort
+            // key to compute for such a parameter.
+            unreachable!("found type generic param definition in HRTB position: {param:?}");
+        }
+        GenericParamDefKind::Const { .. } => {
+            // HRTB generic params model `for<...>` binders. As of Rust 1.96,
+            // hypothetical `for<const N: usize>` binders are rejected, so there
+            // is no sort key to compute for such a parameter.
+            unreachable!("found const generic param definition in HRTB position: {param:?}");
+        }
+    }
+}

--- a/src/adapter/normalize/types.rs
+++ b/src/adapter/normalize/types.rs
@@ -6,8 +6,7 @@ use rustdoc_types::{
 };
 
 use super::{
-    context::{FnNormalizationContext, ParameterImplTraitNames},
-    paths,
+    context::FnNormalizationContext, parameter_impl_trait::ParameterImplTraitCursor, paths,
 };
 
 /// Output a normalized parameter type.
@@ -18,16 +17,16 @@ pub(super) fn format_parameter_type<'a>(
     position: NonZeroUsize,
     type_: &'a Type,
 ) -> String {
-    let mut parameter_impl_trait_names = Some(context.parameter_impl_trait_names(position));
+    let mut parameter_impl_trait_cursor = Some(context.impl_trait_cursor_for_parameter(position));
     let mut output = String::new();
     format_type_inner(
         context,
         type_,
         false,
-        &mut parameter_impl_trait_names,
+        &mut parameter_impl_trait_cursor,
         &mut output,
     );
-    parameter_impl_trait_names
+    parameter_impl_trait_cursor
         .as_ref()
         .expect("parameter impl Trait cursor disappeared")
         .assert_finished();
@@ -38,13 +37,13 @@ pub(super) fn format_parameter_type<'a>(
 ///
 /// In non-parameters, `impl Trait` is normalized to an opaque type, not a synthetic generic type.
 pub(super) fn format_type<'a>(context: &FnNormalizationContext<'a>, type_: &'a Type) -> String {
-    let mut parameter_impl_trait_names = None;
+    let mut parameter_impl_trait_cursor = None;
     let mut output = String::new();
     format_type_inner(
         context,
         type_,
         false,
-        &mut parameter_impl_trait_names,
+        &mut parameter_impl_trait_cursor,
         &mut output,
     );
     output
@@ -54,12 +53,12 @@ fn format_type_inner<'a>(
     context: &FnNormalizationContext<'a>,
     type_: &'a Type,
     wrap_before_bounds: bool,
-    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
+    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor<'_>>,
     output: &mut String,
 ) {
     match type_ {
         Type::ResolvedPath(path) => {
-            format_path(context, path, false, parameter_impl_trait_names, output);
+            format_path(context, path, false, parameter_impl_trait_cursor, output);
         }
         Type::DynTrait(dyn_trait) => {
             if wrap_before_bounds {
@@ -76,7 +75,7 @@ fn format_type_inner<'a>(
                         context,
                         poly_trait,
                         dyn_trait.traits.len() + usize::from(dyn_trait.lifetime.is_some()) > 1,
-                        parameter_impl_trait_names,
+                        parameter_impl_trait_cursor,
                         &mut formatted,
                     );
                     formatted
@@ -114,31 +113,26 @@ fn format_type_inner<'a>(
             // Function-pointer ABI and safety are part of the type being
             // normalized, unlike ABI and safety on the containing function.
             let pointer_context = context.with_params(&pointer.generic_params);
-            format_scoped_generic_params(
-                &pointer_context,
-                &pointer.generic_params,
-                parameter_impl_trait_names,
-                output,
-            );
+            format_scoped_generic_params(&pointer_context, &pointer.generic_params, output);
             format_function_header(&pointer.header, output);
             output.push_str("fn");
             format_function_signature(
                 &pointer_context,
                 &pointer.sig,
                 wrap_before_bounds,
-                parameter_impl_trait_names,
+                parameter_impl_trait_cursor,
                 output,
             );
         }
-        Type::Tuple(types) => format_tuple(context, types, parameter_impl_trait_names, output),
+        Type::Tuple(types) => format_tuple(context, types, parameter_impl_trait_cursor, output),
         Type::Slice(type_) => {
             output.push('[');
-            format_type_inner(context, type_, false, parameter_impl_trait_names, output);
+            format_type_inner(context, type_, false, parameter_impl_trait_cursor, output);
             output.push(']');
         }
         Type::Array { type_, len } => {
             output.push('[');
-            format_type_inner(context, type_, false, parameter_impl_trait_names, output);
+            format_type_inner(context, type_, false, parameter_impl_trait_cursor, output);
             output.push_str("; ");
             let len = context.names().const_expr(len);
             output.push_str(len.as_ref());
@@ -146,7 +140,7 @@ fn format_type_inner<'a>(
         }
         Type::Pat { .. } => unimplemented!("Type::Pat is unstable"),
         Type::ImplTrait(bounds) => {
-            if let Some(names) = parameter_impl_trait_names.as_mut() {
+            if let Some(names) = parameter_impl_trait_cursor.as_mut() {
                 // We're in parameter mode, output a synthetic generic.
                 output.push_str(names.next());
             } else {
@@ -155,7 +149,7 @@ fn format_type_inner<'a>(
                     output.push('(');
                 }
                 output.push_str("impl ");
-                format_bounds(context, bounds, parameter_impl_trait_names, output);
+                format_bounds(context, bounds, parameter_impl_trait_cursor, output);
                 if wrap_before_bounds {
                     output.push(')');
                 }
@@ -174,7 +168,7 @@ fn format_type_inner<'a>(
                 context,
                 type_,
                 wrap_before_bounds || needs_parens_before_bounds(type_),
-                parameter_impl_trait_names,
+                parameter_impl_trait_cursor,
                 output,
             );
         }
@@ -196,7 +190,7 @@ fn format_type_inner<'a>(
                 context,
                 type_,
                 wrap_before_bounds || needs_parens_before_bounds(type_),
-                parameter_impl_trait_names,
+                parameter_impl_trait_cursor,
                 output,
             );
         }
@@ -212,7 +206,7 @@ fn format_type_inner<'a>(
                         context,
                         self_type,
                         false,
-                        parameter_impl_trait_names,
+                        parameter_impl_trait_cursor,
                         output,
                     );
                 } else {
@@ -221,11 +215,11 @@ fn format_type_inner<'a>(
                         context,
                         self_type,
                         false,
-                        parameter_impl_trait_names,
+                        parameter_impl_trait_cursor,
                         output,
                     );
                     output.push_str(" as ");
-                    format_path(context, trait_, false, parameter_impl_trait_names, output);
+                    format_path(context, trait_, false, parameter_impl_trait_cursor, output);
                     output.push('>');
                 }
             } else {
@@ -233,7 +227,7 @@ fn format_type_inner<'a>(
                     context,
                     self_type,
                     false,
-                    parameter_impl_trait_names,
+                    parameter_impl_trait_cursor,
                     output,
                 );
             }
@@ -241,7 +235,7 @@ fn format_type_inner<'a>(
             output.push_str("::");
             output.push_str(name);
             if let Some(args) = args.as_deref() {
-                format_generic_args(context, args, false, parameter_impl_trait_names, output);
+                format_generic_args(context, args, false, parameter_impl_trait_cursor, output);
             }
         }
     }
@@ -250,14 +244,14 @@ fn format_type_inner<'a>(
 fn format_tuple<'a>(
     context: &FnNormalizationContext<'a>,
     types: &'a [Type],
-    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
+    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor<'_>>,
     output: &mut String,
 ) {
     match types {
         [] => output.push_str("()"),
         [type_] => {
             output.push('(');
-            format_type_inner(context, type_, false, parameter_impl_trait_names, output);
+            format_type_inner(context, type_, false, parameter_impl_trait_cursor, output);
             output.push_str(",)");
         }
         _ => {
@@ -266,7 +260,7 @@ fn format_tuple<'a>(
                 if index != 0 {
                     output.push_str(", ");
                 }
-                format_type_inner(context, type_, false, parameter_impl_trait_names, output);
+                format_type_inner(context, type_, false, parameter_impl_trait_cursor, output);
             }
             output.push(')');
         }
@@ -277,21 +271,16 @@ fn format_poly_trait<'a>(
     context: &FnNormalizationContext<'a>,
     poly_trait: &'a rustdoc_types::PolyTrait,
     wrap_before_bounds: bool,
-    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
+    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor<'_>>,
     output: &mut String,
 ) {
     let context = context.with_params(&poly_trait.generic_params);
-    format_scoped_generic_params(
-        &context,
-        &poly_trait.generic_params,
-        parameter_impl_trait_names,
-        output,
-    );
+    format_scoped_generic_params(&context, &poly_trait.generic_params, output);
     format_path(
         &context,
         &poly_trait.trait_,
         wrap_before_bounds,
-        parameter_impl_trait_names,
+        parameter_impl_trait_cursor,
         output,
     );
 }
@@ -300,16 +289,16 @@ fn format_path<'a>(
     context: &FnNormalizationContext<'a>,
     path: &'a rustdoc_types::Path,
     wrap_args_before_bounds: bool,
-    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
+    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor<'_>>,
     output: &mut String,
 ) {
-    output.push_str(&paths::normalized_path(context, path));
+    output.push_str(&paths::normalized_path(context.crate_(), path));
     if let Some(args) = path.args.as_deref() {
         format_generic_args(
             context,
             args,
             wrap_args_before_bounds,
-            parameter_impl_trait_names,
+            parameter_impl_trait_cursor,
             output,
         );
     }
@@ -319,7 +308,7 @@ fn format_generic_args<'a>(
     context: &FnNormalizationContext<'a>,
     args: &'a rustdoc_types::GenericArgs,
     wrap_output_before_bounds: bool,
-    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
+    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor<'_>>,
     output: &mut String,
 ) {
     match args {
@@ -334,33 +323,35 @@ fn format_generic_args<'a>(
                 if needs_separator {
                     output.push_str(", ");
                 }
-                format_generic_arg(context, arg, parameter_impl_trait_names, output);
+                format_generic_arg(context, arg, parameter_impl_trait_cursor, output);
                 needs_separator = true;
             }
 
-            let mut constraints = constraints.iter().collect::<Vec<_>>();
-            constraints.sort_unstable_by(|a, b| a.name.cmp(&b.name));
+            let mut constraints = constraints
+                .iter()
+                .map(|constraint| {
+                    let mut formatted = String::new();
+                    format_assoc_item_constraint(
+                        context,
+                        constraint,
+                        parameter_impl_trait_cursor,
+                        &mut formatted,
+                    );
+                    formatted
+                })
+                .collect::<Vec<_>>();
+            constraints.sort_unstable();
             if !constraints.is_empty() {
                 if needs_separator {
                     output.push_str(", ");
                 }
                 let mut constraints_iter = constraints.iter();
                 if let Some(constraint) = constraints_iter.next() {
-                    format_assoc_item_constraint(
-                        context,
-                        constraint,
-                        parameter_impl_trait_names,
-                        output,
-                    );
+                    output.push_str(constraint);
                 }
                 for constraint in constraints_iter {
                     output.push_str(", ");
-                    format_assoc_item_constraint(
-                        context,
-                        constraint,
-                        parameter_impl_trait_names,
-                        output,
-                    );
+                    output.push_str(constraint);
                 }
             }
             output.push('>');
@@ -374,7 +365,7 @@ fn format_generic_args<'a>(
                 if index != 0 {
                     output.push_str(", ");
                 }
-                format_type_inner(context, type_, false, parameter_impl_trait_names, output);
+                format_type_inner(context, type_, false, parameter_impl_trait_cursor, output);
             }
             output.push(')');
 
@@ -384,7 +375,7 @@ fn format_generic_args<'a>(
                     context,
                     return_type,
                     wrap_output_before_bounds,
-                    parameter_impl_trait_names,
+                    parameter_impl_trait_cursor,
                     output,
                 );
             }
@@ -396,7 +387,7 @@ fn format_generic_args<'a>(
 fn format_generic_arg<'a>(
     context: &FnNormalizationContext<'a>,
     arg: &'a GenericArg,
-    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
+    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor<'_>>,
     output: &mut String,
 ) {
     match arg {
@@ -405,7 +396,7 @@ fn format_generic_arg<'a>(
             output.push_str(lifetime.as_ref());
         }
         GenericArg::Type(type_) => {
-            format_type_inner(context, type_, false, parameter_impl_trait_names, output);
+            format_type_inner(context, type_, false, parameter_impl_trait_cursor, output);
         }
         GenericArg::Const(constant) => format_constant(context, constant, output),
         GenericArg::Infer => output.push('_'),
@@ -415,22 +406,22 @@ fn format_generic_arg<'a>(
 fn format_assoc_item_constraint<'a>(
     context: &FnNormalizationContext<'a>,
     constraint: &'a AssocItemConstraint,
-    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
+    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor<'_>>,
     output: &mut String,
 ) {
     output.push_str(&constraint.name);
     if let Some(args) = constraint.args.as_deref() {
-        format_generic_args(context, args, false, parameter_impl_trait_names, output);
+        format_generic_args(context, args, false, parameter_impl_trait_cursor, output);
     }
 
     match &constraint.binding {
         AssocItemConstraintKind::Constraint(bounds) => {
             output.push_str(": ");
-            format_bounds(context, bounds, parameter_impl_trait_names, output);
+            format_bounds(context, bounds, parameter_impl_trait_cursor, output);
         }
         AssocItemConstraintKind::Equality(term) => {
             output.push_str(" = ");
-            format_term(context, term, parameter_impl_trait_names, output);
+            format_term(context, term, parameter_impl_trait_cursor, output);
         }
     }
 }
@@ -438,7 +429,7 @@ fn format_assoc_item_constraint<'a>(
 fn format_bounds<'a>(
     context: &FnNormalizationContext<'a>,
     bounds: &'a [GenericBound],
-    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
+    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor<'_>>,
     output: &mut String,
 ) {
     let mut bounds = bounds
@@ -449,7 +440,7 @@ fn format_bounds<'a>(
                 context,
                 bound,
                 bounds.len() > 1,
-                parameter_impl_trait_names,
+                parameter_impl_trait_cursor,
                 &mut formatted,
             );
             formatted
@@ -470,7 +461,7 @@ fn format_generic_bound<'a>(
     context: &FnNormalizationContext<'a>,
     bound: &'a GenericBound,
     wrap_before_or_after_bounds: bool,
-    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
+    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor<'_>>,
     output: &mut String,
 ) {
     match bound {
@@ -480,12 +471,7 @@ fn format_generic_bound<'a>(
             modifier,
         } => {
             let context = context.with_params(generic_params);
-            format_scoped_generic_params(
-                &context,
-                generic_params,
-                parameter_impl_trait_names,
-                output,
-            );
+            format_scoped_generic_params(&context, generic_params, output);
             match modifier {
                 TraitBoundModifier::None => {}
                 TraitBoundModifier::Maybe => output.push('?'),
@@ -495,7 +481,7 @@ fn format_generic_bound<'a>(
                 &context,
                 trait_,
                 wrap_before_or_after_bounds,
-                parameter_impl_trait_names,
+                parameter_impl_trait_cursor,
                 output,
             );
         }
@@ -528,7 +514,6 @@ fn format_generic_bound<'a>(
 fn format_scoped_generic_params<'a>(
     context: &FnNormalizationContext<'a>,
     params: &'a [GenericParamDef],
-    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
     output: &mut String,
 ) {
     if params.is_empty() {
@@ -540,7 +525,7 @@ fn format_scoped_generic_params<'a>(
         if index != 0 {
             output.push_str(", ");
         }
-        format_generic_param_def(context, param, parameter_impl_trait_names, output);
+        format_generic_param_def(context, param, output);
     }
     output.push_str("> ");
 }
@@ -548,7 +533,6 @@ fn format_scoped_generic_params<'a>(
 fn format_generic_param_def<'a>(
     context: &FnNormalizationContext<'a>,
     param: &'a GenericParamDef,
-    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
     output: &mut String,
 ) {
     match &param.kind {
@@ -557,15 +541,18 @@ fn format_generic_param_def<'a>(
             output.push_str(lifetime.as_ref());
         }
         GenericParamDefKind::Type { .. } => {
-            let name = context.names().type_name(&param.name);
-            output.push_str(name.as_ref());
+            // These generic params come from higher-ranked `for<...>` binders
+            // on `fn` pointers or trait bounds. As of Rust 1.96, hypothetical
+            // `for<T>` binders are rejected, so there is no normalized
+            // signature text to produce for such a parameter.
+            unreachable!("found type generic param definition in HRTB position: {param:?}");
         }
-        GenericParamDefKind::Const { type_, .. } => {
-            output.push_str("const ");
-            let name = context.names().const_name(&param.name);
-            output.push_str(name.as_ref());
-            output.push_str(": ");
-            format_type_inner(context, type_, false, parameter_impl_trait_names, output);
+        GenericParamDefKind::Const { .. } => {
+            // These generic params come from higher-ranked `for<...>` binders
+            // on `fn` pointers or trait bounds. As of Rust 1.96, hypothetical
+            // `for<const N: usize>` binders are rejected, so there is no
+            // normalized signature text to produce for such a parameter.
+            unreachable!("found const generic param definition in HRTB position: {param:?}");
         }
     }
 }
@@ -574,7 +561,7 @@ fn format_function_signature<'a>(
     context: &FnNormalizationContext<'a>,
     signature: &'a rustdoc_types::FunctionSignature,
     wrap_output_before_bounds: bool,
-    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
+    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor<'_>>,
     output: &mut String,
 ) {
     output.push('(');
@@ -583,7 +570,7 @@ fn format_function_signature<'a>(
         if needs_separator {
             output.push_str(", ");
         }
-        format_type_inner(context, type_, false, parameter_impl_trait_names, output);
+        format_type_inner(context, type_, false, parameter_impl_trait_cursor, output);
         needs_separator = true;
     }
     if signature.is_c_variadic {
@@ -600,7 +587,7 @@ fn format_function_signature<'a>(
             context,
             return_type,
             wrap_output_before_bounds,
-            parameter_impl_trait_names,
+            parameter_impl_trait_cursor,
             output,
         );
     }
@@ -608,10 +595,16 @@ fn format_function_signature<'a>(
 
 fn format_function_header(header: &FunctionHeader, output: &mut String) {
     if header.is_const {
-        output.push_str("const ");
+        // As of Rust 1.96, function pointer types cannot use hypothetical
+        // `const fn(...)` syntax, so there is no normalized signature text to
+        // produce for this header shape.
+        unreachable!("found const function pointer header: {header:?}");
     }
     if header.is_async {
-        output.push_str("async ");
+        // As of Rust 1.96, function pointer types cannot use hypothetical
+        // `async fn(...)` syntax, so there is no normalized signature text to
+        // produce for this header shape.
+        unreachable!("found async function pointer header: {header:?}");
     }
     if header.is_unsafe {
         output.push_str("unsafe ");
@@ -657,14 +650,19 @@ fn format_constant<'a>(
 fn format_term<'a>(
     context: &FnNormalizationContext<'a>,
     term: &'a Term,
-    parameter_impl_trait_names: &mut Option<ParameterImplTraitNames<'_>>,
+    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor<'_>>,
     output: &mut String,
 ) {
     match term {
         Term::Type(type_) => {
-            format_type_inner(context, type_, false, parameter_impl_trait_names, output);
+            format_type_inner(context, type_, false, parameter_impl_trait_cursor, output);
         }
-        Term::Constant(constant) => format_constant(context, constant, output),
+        Term::Constant(constant) => {
+            // As of Rust 1.96, associated const equality constraints such as
+            // `T: Trait<N = 3>` are incomplete and rejected, so there is no
+            // normalized signature text to produce for such a term.
+            unreachable!("found associated const equality constraint term: {constant:?}");
+        }
     }
 }
 

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -9587,6 +9587,10 @@ fn function_parameters() {
             params: vec!["value".into(), "values".into()],
         },
         Output {
+            name: "lifetime_const_path_args".into(),
+            params: vec!["value".into()],
+        },
+        Output {
             name: "composite_types".into(),
             params: vec!["tuple".into(), "raw".into()],
         },
@@ -9601,6 +9605,14 @@ fn function_parameters() {
         Output {
             name: "dyn_trait_lifetime".into(),
             params: vec!["value".into()],
+        },
+        Output {
+            name: "dyn_fn_two_arg".into(),
+            params: vec!["value".into()],
+        },
+        Output {
+            name: "dyn_fn_pointer_output".into(),
+            params: vec!["callback".into(), "callback_with_lifetime".into()],
         },
         Output {
             name: "impl_trait_param".into(),
@@ -9624,8 +9636,110 @@ fn function_parameters() {
             params: vec!["value".into(), "other".into()],
         },
         Output {
+            name: "impl_trait_numbering_baseline".into(),
+            params: vec!["first".into(), "second".into()],
+        },
+        Output {
+            name: "impl_trait_numbering_nested_first".into(),
+            params: vec!["first".into(), "second".into()],
+        },
+        Output {
+            name: "impl_trait_numbering_nested_second".into(),
+            params: vec!["first".into(), "second".into()],
+        },
+        Output {
+            name: "multiple_impl_traits_single_param".into(),
+            params: vec!["pair".into(), "later".into()],
+        },
+        Output {
+            name: "maybe_sized_impl_trait".into(),
+            params: vec!["value".into()],
+        },
+        Output {
+            name: "impl_fn_bound".into(),
+            params: vec!["value".into()],
+        },
+        Output {
+            name: "impl_fn_lifetime_bound".into(),
+            params: vec!["value".into()],
+        },
+        Output {
+            name: "impl_fn_two_args_bound".into(),
+            params: vec!["value".into()],
+        },
+        Output {
+            name: "impl_trait_lifetime_return".into(),
+            params: vec!["value".into()],
+        },
+        Output {
+            name: "abi_variant_fn_pointers".into(),
+            params: vec![
+                "c_unwind".into(),
+                "system".into(),
+                "system_unwind".into(),
+                "win64".into(),
+                "sysv64".into(),
+            ],
+        },
+        Output {
+            name: "dyn_pointer_and_mut_ref".into(),
+            params: vec!["pointer".into(), "borrowed".into()],
+        },
+        Output {
+            name: "borrowed_opaque_return".into(),
+            params: vec![],
+        },
+        Output {
+            name: "raw_pointer_opaque_return".into(),
+            params: vec![],
+        },
+        Output {
+            name: "fn_bound_pointer_to_dyn_return".into(),
+            params: vec![],
+        },
+        Output {
+            name: "raw_pointer_impl_trait".into(),
+            params: vec!["value".into(), "mutable".into()],
+        },
+        Output {
+            name: "slice_and_array_impl_trait".into(),
+            params: vec!["value".into(), "array".into()],
+        },
+        Output {
+            name: "unit_and_single_tuple".into(),
+            params: vec!["unit".into(), "single".into()],
+        },
+        Output {
+            name: "higher_ranked_fn_pointer".into(),
+            params: vec!["callback".into()],
+        },
+        Output {
+            name: "unsafe_c_variadic_pointer".into(),
+            params: vec!["callback".into()],
+        },
+        Output {
             name: "impl_trait_return".into(),
             params: vec![],
+        },
+        Output {
+            name: "precise_capture_return".into(),
+            params: vec!["value".into()],
+        },
+        Output {
+            name: "precise_capture_lifetime".into(),
+            params: vec!["value".into()],
+        },
+        Output {
+            name: "precise_capture_const".into(),
+            params: vec!["value".into()],
+        },
+        Output {
+            name: "qualified_path_assoc_arg".into(),
+            params: vec!["pair".into()],
+        },
+        Output {
+            name: "generic_assoc_arg".into(),
+            params: vec!["pair".into()],
         },
         Output {
             name: "add_method".into(),
@@ -9652,8 +9766,20 @@ fn function_parameters() {
             params: vec!["self".into()],
         },
         Output {
+            name: "fn_output_dyn".into(),
+            params: vec!["self".into()],
+        },
+        Output {
+            name: "fn_output_dyn_single_bound".into(),
+            params: vec!["self".into()],
+        },
+        Output {
             name: "combine_trait".into(),
             params: vec!["self".into(), "owner".into(), "method".into()],
+        },
+        Output {
+            name: "self_qualified".into(),
+            params: vec!["pair".into()],
         },
         Output {
             name: "default_combine".into(),
@@ -9789,6 +9915,10 @@ fn function_return_value() {
             is_unit: false,
         },
         Output {
+            name: "lifetime_const_path_args".into(),
+            is_unit: true,
+        },
+        Output {
             name: "composite_types".into(),
             is_unit: false,
         },
@@ -9803,6 +9933,14 @@ fn function_return_value() {
         Output {
             name: "dyn_trait_lifetime".into(),
             is_unit: false,
+        },
+        Output {
+            name: "dyn_fn_two_arg".into(),
+            is_unit: true,
+        },
+        Output {
+            name: "dyn_fn_pointer_output".into(),
+            is_unit: true,
         },
         Output {
             name: "impl_trait_param".into(),
@@ -9821,8 +9959,104 @@ fn function_return_value() {
             is_unit: false,
         },
         Output {
+            name: "impl_trait_numbering_baseline".into(),
+            is_unit: true,
+        },
+        Output {
+            name: "impl_trait_numbering_nested_first".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "impl_trait_numbering_nested_second".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "multiple_impl_traits_single_param".into(),
+            is_unit: true,
+        },
+        Output {
+            name: "maybe_sized_impl_trait".into(),
+            is_unit: true,
+        },
+        Output {
+            name: "impl_fn_bound".into(),
+            is_unit: true,
+        },
+        Output {
+            name: "impl_fn_lifetime_bound".into(),
+            is_unit: true,
+        },
+        Output {
+            name: "impl_fn_two_args_bound".into(),
+            is_unit: true,
+        },
+        Output {
+            name: "impl_trait_lifetime_return".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "abi_variant_fn_pointers".into(),
+            is_unit: true,
+        },
+        Output {
+            name: "dyn_pointer_and_mut_ref".into(),
+            is_unit: true,
+        },
+        Output {
+            name: "borrowed_opaque_return".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "raw_pointer_opaque_return".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "fn_bound_pointer_to_dyn_return".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "raw_pointer_impl_trait".into(),
+            is_unit: true,
+        },
+        Output {
+            name: "slice_and_array_impl_trait".into(),
+            is_unit: true,
+        },
+        Output {
+            name: "unit_and_single_tuple".into(),
+            is_unit: true,
+        },
+        Output {
+            name: "higher_ranked_fn_pointer".into(),
+            is_unit: true,
+        },
+        Output {
+            name: "unsafe_c_variadic_pointer".into(),
+            is_unit: true,
+        },
+        Output {
             name: "impl_trait_return".into(),
             is_unit: false,
+        },
+        Output {
+            name: "precise_capture_return".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "precise_capture_lifetime".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "precise_capture_const".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "qualified_path_assoc_arg".into(),
+            is_unit: true,
+        },
+        Output {
+            name: "generic_assoc_arg".into(),
+            is_unit: true,
         },
         Output {
             name: "add_method".into(),
@@ -9849,8 +10083,20 @@ fn function_return_value() {
             is_unit: true,
         },
         Output {
+            name: "fn_output_dyn".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "fn_output_dyn_single_bound".into(),
+            is_unit: false,
+        },
+        Output {
             name: "combine_trait".into(),
             is_unit: false,
+        },
+        Output {
+            name: "self_qualified".into(),
+            is_unit: true,
         },
         Output {
             name: "default_combine".into(),
@@ -9977,6 +10223,12 @@ fn function_parameter_normalized_type_signatures() {
                 .into(),
         },
         Output {
+            name: "lifetime_const_path_args".into(),
+            position: 1,
+            param_name: "value".into(),
+            signature: "::function_params_and_return_value::LifetimeConst<'a, C1>".into(),
+        },
+        Output {
             name: "composite_types".into(),
             position: 1,
             param_name: "tuple".into(),
@@ -10008,10 +10260,32 @@ fn function_parameter_normalized_type_signatures() {
                 .into(),
         },
         Output {
+            name: "dyn_fn_two_arg".into(),
+            position: 1,
+            param_name: "value".into(),
+            signature: "::alloc::boxed::Box<dyn ::core::ops::function::Fn(u8, u16) -> u32>".into(),
+        },
+        Output {
+            name: "dyn_fn_pointer_output".into(),
+            position: 1,
+            param_name: "callback".into(),
+            signature:
+                "::alloc::boxed::Box<dyn ::core::ops::function::Fn() -> *const dyn ::core::marker::Send>"
+                    .into(),
+        },
+        Output {
+            name: "dyn_fn_pointer_output".into(),
+            position: 2,
+            param_name: "callback_with_lifetime".into(),
+            signature:
+                "::alloc::boxed::Box<dyn ::core::ops::function::Fn() -> *const (dyn ::core::marker::Send) + 'static>"
+                    .into(),
+        },
+        Output {
             name: "impl_trait_param".into(),
             position: 1,
             param_name: "value".into(),
-            signature: "IT1".into(),
+            signature: "IT1_1".into(),
         },
         Output {
             name: "generic_and_impl_trait_params".into(),
@@ -10023,13 +10297,13 @@ fn function_parameter_normalized_type_signatures() {
             name: "generic_and_impl_trait_params".into(),
             position: 2,
             param_name: "first".into(),
-            signature: "IT2".into(),
+            signature: "IT2_1".into(),
         },
         Output {
             name: "generic_and_impl_trait_params".into(),
             position: 3,
             param_name: "second".into(),
-            signature: "IT3".into(),
+            signature: "IT3_1".into(),
         },
         Output {
             name: "nested_impl_trait_params".into(),
@@ -10041,31 +10315,230 @@ fn function_parameter_normalized_type_signatures() {
             name: "nested_impl_trait_params".into(),
             position: 2,
             param_name: "borrowed".into(),
-            signature: "&IT2".into(),
+            signature: "&IT2_1".into(),
         },
         Output {
             name: "nested_impl_trait_params".into(),
             position: 3,
             param_name: "values".into(),
-            signature: "::alloc::vec::Vec<IT3>".into(),
+            signature: "::alloc::vec::Vec<IT3_1>".into(),
         },
         Output {
             name: "nested_impl_trait_params".into(),
             position: 4,
             param_name: "nested_tuple".into(),
-            signature: "(IT4, T1)".into(),
+            signature: "(IT4_1, T1)".into(),
         },
         Output {
             name: "nested_assoc_impl_trait_param".into(),
             position: 1,
             param_name: "value".into(),
-            signature: "IT2".into(),
+            signature: "IT1_2".into(),
         },
         Output {
             name: "nested_assoc_impl_trait_param".into(),
             position: 2,
             param_name: "other".into(),
-            signature: "IT3".into(),
+            signature: "IT2_1".into(),
+        },
+        Output {
+            name: "impl_trait_numbering_baseline".into(),
+            position: 1,
+            param_name: "first".into(),
+            signature: "IT1_1".into(),
+        },
+        Output {
+            name: "impl_trait_numbering_baseline".into(),
+            position: 2,
+            param_name: "second".into(),
+            signature: "IT2_1".into(),
+        },
+        Output {
+            name: "impl_trait_numbering_nested_first".into(),
+            position: 1,
+            param_name: "first".into(),
+            signature: "IT1_2".into(),
+        },
+        Output {
+            name: "impl_trait_numbering_nested_first".into(),
+            position: 2,
+            param_name: "second".into(),
+            signature: "IT2_1".into(),
+        },
+        Output {
+            name: "impl_trait_numbering_nested_second".into(),
+            position: 1,
+            param_name: "first".into(),
+            signature: "IT1_1".into(),
+        },
+        Output {
+            name: "impl_trait_numbering_nested_second".into(),
+            position: 2,
+            param_name: "second".into(),
+            signature: "IT2_2".into(),
+        },
+        Output {
+            name: "multiple_impl_traits_single_param".into(),
+            position: 1,
+            param_name: "pair".into(),
+            signature: "(IT1_1, IT1_2)".into(),
+        },
+        Output {
+            name: "multiple_impl_traits_single_param".into(),
+            position: 2,
+            param_name: "later".into(),
+            signature: "IT2_1".into(),
+        },
+        Output {
+            name: "maybe_sized_impl_trait".into(),
+            position: 1,
+            param_name: "value".into(),
+            signature: "&IT1_1".into(),
+        },
+        Output {
+            name: "impl_fn_bound".into(),
+            position: 1,
+            param_name: "value".into(),
+            signature: "IT1_1".into(),
+        },
+        Output {
+            name: "impl_fn_lifetime_bound".into(),
+            position: 1,
+            param_name: "value".into(),
+            signature: "IT1_1".into(),
+        },
+        Output {
+            name: "impl_fn_two_args_bound".into(),
+            position: 1,
+            param_name: "value".into(),
+            signature: "IT1_1".into(),
+        },
+        Output {
+            name: "impl_trait_lifetime_return".into(),
+            position: 1,
+            param_name: "value".into(),
+            signature: "&'a u8".into(),
+        },
+        Output {
+            name: "abi_variant_fn_pointers".into(),
+            position: 1,
+            param_name: "c_unwind".into(),
+            signature: "extern \"C-unwind\" fn(u8) -> u8".into(),
+        },
+        Output {
+            name: "abi_variant_fn_pointers".into(),
+            position: 2,
+            param_name: "system".into(),
+            signature: "extern \"system\" fn(u8) -> u8".into(),
+        },
+        Output {
+            name: "abi_variant_fn_pointers".into(),
+            position: 3,
+            param_name: "system_unwind".into(),
+            signature: "extern \"system-unwind\" fn(u8) -> u8".into(),
+        },
+        Output {
+            name: "abi_variant_fn_pointers".into(),
+            position: 4,
+            param_name: "win64".into(),
+            signature: "extern \"win64\" fn(u8) -> u8".into(),
+        },
+        Output {
+            name: "abi_variant_fn_pointers".into(),
+            position: 5,
+            param_name: "sysv64".into(),
+            signature: "extern \"sysv64\" fn(u8) -> u8".into(),
+        },
+        Output {
+            name: "dyn_pointer_and_mut_ref".into(),
+            position: 1,
+            param_name: "pointer".into(),
+            signature: "*const (dyn ::core::marker::Send + ::core::marker::Sync + 'a)".into(),
+        },
+        Output {
+            name: "dyn_pointer_and_mut_ref".into(),
+            position: 2,
+            param_name: "borrowed".into(),
+            signature: "&'a mut (dyn ::core::marker::Send + ::core::marker::Sync)".into(),
+        },
+        Output {
+            name: "raw_pointer_impl_trait".into(),
+            position: 1,
+            param_name: "value".into(),
+            signature: "*const IT1_1".into(),
+        },
+        Output {
+            name: "raw_pointer_impl_trait".into(),
+            position: 2,
+            param_name: "mutable".into(),
+            signature: "*mut IT2_1".into(),
+        },
+        Output {
+            name: "slice_and_array_impl_trait".into(),
+            position: 1,
+            param_name: "value".into(),
+            signature: "&[IT1_1]".into(),
+        },
+        Output {
+            name: "slice_and_array_impl_trait".into(),
+            position: 2,
+            param_name: "array".into(),
+            signature: "[IT2_1; 3]".into(),
+        },
+        Output {
+            name: "unit_and_single_tuple".into(),
+            position: 1,
+            param_name: "unit".into(),
+            signature: "()".into(),
+        },
+        Output {
+            name: "unit_and_single_tuple".into(),
+            position: 2,
+            param_name: "single".into(),
+            signature: "(IT2_1,)".into(),
+        },
+        Output {
+            name: "higher_ranked_fn_pointer".into(),
+            position: 1,
+            param_name: "callback".into(),
+            signature: "for<'a> fn(&'a u8) -> &'a u8".into(),
+        },
+        Output {
+            name: "unsafe_c_variadic_pointer".into(),
+            position: 1,
+            param_name: "callback".into(),
+            signature: "unsafe extern \"C\" fn(u8, ...) -> u8".into(),
+        },
+        Output {
+            name: "precise_capture_return".into(),
+            position: 1,
+            param_name: "value".into(),
+            signature: "T1".into(),
+        },
+        Output {
+            name: "precise_capture_lifetime".into(),
+            position: 1,
+            param_name: "value".into(),
+            signature: "&'a T1".into(),
+        },
+        Output {
+            name: "precise_capture_const".into(),
+            position: 1,
+            param_name: "value".into(),
+            signature: "[u8; C1]".into(),
+        },
+        Output {
+            name: "qualified_path_assoc_arg".into(),
+            position: 1,
+            param_name: "pair".into(),
+            signature:
+                "(<T1 as ::function_params_and_return_value::Provider>::Assoc<IT1_1>, IT1_2)".into(),
+        },
+        Output {
+            name: "generic_assoc_arg".into(),
+            position: 1,
+            param_name: "pair".into(),
+            signature: "(T1::Assoc<IT1_1>, IT1_2)".into(),
         },
     ];
     expected_results.sort_unstable();
@@ -10080,8 +10553,13 @@ fn function_parameter_normalized_type_signatures() {
     similar_asserts::assert_eq!(expected_results, results);
 }
 
+/// Query every function in `assoc_constraint_order` so new fixture examples
+/// require an expected output here by default. Associated-item constraints are
+/// sorted before parameter-position `impl Trait` names are assigned, while
+/// `impl Trait` occurrences in generic bounds are consumed but do not appear in
+/// the normalized parameter type signature.
 #[test]
-fn function_parameter_normalized_type_signature_sorts_assoc_constraints_before_impl_trait_names() {
+fn function_parameter_normalized_type_signature_handles_assoc_constraint_impl_trait() {
     get_test_data!(data, assoc_constraint_order);
     let adapter = RustdocAdapter::new(&data, None);
     let adapter = Arc::new(&adapter);
@@ -10091,7 +10569,7 @@ fn function_parameter_normalized_type_signature_sorts_assoc_constraints_before_i
     Crate {
         item {
             ... on Function {
-                name @filter(op: "one_of", value: ["$functions"]) @output
+                name @output
 
                 parameter {
                     normalized_type_signature {
@@ -10103,12 +10581,176 @@ fn function_parameter_normalized_type_signature_sorts_assoc_constraints_before_i
     }
 }
 "#;
-    let variables = btreemap! {
-        "functions" => FieldValue::List(vec![
-            FieldValue::String("a_then_b".into()),
-            FieldValue::String("b_then_a".into()),
-        ].into()),
-    };
+    let variables: BTreeMap<&str, bool> = BTreeMap::default();
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        signature: String,
+    }
+
+    let expected_results = vec![
+        Output {
+            name: "a_then_b".into(),
+            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = IT1_1, B = IT1_2>>".into(),
+        },
+        Output {
+            name: "b_then_a".into(),
+            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = IT1_1, B = IT1_2>>".into(),
+        },
+        Output {
+            name: "bound_a_then_b".into(),
+            signature: "T1".into(),
+        },
+        Output {
+            name: "bound_b_then_a".into(),
+            signature: "T1".into(),
+        },
+        Output {
+            name: "same_synthetic_names".into(),
+            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = IT1_1, B = IT1_2>>".into(),
+        },
+        Output {
+            name: "gat_bound_u8_then_u16".into(),
+            signature: "T1".into(),
+        },
+        Output {
+            name: "repeated_gat_bound_u8_then_u16".into(),
+            signature: "T1".into(),
+        },
+        Output {
+            name: "generic_bound_before_input_impl_trait".into(),
+            signature: "IT1_1".into(),
+        },
+        Output {
+            name: "generic_bound_before_input_impl_trait".into(),
+            signature: "T1".into(),
+        },
+        Output {
+            name: "top_level_assoc_bound_counts_hidden_impls".into(),
+            signature: "(IT1_2, IT1_3)".into(),
+        },
+        Output {
+            name: "assoc_constraint_args_count_before_outer_impl".into(),
+            signature: "(IT1_3, IT1_4)".into(),
+        },
+        Output {
+            name: "hrtb_bound_counts_before_later_impl".into(),
+            signature: "(IT1_1, IT1_2)".into(),
+        },
+        Output {
+            name: "hrtb_two_lifetime_bound_counts_before_later_impl".into(),
+            signature: "(IT1_1, IT1_2)".into(),
+        },
+        Output {
+            name: "lifetime_const_generic_arg_counts_before_later_impl".into(),
+            signature: "(IT1_1, IT1_2)".into(),
+        },
+        Output {
+            name: "complex_constraint_a_then_b".into(),
+            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = ::alloc::boxed::Box<dyn for<'b> ::core::ops::function::Fn(&'b u8) -> &'b u8 + 'a>, B = IT1_1>>".into(),
+        },
+        Output {
+            name: "complex_constraint_b_then_a".into(),
+            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = ::alloc::boxed::Box<dyn for<'b> ::core::ops::function::Fn(&'b u8) -> &'b u8 + 'a>, B = IT1_1>>".into(),
+        },
+        Output {
+            name: "constraint_type_shapes".into(),
+            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = (&'a [u8], [u8; C1]), B = IT1_1>>".into(),
+        },
+        Output {
+            name: "constraint_function_pointer".into(),
+            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = fn(u8) -> u8, B = IT1_1>>".into(),
+        },
+        Output {
+            name: "constraint_higher_ranked_function_pointer".into(),
+            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = for<'a> fn(&'a u8) -> &'a u8, B = IT1_1>>".into(),
+        },
+        Output {
+            name: "constraint_two_lifetime_function_pointer".into(),
+            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = for<'a, 'b> fn(&'a u8, &'b u8) -> &'b u8, B = IT1_1>>".into(),
+        },
+        Output {
+            name: "constraint_dyn_fn_trait_two_args".into(),
+            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = ::alloc::boxed::Box<dyn ::core::ops::function::Fn(u8, u16) -> u32>, B = IT1_1>>".into(),
+        },
+        Output {
+            name: "constraint_qualified_path".into(),
+            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = <T1 as ::assoc_constraint_order::Provider>::Assoc<IT1_1>, B = IT1_2>>".into(),
+        },
+        Output {
+            name: "where_bound_after_input_impl_trait".into(),
+            signature: "IT1_1".into(),
+        },
+        Output {
+            name: "where_bound_after_input_impl_trait".into(),
+            signature: "T1".into(),
+        },
+        Output {
+            name: "constraint_multiple_bounds".into(),
+            signature: "IT1_2".into(),
+        },
+        Output {
+            name: "constraint_mutable_reference".into(),
+            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = &'static mut IT1_1, B = IT1_2>>".into(),
+        },
+        Output {
+            name: "constraint_raw_pointers".into(),
+            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = *const IT1_1, B = *mut IT1_2>>".into(),
+        },
+        Output {
+            name: "constraint_slice_and_array".into(),
+            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = &'static [IT1_1], B = [IT1_2; 3]>>".into(),
+        },
+        Output {
+            name: "constraint_single_tuple".into(),
+            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = (IT1_1,), B = IT1_2>>".into(),
+        },
+        Output {
+            name: "constraint_dyn_multi_trait".into(),
+            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = ::alloc::boxed::Box<dyn ::core::marker::Send + ::core::marker::Sync + 'a>, B = IT1_1>>".into(),
+        },
+    ];
+    let mut sorted_expected_results = expected_results.clone();
+    sorted_expected_results.sort_unstable();
+
+    let mut results: Vec<Output> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables)
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    similar_asserts::assert_eq!(sorted_expected_results, results);
+}
+
+#[test]
+fn function_return_normalized_type_signature_handles_assoc_constraint_bound() {
+    get_test_data!(data, assoc_constraint_order);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Function {
+                name @output
+
+                return_value {
+                    normalized_type_signature {
+                        signature @output
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+    let variables: BTreeMap<&str, FieldValue> = BTreeMap::default();
 
     let schema =
         Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
@@ -10119,16 +10761,64 @@ fn function_parameter_normalized_type_signature_sorts_assoc_constraints_before_i
         signature: String,
     }
 
-    let mut expected_results = vec![
-        Output {
-            name: "a_then_b".into(),
-            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = IT1, B = IT2>>".into(),
-        },
-        Output {
-            name: "b_then_a".into(),
-            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = IT1, B = IT2>>".into(),
-        },
+    let unit_return_functions = [
+        "a_then_b",
+        "b_then_a",
+        "bound_a_then_b",
+        "bound_b_then_a",
+        "same_synthetic_names",
+        "gat_bound_u8_then_u16",
+        "repeated_gat_bound_u8_then_u16",
+        "generic_bound_before_input_impl_trait",
+        "top_level_assoc_bound_counts_hidden_impls",
+        "assoc_constraint_args_count_before_outer_impl",
+        "hrtb_bound_counts_before_later_impl",
+        "hrtb_two_lifetime_bound_counts_before_later_impl",
+        "lifetime_const_generic_arg_counts_before_later_impl",
+        "complex_constraint_a_then_b",
+        "complex_constraint_b_then_a",
+        "constraint_type_shapes",
+        "constraint_function_pointer",
+        "constraint_higher_ranked_function_pointer",
+        "constraint_two_lifetime_function_pointer",
+        "constraint_dyn_fn_trait_two_args",
+        "constraint_qualified_path",
+        "where_bound_after_input_impl_trait",
+        "constraint_multiple_bounds",
+        "constraint_raw_pointers",
+        "constraint_slice_and_array",
+        "constraint_mutable_reference",
+        "constraint_single_tuple",
+        "constraint_dyn_multi_trait",
     ];
+
+    let mut expected_results = unit_return_functions
+        .into_iter()
+        .map(|name| Output {
+            name: name.into(),
+            signature: "()".into(),
+        })
+        .chain([
+            Output {
+                name: "return_assoc_constraint_bound".into(),
+                signature:
+                    "impl ::assoc_constraint_order::AssocConstraintOrder<A: ::core::clone::Clone + ::core::marker::Copy, B = u8>"
+                        .into(),
+            },
+            Output {
+                name: "return_generic_assoc_constraint_bound".into(),
+                signature:
+                    "impl ::assoc_constraint_order::GenericAssoc<u8, A: ::core::clone::Clone + ::core::marker::Copy>"
+                        .into(),
+            },
+            Output {
+                name: "return_gat_assoc_constraint_bound".into(),
+                signature:
+                    "impl ::assoc_constraint_order::HasGenericItem<Item<u8>: ::core::clone::Clone + ::core::marker::Copy>"
+                        .into(),
+            },
+        ])
+        .collect::<Vec<_>>();
     expected_results.sort_unstable();
 
     let mut results: Vec<Output> =
@@ -10206,6 +10896,10 @@ fn function_return_normalized_type_signatures() {
                 .into(),
         },
         Output {
+            name: "lifetime_const_path_args".into(),
+            signature: "()".into(),
+        },
+        Output {
             name: "composite_types".into(),
             signature: "(&'a [T1], *mut T1)".into(),
         },
@@ -10221,6 +10915,14 @@ fn function_return_normalized_type_signatures() {
             name: "dyn_trait_lifetime".into(),
             signature: "::alloc::boxed::Box<dyn ::core::marker::Send + ::core::marker::Sync + 'a>"
                 .into(),
+        },
+        Output {
+            name: "dyn_fn_two_arg".into(),
+            signature: "()".into(),
+        },
+        Output {
+            name: "dyn_fn_pointer_output".into(),
+            signature: "()".into(),
         },
         Output {
             name: "impl_trait_param".into(),
@@ -10239,8 +10941,106 @@ fn function_return_normalized_type_signatures() {
             signature: "usize".into(),
         },
         Output {
+            name: "impl_trait_numbering_baseline".into(),
+            signature: "()".into(),
+        },
+        Output {
+            name: "impl_trait_numbering_nested_first".into(),
+            signature: "usize".into(),
+        },
+        Output {
+            name: "impl_trait_numbering_nested_second".into(),
+            signature: "usize".into(),
+        },
+        Output {
+            name: "multiple_impl_traits_single_param".into(),
+            signature: "()".into(),
+        },
+        Output {
+            name: "maybe_sized_impl_trait".into(),
+            signature: "()".into(),
+        },
+        Output {
+            name: "impl_fn_bound".into(),
+            signature: "()".into(),
+        },
+        Output {
+            name: "impl_fn_lifetime_bound".into(),
+            signature: "()".into(),
+        },
+        Output {
+            name: "impl_fn_two_args_bound".into(),
+            signature: "()".into(),
+        },
+        Output {
+            name: "impl_trait_lifetime_return".into(),
+            signature: "impl 'a + ::core::clone::Clone".into(),
+        },
+        Output {
+            name: "abi_variant_fn_pointers".into(),
+            signature: "()".into(),
+        },
+        Output {
+            name: "dyn_pointer_and_mut_ref".into(),
+            signature: "()".into(),
+        },
+        Output {
+            name: "borrowed_opaque_return".into(),
+            signature: "&'static (impl ::core::clone::Clone + ::core::marker::Copy)".into(),
+        },
+        Output {
+            name: "raw_pointer_opaque_return".into(),
+            signature: "*const (impl ::core::clone::Clone + ::core::marker::Copy)".into(),
+        },
+        Output {
+            name: "fn_bound_pointer_to_dyn_return".into(),
+            signature:
+                "impl ::core::clone::Clone + ::core::ops::function::Fn() -> *const (dyn ::core::marker::Send + ::core::marker::Sync)"
+                    .into(),
+        },
+        Output {
+            name: "raw_pointer_impl_trait".into(),
+            signature: "()".into(),
+        },
+        Output {
+            name: "slice_and_array_impl_trait".into(),
+            signature: "()".into(),
+        },
+        Output {
+            name: "unit_and_single_tuple".into(),
+            signature: "()".into(),
+        },
+        Output {
+            name: "higher_ranked_fn_pointer".into(),
+            signature: "()".into(),
+        },
+        Output {
+            name: "unsafe_c_variadic_pointer".into(),
+            signature: "()".into(),
+        },
+        Output {
             name: "impl_trait_return".into(),
             signature: "impl ::core::iter::traits::iterator::Iterator<Item = u8>".into(),
+        },
+        Output {
+            name: "precise_capture_return".into(),
+            signature: "impl ::core::clone::Clone + use<T1>".into(),
+        },
+        Output {
+            name: "precise_capture_lifetime".into(),
+            signature: "impl ::core::clone::Clone + use<'a, T1>".into(),
+        },
+        Output {
+            name: "precise_capture_const".into(),
+            signature: "impl ::core::clone::Clone + use<C1>".into(),
+        },
+        Output {
+            name: "qualified_path_assoc_arg".into(),
+            signature: "()".into(),
+        },
+        Output {
+            name: "generic_assoc_arg".into(),
+            signature: "()".into(),
         },
     ];
     expected_results.sort_unstable();
@@ -10399,6 +11199,18 @@ fn method_normalized_type_signatures_include_parent_generics() {
         "trait_owner" => "GenericTrait",
         "trait_method" => "combine_trait",
     };
+    let provider_trait_variables = btreemap! {
+        "trait_owner" => "Provider",
+        "trait_method" => "self_qualified",
+    };
+    let fn_output_trait_variables = btreemap! {
+        "trait_owner" => "FnOutputTrait",
+        "trait_method" => "fn_output_dyn",
+    };
+    let fn_output_trait_single_bound_variables = btreemap! {
+        "trait_owner" => "FnOutputTrait",
+        "trait_method" => "fn_output_dyn_single_bound",
+    };
     let trait_impl_variables = btreemap! {
         "trait_owner" => "GenericTrait",
         "trait_method" => "combine_trait",
@@ -10481,6 +11293,34 @@ fn method_normalized_type_signatures_include_parent_generics() {
             return_signature: "(T1, T2)".into(),
         },
         Output {
+            owner: "Provider".into(),
+            method_name: "self_qualified".into(),
+            position: 1,
+            param_name: "pair".into(),
+            param_signature: "(Self::Assoc<IT1_1>, IT1_2)".into(),
+            return_signature: "()".into(),
+        },
+        Output {
+            owner: "FnOutputTrait".into(),
+            method_name: "fn_output_dyn".into(),
+            position: 1,
+            param_name: "self".into(),
+            param_signature: "&Self".into(),
+            return_signature:
+                "impl ::core::clone::Clone + ::core::ops::function::Fn() -> (dyn ::core::marker::Send + ::core::marker::Sync)"
+                    .into(),
+        },
+        Output {
+            owner: "FnOutputTrait".into(),
+            method_name: "fn_output_dyn_single_bound".into(),
+            position: 1,
+            param_name: "self".into(),
+            param_signature: "&Self".into(),
+            return_signature:
+                "impl ::core::ops::function::Fn() -> dyn ::core::marker::Send + ::core::marker::Sync"
+                    .into(),
+        },
+        Output {
             owner: "ImplementsGenericTrait".into(),
             method_name: "combine_trait".into(),
             position: 1,
@@ -10537,6 +11377,33 @@ fn method_normalized_type_signatures_include_parent_generics() {
             .chain(
                 trustfall::execute_query(&schema, adapter.clone(), trait_query, trait_variables)
                     .expect("failed to run trait method query"),
+            )
+            .chain(
+                trustfall::execute_query(
+                    &schema,
+                    adapter.clone(),
+                    trait_query,
+                    provider_trait_variables,
+                )
+                .expect("failed to run provider trait method query"),
+            )
+            .chain(
+                trustfall::execute_query(
+                    &schema,
+                    adapter.clone(),
+                    trait_query,
+                    fn_output_trait_variables,
+                )
+                .expect("failed to run FnOutputTrait method query"),
+            )
+            .chain(
+                trustfall::execute_query(
+                    &schema,
+                    adapter.clone(),
+                    trait_query,
+                    fn_output_trait_single_bound_variables,
+                )
+                .expect("failed to run FnOutputTrait single-bound method query"),
             )
             .chain(
                 trustfall::execute_query(

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -2102,22 +2102,31 @@ type NormalizedTypeSignature {
   The signature is scoped to the item that contains the type.
   Generic parameter names from that scope are normalized in declaration order:
   lifetimes become `'a`, `'b`, and so on; non-synthetic type parameters
-  become `T1`, `T2`, and so on; synthetic type parameters from
-  parameter-position `impl Trait` become `IT1`, `IT2`, and so on using that
-  same type-parameter counter; const parameters become `C1`, `C2`, and so on.
-  For example, in
-  `impl<A> Example<A> { fn f<B>(&self, a: A, b: B) }`, parameter `a` has
-  signature `T1` and parameter `b` has signature `T2`.
+  become `T1`, `T2`, and so on; const parameters become `C1`, `C2`, and so on.
+  For example, in `impl<A> Example<A> { fn f<B>(&self, a: A, b: B) }`,
+  parameter `a` has signature `T1` while parameter `b` has signature `T2`.
 
-  Parameter names and patterns are not included. Neither are the containing
-  item's attributes such as ABI, safety, asyncness, constness, generic bounds,
-  and `where` clauses. For example, in
+  A single function parameter may contain multiple parameter-position `impl Trait`
+  uses, for example: `impl Iterator<Item = impl Into<String>>`.
+  We normalize parameter-position `impl Trait` into synthetic type parameters,
+  with each synthetic generic type scoped to the function parameter
+  that contains it. The first parameter uses synthetic generic types `IT1_1`,
+  `IT1_2`, and so on; the second parameter uses `IT2_1`, `IT2_2`, and so on.
+  For example, in `fn f(a: impl Clone, b: impl Copy)`, parameter `a` has
+  signature `IT1_1` and parameter `b` has signature `IT2_1`.
+
+  Bounds inside parameter-position `impl Trait` belong to that synthetic type
+  parameter, not to the normalized signature of the containing parameter type.
+  For example, in `fn f(value: impl Iterator<Item = impl Into<String>>)`,
+  `value` has signature `IT1_2` because the nested `impl Into<String>` is
+  assigned `IT1_1` before the outer `impl Iterator<...>`.
+
+  Parameter names and patterns are not included in the signature.
+  Neither are the containing item's attributes such as ABI, safety, asyncness,
+  constness, generic bounds, and `where` clauses. For example, in
   `fn f<T: Clone>(value: T) -> T where T: Debug`, the parameter and return
   value both have signature `T1` since the generic `T` is normalized to `T1`.
 
-  `impl Trait` in parameter position is normalized to the corresponding
-  synthetic type parameter; for example, `impl Into<String>` may become `IT1`
-  or `IT2` depending on where it appears in the type-parameter counter.
   Return-position `impl Trait` remains an `impl` (opaque) type, such as
   `impl ::core::iter::traits::iterator::Iterator<Item = u8>`.
 

--- a/test_crates/assoc_constraint_order/src/lib.rs
+++ b/test_crates/assoc_constraint_order/src/lib.rs
@@ -3,10 +3,244 @@ pub trait AssocConstraintOrder {
     type B;
 }
 
+pub struct ConcreteAssoc;
+
+impl AssocConstraintOrder for ConcreteAssoc {
+    type A = u8;
+    type B = u8;
+}
+
+pub trait Takes<T> {}
+
+pub trait TakesLifetimeConst<'a, const N: usize> {}
+
 pub fn a_then_b(value: Box<dyn AssocConstraintOrder<A = impl Clone, B = impl Copy>>) {
     let _ = value;
 }
 
 pub fn b_then_a(value: Box<dyn AssocConstraintOrder<B = impl Copy, A = impl Clone>>) {
+    let _ = value;
+}
+
+pub fn return_assoc_constraint_bound() -> impl AssocConstraintOrder<A: Clone + Copy, B = u8> {
+    ConcreteAssoc
+}
+
+pub trait HasItem {
+    type Item;
+}
+
+pub trait HasGenericItem {
+    type Item<T>;
+}
+
+pub trait GenericAssoc<T> {
+    type A;
+}
+
+impl HasGenericItem for ConcreteAssoc {
+    type Item<T> = u8;
+}
+
+impl GenericAssoc<u8> for ConcreteAssoc {
+    type A = u8;
+}
+
+pub fn return_generic_assoc_constraint_bound() -> impl GenericAssoc<u8, A: Clone + Copy> {
+    ConcreteAssoc
+}
+
+pub fn return_gat_assoc_constraint_bound() -> impl HasGenericItem<Item<u8>: Clone + Copy> {
+    ConcreteAssoc
+}
+
+pub trait Provider {
+    type Assoc<T>;
+}
+
+pub fn bound_a_then_b<
+    T: AssocConstraintOrder<A: HasItem<Item = impl Clone>, B: HasItem<Item = impl Copy>>,
+>(
+    value: T,
+) {
+    let _ = value;
+}
+
+pub fn bound_b_then_a<
+    T: AssocConstraintOrder<B: HasItem<Item = impl Copy>, A: HasItem<Item = impl Clone>>,
+>(
+    value: T,
+) {
+    let _ = value;
+}
+
+pub fn same_synthetic_names(value: Box<dyn AssocConstraintOrder<A = impl Clone, B = impl Clone>>) {
+    let _ = value;
+}
+
+pub fn gat_bound_u8_then_u16<
+    T: HasGenericItem<Item<u8> = impl Clone, Item<u16> = impl Copy>,
+>(
+    value: T,
+) {
+    let _ = value;
+}
+
+pub fn repeated_gat_bound_u8_then_u16<
+    T: HasGenericItem<Item<u8> = impl Clone> + HasGenericItem<Item<u16> = impl Copy>,
+>(
+    value: T,
+) {
+    let _ = value;
+}
+
+pub fn generic_bound_before_input_impl_trait<
+    T: AssocConstraintOrder<A: HasItem<Item = impl Clone>>,
+>(
+    value: impl Send,
+    other: T,
+) {
+    let _ = (value, other);
+}
+
+pub fn top_level_assoc_bound_counts_hidden_impls(
+    pair: (
+        impl AssocConstraintOrder<A: HasItem<Item = impl Clone>>,
+        impl Copy,
+    ),
+) {
+    let _ = pair;
+}
+
+pub fn assoc_constraint_args_count_before_outer_impl(
+    pair: (
+        impl HasGenericItem<Item<impl Clone> = impl Copy>,
+        impl Default,
+    ),
+) {
+    let _ = pair;
+}
+
+pub fn hrtb_bound_counts_before_later_impl(
+    pair: (impl for<'a> Takes<&'a u8>, impl Clone),
+) {
+    let _ = pair;
+}
+
+pub fn hrtb_two_lifetime_bound_counts_before_later_impl(
+    pair: (impl for<'a, 'b> Takes<(&'a u8, &'b u8)>, impl Clone),
+) {
+    let _ = pair;
+}
+
+pub fn lifetime_const_generic_arg_counts_before_later_impl<'a, const N: usize>(
+    pair: (impl TakesLifetimeConst<'a, N>, impl Clone),
+) {
+    let _ = pair;
+}
+
+pub fn complex_constraint_a_then_b<'a>(
+    value: Box<
+        dyn AssocConstraintOrder<
+            A = Box<dyn for<'b> Fn(&'b u8) -> &'b u8 + 'a>,
+            B = impl Clone,
+        >,
+    >,
+) {
+    let _ = value;
+}
+
+pub fn complex_constraint_b_then_a<'a>(
+    value: Box<
+        dyn AssocConstraintOrder<
+            B = impl Clone,
+            A = Box<dyn for<'b> Fn(&'b u8) -> &'b u8 + 'a>,
+        >,
+    >,
+) {
+    let _ = value;
+}
+
+pub fn constraint_type_shapes<'a, const N: usize>(
+    value: Box<dyn AssocConstraintOrder<A = (&'a [u8], [u8; N]), B = impl Clone>>,
+) {
+    let _ = value;
+}
+
+pub fn constraint_function_pointer(
+    value: Box<dyn AssocConstraintOrder<A = fn(u8) -> u8, B = impl Clone>>,
+) {
+    let _ = value;
+}
+
+pub fn constraint_higher_ranked_function_pointer(
+    value: Box<dyn AssocConstraintOrder<A = for<'a> fn(&'a u8) -> &'a u8, B = impl Clone>>,
+) {
+    let _ = value;
+}
+
+pub fn constraint_two_lifetime_function_pointer(
+    value: Box<
+        dyn AssocConstraintOrder<
+            A = for<'a, 'b> fn(&'a u8, &'b u8) -> &'b u8,
+            B = impl Clone,
+        >,
+    >,
+) {
+    let _ = value;
+}
+
+pub fn constraint_dyn_fn_trait_two_args(
+    value: Box<dyn AssocConstraintOrder<A = Box<dyn Fn(u8, u16) -> u32>, B = impl Clone>>,
+) {
+    let _ = value;
+}
+
+pub fn constraint_qualified_path<T: Provider>(
+    value: Box<dyn AssocConstraintOrder<A = <T as Provider>::Assoc<impl Clone>, B = impl Copy>>,
+) {
+    let _ = value;
+}
+
+pub fn where_bound_after_input_impl_trait<T>(value: impl Send, other: T)
+where
+    T: AssocConstraintOrder<A: HasItem>,
+{
+    let _ = (value, other);
+}
+
+pub fn constraint_multiple_bounds(
+    value: impl AssocConstraintOrder<A: Clone + Copy, B = impl Default>,
+) {
+    let _ = value;
+}
+
+pub fn constraint_raw_pointers(
+    value: Box<dyn AssocConstraintOrder<A = *const impl Clone, B = *mut impl Copy>>,
+) {
+    let _ = value;
+}
+
+pub fn constraint_slice_and_array(
+    value: Box<dyn AssocConstraintOrder<A = &'static [impl Clone], B = [impl Copy; 3]>>,
+) {
+    let _ = value;
+}
+
+pub fn constraint_mutable_reference(
+    value: Box<dyn AssocConstraintOrder<A = &'static mut impl Clone, B = impl Copy>>,
+) {
+    let _ = value;
+}
+
+pub fn constraint_single_tuple(
+    value: Box<dyn AssocConstraintOrder<A = (impl Clone,), B = impl Copy>>,
+) {
+    let _ = value;
+}
+
+pub fn constraint_dyn_multi_trait<'a>(
+    value: Box<dyn AssocConstraintOrder<A = Box<dyn Send + Sync + 'a>, B = impl Clone>>,
+) {
     let _ = value;
 }

--- a/test_crates/function_params_and_return_value/src/lib.rs
+++ b/test_crates/function_params_and_return_value/src/lib.rs
@@ -6,6 +6,8 @@ pub fn fn_returns_nothing() {}
 
 pub struct PublicType<T>(pub T);
 
+pub struct LifetimeConst<'a, const N: usize>(pub &'a [u8; N]);
+
 pub fn concrete_types(value: u64) -> bool {
     value > 0
 }
@@ -28,6 +30,10 @@ pub fn path_types(
 ) -> Option<PublicType<u8>> {
     let _ = values;
     Some(value)
+}
+
+pub fn lifetime_const_path_args<'a, const N: usize>(value: LifetimeConst<'a, N>) {
+    let _ = value;
 }
 
 pub fn composite_types<'long, T, const N: usize>(
@@ -53,6 +59,17 @@ pub fn dyn_trait_lifetime<'long>(
     value: Box<dyn Send + Sync + 'long>,
 ) -> Box<dyn Sync + Send + 'long> {
     value
+}
+
+pub fn dyn_fn_two_arg(value: Box<dyn Fn(u8, u16) -> u32>) {
+    let _ = value;
+}
+
+pub fn dyn_fn_pointer_output(
+    callback: Box<dyn Fn() -> *const dyn Send>,
+    callback_with_lifetime: Box<dyn Fn() -> *const (dyn Send) + 'static>,
+) {
+    let _ = (callback, callback_with_lifetime);
 }
 
 pub fn impl_trait_param(value: impl Into<String>) -> String {
@@ -86,8 +103,118 @@ pub fn nested_assoc_impl_trait_param(
     value.count()
 }
 
+pub fn impl_trait_numbering_baseline(first: impl Clone, second: impl Copy) {
+    let _ = (first, second);
+}
+
+pub fn impl_trait_numbering_nested_first(
+    first: impl Iterator<Item = impl Clone>,
+    second: impl Copy,
+) -> usize {
+    let _ = second;
+    first.count()
+}
+
+pub fn impl_trait_numbering_nested_second(
+    first: impl Clone,
+    second: impl Iterator<Item = impl Copy>,
+) -> usize {
+    let _ = first;
+    second.count()
+}
+
+pub fn multiple_impl_traits_single_param(pair: (impl Clone, impl Copy), later: impl Default) {
+    let _ = (pair, later);
+}
+
+pub fn maybe_sized_impl_trait(value: &impl ?Sized) {
+    let _ = value;
+}
+
+pub fn impl_fn_bound(value: impl Fn(u8) -> u16 + Clone) {
+    let _ = value;
+}
+
+pub fn impl_fn_lifetime_bound<'long>(value: impl Fn(u8) -> u16 + Clone + 'long) {
+    let _ = value;
+}
+
+pub fn impl_fn_two_args_bound(value: impl Fn(u8, u16) -> u32 + Clone) {
+    let _ = value;
+}
+
+pub fn raw_pointer_impl_trait(value: *const impl Clone, mutable: *mut impl Copy) {
+    let _ = (value, mutable);
+}
+
+pub fn slice_and_array_impl_trait(value: &[impl Clone], array: [impl Copy; 3]) {
+    let _ = (value, array);
+}
+
+pub fn unit_and_single_tuple(unit: (), single: (impl Clone,)) {
+    let _ = (unit, single);
+}
+
+pub fn higher_ranked_fn_pointer(callback: for<'a> fn(&'a u8) -> &'a u8) {
+    let _ = callback;
+}
+
+pub fn unsafe_c_variadic_pointer(callback: unsafe extern "C" fn(u8, ...) -> u8) {
+    let _ = callback;
+}
+
+pub fn abi_variant_fn_pointers(
+    c_unwind: extern "C-unwind" fn(u8) -> u8,
+    system: extern "system" fn(u8) -> u8,
+    system_unwind: extern "system-unwind" fn(u8) -> u8,
+    win64: extern "win64" fn(u8) -> u8,
+    sysv64: extern "sysv64" fn(u8) -> u8,
+) {
+    let _ = (c_unwind, system, system_unwind, win64, sysv64);
+}
+
+pub fn dyn_pointer_and_mut_ref<'a>(
+    pointer: *const (dyn Send + Sync + 'a),
+    borrowed: &'a mut (dyn Send + Sync),
+) {
+    let _ = (pointer, borrowed);
+}
+
 pub fn impl_trait_return() -> impl Iterator<Item = u8> {
     0u8..=1
+}
+
+pub fn borrowed_opaque_return() -> &'static (impl Clone + Copy) {
+    &1u8
+}
+
+pub fn raw_pointer_opaque_return() -> *const (impl Clone + Copy) {
+    std::ptr::null::<u8>()
+}
+
+pub fn fn_bound_pointer_to_dyn_return() -> impl Fn() -> *const (dyn Send + Sync) + Clone {
+    || {
+        static VALUE: u8 = 0;
+        &VALUE as &(dyn Send + Sync) as *const (dyn Send + Sync)
+    }
+}
+
+pub fn precise_capture_return<T: Clone>(value: T) -> impl Clone + use<T> {
+    value
+}
+
+pub fn precise_capture_lifetime<'a, T: Clone + 'a>(
+    value: &'a T,
+) -> impl Clone + use<'a, T> {
+    value
+}
+
+pub fn impl_trait_lifetime_return<'a>(value: &'a u8) -> impl Clone + 'a {
+    value
+}
+
+pub fn precise_capture_const<const N: usize>(value: [u8; N]) -> impl Clone + use<N> {
+    value
 }
 
 pub struct Example;
@@ -106,6 +233,12 @@ pub trait MyTrait {
     fn trait_fn_returns_nothing(&self);
 }
 
+pub trait FnOutputTrait {
+    fn fn_output_dyn(&self) -> impl Fn() -> (dyn Send + Sync) + Clone;
+
+    fn fn_output_dyn_single_bound(&self) -> impl Fn() -> (dyn Send + Sync);
+}
+
 pub struct GenericExample<Owner>(pub Owner);
 
 impl<Owner> GenericExample<Owner> {
@@ -122,6 +255,22 @@ pub trait GenericTrait<TraitParam> {
         owner: TraitParam,
         method: MethodParam,
     ) -> (TraitParam, MethodParam);
+}
+
+pub trait Provider {
+    type Assoc<T>;
+
+    fn self_qualified(pair: (Self::Assoc<impl Clone>, impl Copy));
+}
+
+pub fn qualified_path_assoc_arg<T: Provider>(
+    pair: (<T as Provider>::Assoc<impl Clone>, impl Copy),
+) {
+    let _ = pair;
+}
+
+pub fn generic_assoc_arg<T: Provider>(pair: (T::Assoc<impl Clone>, impl Copy)) {
+    let _ = pair;
 }
 
 pub struct ImplementsGenericTrait<ImplParam>(pub ImplParam);


### PR DESCRIPTION
Ensure that normalization correctly handles associated items and will not accidentally rewrite bounds incorrectly. Fixes the bug identified in https://github.com/obi1kenobi/trustfall-rustdoc-adapter/pull/1069#discussion_r3358407528

Also change how `impl Trait` in parameter position is represented, to avoid cases where adding an additional (nested) `impl Trait` in an earlier fn parameter changes the normalization numbering of `impl Trait` in later fn parameters, making it look like they changed types too. Now `impl Trait` in parameter position is represented with a parameter index and an occurrence index: `IT1_2` means this is the second parameter-position `impl Trait` of the first parameter in the function signature.

Exhaustively tested using `cargo-llvm-cov` and `cargo-mutants` in an AI-driven loop, adding more coverage and fixing bugs until fixpoint.
