### PR TITLE
Fix `#[doc(hidden)]` re-export bug. (#1083)

### DIFF
--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -117,7 +117,7 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
             match type_name.as_ref() {
                 "Crate" => properties::resolve_crate_property(contexts, property_name),
                 "Item" | "Importable" | "GenericItem" => {
-                    properties::resolve_item_property(contexts, property_name)
+                    properties::resolve_item_property(contexts, property_name, self)
                 }
                 "ImplOwner"
                 | "Struct"
@@ -157,7 +157,7 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
                     ) =>
                 {
                     // properties inherited from Item, accesssed on Item subtypes
-                    properties::resolve_item_property(contexts, property_name)
+                    properties::resolve_item_property(contexts, property_name, self)
                 }
                 "Module" => properties::resolve_module_property(contexts, property_name),
                 "Struct" => properties::resolve_struct_property(contexts, property_name),
@@ -178,7 +178,7 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
                         "const" | "unsafe" | "async" | "has_body" | "signature"
                     ) =>
                 {
-                    properties::resolve_function_like_property(contexts, property_name)
+                    properties::resolve_function_like_property(contexts, property_name, self)
                 }
                 "ExportableFunction" | "Function" | "Method"
                     if matches!(property_name.as_ref(), "export_name") =>

--- a/src/adapter/normalize/paths.rs
+++ b/src/adapter/normalize/paths.rs
@@ -8,16 +8,14 @@ use crate::PackageIndex;
 /// fallback is only for rustdoc data that did not resolve to either source.
 pub(super) fn normalized_path(crate_: &PackageIndex<'_>, path: &rustdoc_types::Path) -> String {
     if crate_.own_crate.inner.index.contains_key(&path.id) {
-        let importable_paths = crate_
-            .own_crate
-            .visibility_tracker
-            .collect_publicly_importable_names(path.id.0);
+        let importable_paths = crate_.own_crate.publicly_importable_names(&path.id);
         // Normalized signatures should use a public API spelling when one exists.
         // The `importable_path` edge has query-observable order, so choose here
         // without reordering that edge.
         let importable_path = importable_paths.iter().min_by_key(|importable_path| {
             (
                 !importable_path.public_api(),
+                importable_path.modifiers.unstable,
                 importable_path.modifiers.doc_hidden,
                 importable_path.modifiers.deprecated,
             )

--- a/src/adapter/normalize/types.rs
+++ b/src/adapter/normalize/types.rs
@@ -475,7 +475,9 @@ fn format_generic_bound<'a>(
             match modifier {
                 TraitBoundModifier::None => {}
                 TraitBoundModifier::Maybe => output.push('?'),
-                TraitBoundModifier::MaybeConst => output.push_str("~const "),
+                // The schema has no separate const-trait facet. Render the stable
+                // ordinary-bound view instead of leaking nightly-only `[const]` syntax.
+                TraitBoundModifier::MaybeConst => {}
             }
             format_path(
                 &context,

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -1,4 +1,4 @@
-use rustdoc_types::{ItemEnum, Visibility, WherePredicate};
+use rustdoc_types::{ItemEnum, WherePredicate};
 use trustfall::{
     FieldValue,
     provider::{
@@ -35,6 +35,7 @@ pub(super) fn resolve_crate_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
 pub(super) fn resolve_item_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     property_name: &str,
+    adapter: &'a RustdocAdapter<'a>,
 ) -> ContextOutcomeIterator<'a, V, FieldValue> {
     match property_name {
         "id" => resolve_property_with(
@@ -65,19 +66,12 @@ pub(super) fn resolve_item_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
             }),
         ),
         "public_api_eligible" => resolve_property_with(contexts, move |vertex| {
-            // Items are eligible for public API if both:
-            // - The item is public, either explicitly (`pub`) or implicitly (like enum variants).
-            // - The item is deprecated, or not `#[doc(hidden)]`.
-            //
-            // This does not mean that the item is necessarily part of the public API!
-            // An item that is not eligible by itself cannot be part of the public API,
-            // but eligible items might not be public API -- for example, pub-in-priv items
-            // (public items in a private module) are eligible but not public API.
             let item = vertex.as_item().expect("vertex was not an Item");
-            let is_public = matches!(item.visibility, Visibility::Public | Visibility::Default);
-            (is_public
-                && (item.deprecation.is_some() || !item.attrs.iter().any(Attribute::is_doc_hidden)))
-            .into()
+            adapter
+                .crate_at_origin(vertex.origin)
+                .own_crate
+                .public_api_eligible(item)
+                .into()
         }),
         "visibility_limit" => resolve_property_with(contexts, |vertex| {
             let item = vertex.as_item().expect("not an item");
@@ -264,12 +258,19 @@ pub(super) fn resolve_importable_path_property<'a, V: AsVertex<Vertex<'a>> + 'a>
 pub(super) fn resolve_function_like_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     property_name: &str,
+    adapter: &'a RustdocAdapter<'a>,
 ) -> ContextOutcomeIterator<'a, V, FieldValue> {
     match property_name {
-        "const" => resolve_property_with(
-            contexts,
-            field_property!(as_function, header, { header.is_const.into() }),
-        ),
+        "const" => resolve_property_with(contexts, move |vertex| {
+            let item = vertex.as_item().expect("FunctionLike not an item");
+            let func = vertex.as_function().expect("FunctionLike not a function");
+
+            adapter
+                .crate_at_origin(vertex.origin)
+                .own_crate
+                .effective_function_constness(item, func)
+                .into()
+        }),
         "async" => resolve_property_with(
             contexts,
             field_property!(as_function, header, { header.is_async.into() }),
@@ -286,11 +287,17 @@ pub(super) fn resolve_function_like_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
             let item = vertex.as_item().expect("FunctionLike not an item");
             let func = vertex.as_function().expect("FunctionLike not a function");
 
-            rust_type_name::function_signature(
+            let effective_constness = adapter
+                .crate_at_origin(vertex.origin)
+                .own_crate
+                .effective_function_constness(item, func);
+
+            rust_type_name::function_signature_with_constness(
                 func,
                 item.name
                     .as_ref()
                     .expect("FunctionLike does not have a name"),
+                effective_constness,
             )
             .into()
         }),

--- a/src/adapter/rust_type_name.rs
+++ b/src/adapter/rust_type_name.rs
@@ -22,12 +22,19 @@ pub(crate) fn implemented_trait_instantiated_name(
 }
 
 /// Serializes a [`Function`] to a `String` containing the function signature,
-/// including generic parameter definitions, to be as close to the original code
-/// as possible.
+/// including generic parameter definitions, to be as close to the signature this
+/// adapter should expose as possible.
+///
+/// `effective_constness` may differ from `func.header.is_const` if rustdoc JSON
+/// says the function is syntactically `const` but its const facet is unstable.
 ///
 /// [`Function`]: rustdoc_types::Function
-pub(crate) fn function_signature(func: &rustdoc_types::Function, name: &str) -> String {
-    Function(func, name).to_string()
+pub(crate) fn function_signature_with_constness(
+    func: &rustdoc_types::Function,
+    name: &str,
+    effective_constness: bool,
+) -> String {
+    Function(func, name, effective_constness).to_string()
 }
 
 fn rustdoc_path_instantiated_name(path: &rustdoc_types::Path) -> String {
@@ -242,7 +249,7 @@ fn fmt_type(this: &Type, f: &mut Formatter<'_>) -> Result {
             write!(
                 f,
                 "{}fn{}",
-                FunctionHeader(&fnp.header),
+                FunctionHeader(&fnp.header, fnp.header.is_const),
                 FunctionSignature(&fnp.sig, this.1)
             )?;
 
@@ -367,8 +374,11 @@ fn fmt_generic_bound(this: &GenericBound, f: &mut Formatter<'_>) -> Result {
 
             match modifier {
                 rustdoc_types::TraitBoundModifier::Maybe => write!(f, "?")?,
-                // TODO: check this/find a good reference.  it's currently unstable
-                rustdoc_types::TraitBoundModifier::MaybeConst => write!(f, "~const ")?,
+                // The schema has no separate const-trait facet. Render the stable
+                // ordinary-bound view instead of leaking nightly-only `[const]` syntax.
+                //
+                // TODO: If and when `[const]` becomes stable, we'll likely need to revisit this.
+                rustdoc_types::TraitBoundModifier::MaybeConst => (),
                 rustdoc_types::TraitBoundModifier::None => (),
             };
 
@@ -491,7 +501,10 @@ fn fmt_path(this: &Path, f: &mut Formatter<'_>) -> Result {
 display_wrapper!(Path, fmt_path, bool);
 
 fn fmt_function_header(this: &FunctionHeader, f: &mut Formatter<'_>) -> Result {
-    if this.0.is_const {
+    // `this.1` is the effective constness selected by the caller.
+    // For std library JSON, an unstable const facet is rendered as non-const
+    // even though the raw rustdoc header still has `is_const = true`.
+    if this.1 {
         write!(f, "const ")?;
     }
 
@@ -531,7 +544,10 @@ fn fmt_function_header(this: &FunctionHeader, f: &mut Formatter<'_>) -> Result {
     Ok(())
 }
 
-display_wrapper!(FunctionHeader, fmt_function_header);
+// The extra `bool` here is the effective constness of the function,
+// in case the function is declared to be `const` but that facet is not stable
+// and should not be leaked in the function signature.
+display_wrapper!(FunctionHeader, fmt_function_header, bool);
 
 fn fmt_function_signature(this: &FunctionSignature, f: &mut Formatter<'_>) -> Result {
     write!(f, "(")?;
@@ -614,7 +630,9 @@ fn fmt_where_predicate(this: &WherePredicate, f: &mut Formatter<'_>) -> Result {
 display_wrapper!(WherePredicate, fmt_where_predicate);
 
 fn fmt_function(this: &Function, f: &mut Formatter<'_>) -> Result {
-    write!(f, "{}fn {}", FunctionHeader(&this.0.header), this.1)?;
+    // Pass effective constness into `FunctionHeader` so the rendered signature
+    // agrees with the schema-level `const` property.
+    write!(f, "{}fn {}", FunctionHeader(&this.0.header, this.2), this.1)?;
     if !GenericParamDefs(&this.0.generics.params).is_empty() {
         write!(f, "<{}>", GenericParamDefs(&this.0.generics.params))?;
     }
@@ -629,7 +647,10 @@ fn fmt_function(this: &Function, f: &mut Formatter<'_>) -> Result {
     Ok(())
 }
 
-display_wrapper!(Function, fmt_function, &'a str);
+// The extra `bool` here is the effective constness of the function,
+// in case the function is declared to be `const` but that facet is not stable
+// and should not be leaked in the function signature.
+display_wrapper!(Function, fmt_function, &'a str, bool);
 
 #[cfg(test)]
 mod tests {
@@ -908,7 +929,7 @@ mod tests {
 
             similar_asserts::assert_eq!(
                 "fn is_synthetic(x: impl std::any::Any) -> impl std::any::Any",
-                super::function_signature(func, name),
+                super::function_signature_with_constness(func, name, func.header.is_const),
             );
         });
     }
@@ -1001,8 +1022,53 @@ mod tests {
                 + 'static, \
                 e: <U as GAT<T>>::Type<'a, &'static *const ()>\
                 ) -> impl std::future::Future<Output: Iterator<Item: 'a + Send> + for<'z> FnMut(&'z ()) -> &'z &'a ()>",
-                super::function_signature(func, name),
+                super::function_signature_with_constness(func, name, func.header.is_const),
             );
         });
+    }
+
+    #[test]
+    fn maybe_const_generic_bound() {
+        let test_case = "maybe_const_function_signature";
+
+        let rustdoc_path = format!("./localdata/test_data/{test_case}/rustdoc.json");
+        let content = std::fs::read_to_string(&rustdoc_path)
+            .with_context(|| format!("could not load {rustdoc_path} file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?"))
+            .expect("failed to load rustdoc");
+        let crate_: rustdoc_types::Crate =
+            serde_json::from_str(&content).expect("failed to parse rustdoc");
+
+        let module = crate_.index.get(&crate_.root).expect("no root");
+
+        let rustdoc_types::ItemEnum::Module(module) = &module.inner else {
+            panic!("root is not a module");
+        };
+
+        let func = module
+            .items
+            .iter()
+            .find_map(|id| {
+                let item = crate_.index.get(id)?;
+                if item.name.as_ref()? == "maybe_const_function_signature" {
+                    if let rustdoc_types::ItemEnum::Function(func) = &item.inner {
+                        return Some(func);
+                    }
+                }
+
+                None
+            })
+            .expect("couldn't find `maybe_const_function_signature`");
+
+        // The fixture uses `impl [const] MaybeConst`, which rustdoc JSON stores
+        // as `TraitBoundModifier::MaybeConst` inside an `impl Trait` type.
+        let (param_name, param_type) = func.sig.inputs.first().expect("expected one parameter");
+        similar_asserts::assert_eq!("arg", param_name);
+
+        // Stable-facing type rendering should hide that nightly-only `[const]` marker
+        // and render the ordinary trait bound only.
+        similar_asserts::assert_eq!("impl MaybeConst", rust_type_name(param_type));
+
+        let return_type = func.sig.output.as_ref().expect("expected a return type");
+        similar_asserts::assert_eq!("impl MaybeConst", rust_type_name(return_type));
     }
 }

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -56,6 +56,15 @@ macro_rules! get_test_data {
     }
 }
 
+// This mirrors `get_test_data!` for fixtures that intentionally need the
+// Rust standard-library indexing policy instead of ordinary crate indexing.
+macro_rules! get_rust_std_test_data {
+    ($data:ident, $case:ident) => {
+        let crate_ = crate::test_util::load_pregenerated_rustdoc(stringify!($case));
+        let $data = crate::PackageIndex::from_rust_std_component_crate(&crate_);
+    };
+}
+
 #[test]
 fn rustdoc_json_format_version() {
     let path = "./localdata/test_data/reexport/rustdoc.json";
@@ -2497,9 +2506,9 @@ fn importable_paths() {
         Output {
             name: "NestedHiddenGlobOnly".into(),
             path: vec!["importable_paths".into(), "NestedHiddenGlobOnly".into()],
-            doc_hidden: false,
+            doc_hidden: true,
             deprecated: false,
-            public_api: true,
+            public_api: false,
         },
         Output {
             name: "NestedHiddenDeprecatedGlobOnly".into(),
@@ -2507,8 +2516,8 @@ fn importable_paths() {
                 "importable_paths".into(),
                 "NestedHiddenDeprecatedGlobOnly".into(),
             ],
-            doc_hidden: false,
-            deprecated: false,
+            doc_hidden: true,
+            deprecated: true,
             public_api: true,
         },
         Output {
@@ -2534,9 +2543,9 @@ fn importable_paths() {
                 "importable_paths".into(),
                 "HiddenPerItemThenRootGlob".into(),
             ],
-            doc_hidden: false,
+            doc_hidden: true,
             deprecated: false,
-            public_api: true,
+            public_api: false,
         },
         Output {
             name: "HiddenGlobThenRootPerItem".into(),
@@ -2551,9 +2560,9 @@ fn importable_paths() {
         Output {
             name: "HiddenGlobThenRootGlob".into(),
             path: vec!["importable_paths".into(), "HiddenGlobThenRootGlob".into()],
-            doc_hidden: false,
+            doc_hidden: true,
             deprecated: false,
-            public_api: true,
+            public_api: false,
         },
         Output {
             name: "Aliased".into(),
@@ -2561,6 +2570,85 @@ fn importable_paths() {
             doc_hidden: true,
             deprecated: false,
             public_api: false,
+        },
+    ];
+    expected_results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
+/// Ensure that if the same path is available via both a `#[doc(hidden)]` glob re-export
+/// and also via some other manner that is public API, the net result is a valid public API path.
+#[test]
+fn hidden_glob_reexports_affect_synthesized_public_api_paths() {
+    get_test_data!(data, doc_hidden_glob_reexports);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Struct {
+                name @output
+                importable_path {
+                    path @output
+                    doc_hidden @output
+                    deprecated @output
+                    public_api @output
+                }
+            }
+        }
+    }
+}
+"#;
+    let variables: BTreeMap<&str, &str> = Default::default();
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        path: Vec<String>,
+        doc_hidden: bool,
+        deprecated: bool,
+        public_api: bool,
+    }
+
+    let mut results: Vec<Output> = trustfall::execute_query(&schema, adapter, query, variables)
+        .expect("failed to run query")
+        .map(|row| row.try_into_struct().expect("shape mismatch"))
+        .collect();
+    results.sort_unstable();
+
+    let mut expected_results = vec![
+        Output {
+            name: "HiddenGlobOnly".into(),
+            path: vec!["doc_hidden_glob_reexports".into(), "HiddenGlobOnly".into()],
+            doc_hidden: true,
+            deprecated: false,
+            public_api: false,
+        },
+        Output {
+            name: "HiddenAndVisibleGlob".into(),
+            path: vec![
+                "doc_hidden_glob_reexports".into(),
+                "HiddenAndVisibleGlob".into(),
+            ],
+            doc_hidden: false,
+            deprecated: false,
+            public_api: true,
+        },
+        Output {
+            name: "HiddenGlobAndDirectUse".into(),
+            path: vec![
+                "doc_hidden_glob_reexports".into(),
+                "HiddenGlobAndDirectUse".into(),
+            ],
+            doc_hidden: false,
+            deprecated: false,
+            public_api: true,
         },
     ];
     expected_results.sort_unstable();
@@ -6507,6 +6595,243 @@ fn type_generic_bounds() {
         },
     ];
     expected_results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
+#[test]
+fn rust_std_function_facets_report_stable_guarantee() {
+    get_rust_std_test_data!(data, rust_std_stability);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Function {
+                name @filter(op: "one_of", value: ["$names"]) @output
+                const @output
+                has_body @output
+                public_api_eligible @output
+                signature @output
+            }
+        }
+    }
+}
+    "#;
+    let variables = btreemap! {
+        "names" => FieldValue::List(vec![
+            FieldValue::String("stable_const_stable".into()),
+            FieldValue::String("stable_const_unstable".into()),
+            FieldValue::String("unstable_const_function".into()),
+        ].into()),
+    };
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        #[serde(rename = "const")]
+        const_: bool,
+        has_body: bool,
+        public_api_eligible: bool,
+        signature: String,
+    }
+
+    let mut results: Vec<_> = trustfall::execute_query(&schema, adapter, query, variables)
+        .expect("failed to run query")
+        .map(|row| row.try_into_struct().expect("shape mismatch"))
+        .collect();
+    results.sort_unstable();
+
+    let mut expected_results = vec![
+        Output {
+            name: "stable_const_stable".into(),
+            const_: true,
+            has_body: true,
+            public_api_eligible: true,
+            signature: "const fn stable_const_stable() -> u32".into(),
+        },
+        Output {
+            name: "stable_const_unstable".into(),
+            const_: true, // stability info is not present in this rustdoc version
+            has_body: true,
+            public_api_eligible: true,
+            signature: "const fn stable_const_unstable() -> u32".into(), // stability info is not present in this rustdoc version
+        },
+        Output {
+            name: "unstable_const_function".into(),
+            const_: true,
+            has_body: true,
+            public_api_eligible: true, // stability info is not present in this rustdoc version
+            signature: "const fn unstable_const_function() -> u32".into(),
+        },
+    ];
+    expected_results.sort_unstable();
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
+#[test]
+fn default_policy_ignores_rust_std_const_stability() {
+    let rustdoc = crate::test_util::load_pregenerated_rustdoc("rust_std_stability");
+    let data = PackageIndex::from_crate(&rustdoc);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Function {
+                name @filter(op: "=", value: ["$name"])
+                const @output
+                signature @output
+            }
+        }
+    }
+}
+    "#;
+    let variables = btreemap! {
+        "name" => FieldValue::String("stable_const_unstable".into()),
+    };
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        #[serde(rename = "const")]
+        const_: bool,
+        signature: String,
+    }
+
+    let results: Vec<Output> = trustfall::execute_query(&schema, adapter, query, variables)
+        .expect("failed to run query")
+        .map(|row| row.try_into_struct().expect("shape mismatch"))
+        .collect();
+
+    similar_asserts::assert_eq!(
+        vec![Output {
+            const_: true,
+            signature: "const fn stable_const_unstable() -> u32".into(),
+        }],
+        results,
+    );
+}
+
+#[test]
+fn rust_std_const_impl_methods_use_inherited_const_stability() {
+    get_rust_std_test_data!(data, rust_std_stability);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on ImplOwner {
+                name @filter(op: "=", value: ["$owner"])
+
+                impl {
+                    method {
+                        name @filter(op: "=", value: ["$method"])
+                        const @output
+                        signature @output
+                    }
+                }
+            }
+        }
+    }
+}
+    "#;
+    let variables = btreemap! {
+        "owner" => FieldValue::String("ConstImplOwner".into()),
+        "method" => FieldValue::String("const_impl_method".into()),
+    };
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        #[serde(rename = "const")]
+        const_: bool,
+        signature: String,
+    }
+
+    let results: Vec<Output> = trustfall::execute_query(&schema, adapter, query, variables)
+        .expect("failed to run query")
+        .map(|row| row.try_into_struct().expect("shape mismatch"))
+        .collect();
+
+    similar_asserts::assert_eq!(
+        vec![Output {
+            const_: true, // stability info is not present in this rustdoc version
+            signature: "const fn const_impl_method() -> u32".into(), // stability info is not present in this rustdoc version
+        }],
+        results,
+    );
+}
+
+#[test]
+fn rust_std_signatures_hide_const_trait_markers() {
+    get_rust_std_test_data!(data, rust_std_stability);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Function {
+                name @filter(op: "=", value: ["$name"])
+                signature @output(name: "function_signature")
+
+                parameter {
+                    normalized_type_signature {
+                        signature @output(name: "parameter_signature")
+                    }
+                }
+
+                return_value {
+                    normalized_type_signature {
+                        signature @output(name: "return_signature")
+                    }
+                }
+            }
+        }
+    }
+}
+    "#;
+    let variables = btreemap! {
+        "name" => FieldValue::String("const_trait_marker".into()),
+    };
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        function_signature: String,
+        parameter_signature: String,
+        return_signature: String,
+    }
+
+    let results: Vec<Output> = trustfall::execute_query(&schema, adapter, query, variables)
+        .expect("failed to run query")
+        .map(|row| row.try_into_struct().expect("shape mismatch"))
+        .collect();
+
+    let expected_results = vec![Output {
+        function_signature:
+            "const fn const_trait_marker(arg: impl FixtureConstBound) -> impl FixtureConstBound"
+                .into(), // stability info is not present in this rustdoc version
+        parameter_signature: "IT1_1".into(),
+        return_signature: "impl ::rust_std_stability::FixtureConstBound".into(),
+    }];
 
     similar_asserts::assert_eq!(expected_results, results);
 }

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -6723,60 +6723,6 @@ fn default_policy_ignores_rust_std_const_stability() {
 }
 
 #[test]
-fn rust_std_const_impl_methods_use_inherited_const_stability() {
-    get_rust_std_test_data!(data, rust_std_stability);
-    let adapter = RustdocAdapter::new(&data, None);
-    let adapter = Arc::new(&adapter);
-
-    let query = r#"
-{
-    Crate {
-        item {
-            ... on ImplOwner {
-                name @filter(op: "=", value: ["$owner"])
-
-                impl {
-                    method {
-                        name @filter(op: "=", value: ["$method"])
-                        const @output
-                        signature @output
-                    }
-                }
-            }
-        }
-    }
-}
-    "#;
-    let variables = btreemap! {
-        "owner" => FieldValue::String("ConstImplOwner".into()),
-        "method" => FieldValue::String("const_impl_method".into()),
-    };
-
-    let schema =
-        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
-
-    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
-    struct Output {
-        #[serde(rename = "const")]
-        const_: bool,
-        signature: String,
-    }
-
-    let results: Vec<Output> = trustfall::execute_query(&schema, adapter, query, variables)
-        .expect("failed to run query")
-        .map(|row| row.try_into_struct().expect("shape mismatch"))
-        .collect();
-
-    similar_asserts::assert_eq!(
-        vec![Output {
-            const_: true, // stability info is not present in this rustdoc version
-            signature: "const fn const_impl_method() -> u32".into(), // stability info is not present in this rustdoc version
-        }],
-        results,
-    );
-}
-
-#[test]
 fn rust_std_signatures_hide_const_trait_markers() {
     get_rust_std_test_data!(data, rust_std_stability);
     let adapter = RustdocAdapter::new(&data, None);

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -13,6 +13,7 @@ use crate::{
     adapter::supported_item_kind,
     hashtables::{HashMap, HashSet, IndexMap},
     item_flags::{ItemFlag, build_flags_index},
+    stability::PublicApiStabilityPolicy,
     visibility_tracker::VisibilityTracker,
 };
 
@@ -131,50 +132,94 @@ impl<'a> PackageIndex<'a> {
         }
     }
 
+    /// Create a new [`PackageIndex`] for Rust standard-library rustdoc JSON.
+    ///
+    /// This constructor treats rustdoc stability data as part of the public-API analysis.
+    /// Use this for rustup-provided standard-library component crates such as `std`, `core`,
+    /// `alloc`, `proc_macro`, `std_detect`, and `test`.
+    pub fn from_rust_std_component_crate(crate_: &'a Crate) -> Self {
+        Self {
+            own_crate: IndexedCrate::new_with_stability_policy(
+                crate_,
+                PublicApiStabilityPolicy::RustStandardLibrary,
+            ),
+            features: None,
+            dependencies: Default::default(),
+        }
+    }
+
     /// Create a new [`PackageIndex`] for a given crate, in order to query it with Trustfall.
     pub fn from_storage(storage: &'a PackageStorage) -> Self {
+        Self {
+            own_crate: IndexedCrate::new(&storage.own_crate),
+            features: Self::features_from_storage(storage),
+            dependencies: Self::dependencies_from_storage(storage),
+        }
+    }
+
+    /// Create a new [`PackageIndex`] for Rust standard-library rustdoc JSON stored with metadata.
+    ///
+    /// This applies Rust standard-library stability rules only to `storage`'s own crate. Its
+    /// dependency crates still use the default indexing mode.
+    pub fn from_rust_std_component_storage(storage: &'a PackageStorage) -> Self {
+        // TODO: future multi-std-component indexing should assign stability policies per component,
+        // since `std` depends on `core` and `alloc` and can re-export their items.
+        Self {
+            own_crate: IndexedCrate::new_with_stability_policy(
+                &storage.own_crate,
+                PublicApiStabilityPolicy::RustStandardLibrary,
+            ),
+            features: Self::features_from_storage(storage),
+            dependencies: Self::dependencies_from_storage(storage),
+        }
+    }
+
+    fn features_from_storage(
+        storage: &'a PackageStorage,
+    ) -> Option<cargo_toml::features::Features<'a, 'a>> {
+        storage.package_data.as_ref().map(|data| {
+            let resolver = cargo_toml::features::Resolver::new();
+
+            let dependencies = data
+                .package
+                .dependencies
+                .iter()
+                .zip(data.dependency_info.iter())
+                .filter_map(|(dep, (dep_data, platform))| {
+                    Some(cargo_toml::features::ParseDependency {
+                        key: dep.rename.as_deref().unwrap_or(dep.name.as_ref()),
+                        kind: match dep.kind {
+                            cargo_metadata::DependencyKind::Normal => {
+                                cargo_toml::features::Kind::Normal
+                            }
+                            cargo_metadata::DependencyKind::Development => {
+                                cargo_toml::features::Kind::Dev
+                            }
+                            cargo_metadata::DependencyKind::Build => {
+                                cargo_toml::features::Kind::Build
+                            }
+                            _ => return None,
+                        },
+                        target: platform.as_deref(),
+                        dep: dep_data,
+                    })
+                });
+
+            resolver.parse_custom(&data.features, dependencies)
+        })
+    }
+
+    fn dependencies_from_storage(
+        storage: &'a PackageStorage,
+    ) -> HashMap<DependencyKey, IndexedCrate<'a>> {
         #[cfg(not(feature = "rayon"))]
         let dependencies_iter = storage.dependencies.iter();
         #[cfg(feature = "rayon")]
         let dependencies_iter = storage.dependencies.par_iter();
 
-        Self {
-            own_crate: IndexedCrate::new(&storage.own_crate),
-            features: storage.package_data.as_ref().map(|data| {
-                let resolver = cargo_toml::features::Resolver::new();
-
-                let dependencies = data
-                    .package
-                    .dependencies
-                    .iter()
-                    .zip(data.dependency_info.iter())
-                    .filter_map(|(dep, (dep_data, platform))| {
-                        Some(cargo_toml::features::ParseDependency {
-                            key: dep.rename.as_deref().unwrap_or(dep.name.as_ref()),
-                            kind: match dep.kind {
-                                cargo_metadata::DependencyKind::Normal => {
-                                    cargo_toml::features::Kind::Normal
-                                }
-                                cargo_metadata::DependencyKind::Development => {
-                                    cargo_toml::features::Kind::Dev
-                                }
-                                cargo_metadata::DependencyKind::Build => {
-                                    cargo_toml::features::Kind::Build
-                                }
-                                _ => return None,
-                            },
-                            target: platform.as_deref(),
-                            dep: dep_data,
-                        })
-                    });
-
-                resolver.parse_custom(&data.features, dependencies)
-            }),
-
-            dependencies: dependencies_iter
-                .map(|(k, v)| (k.clone(), IndexedCrate::new(v)))
-                .collect(),
-        }
+        dependencies_iter
+            .map(|(k, v)| (k.clone(), IndexedCrate::new(v)))
+            .collect()
     }
 }
 
@@ -189,6 +234,10 @@ pub struct IndexedCrate<'a> {
 
     /// Track which items are publicly visible and under which names.
     pub(crate) visibility_tracker: VisibilityTracker<'a>,
+
+    /// Whether we should consider stability attributes (which are themselves unstable and only
+    /// used by the standard library) when determining the public API.
+    pub(crate) stability_policy: PublicApiStabilityPolicy,
 
     /// index: importable name (in any namespace) -> list of items under that name
     pub(crate) imports_index: Option<HashMap<Path<'a>, Vec<(&'a Item, Modifiers)>>>,
@@ -539,6 +588,13 @@ fn build_impl_index(index: &HashMap<Id, Item>) -> MapList<ImplEntry<'_>, (&Item,
 
 impl<'a> IndexedCrate<'a> {
     pub fn new(crate_: &'a Crate) -> Self {
+        Self::new_with_stability_policy(crate_, PublicApiStabilityPolicy::Ignore)
+    }
+
+    pub(crate) fn new_with_stability_policy(
+        crate_: &'a Crate,
+        stability_policy: PublicApiStabilityPolicy,
+    ) -> Self {
         let fn_owner_index = build_fn_owner_index(&crate_.index);
         let pub_item_kind_index = PubItemKindIndex::from_crate(crate_, &fn_owner_index);
 
@@ -554,7 +610,8 @@ impl<'a> IndexedCrate<'a> {
 
         let mut value = Self {
             inner: crate_,
-            visibility_tracker: VisibilityTracker::from_crate(crate_),
+            visibility_tracker: VisibilityTracker::from_crate(crate_, stability_policy),
+            stability_policy,
             manually_inlined_builtin_traits,
             sized_trait,
             flags: None,
@@ -600,7 +657,11 @@ impl<'a> IndexedCrate<'a> {
             .flatten()
             .collect::<MapList<_, _>>()
             .into_inner();
-        value.flags = Some(build_flags_index(&crate_.index, &imports_index));
+        value.flags = Some(build_flags_index(
+            &crate_.index,
+            &imports_index,
+            value.stability_policy,
+        ));
         value.imports_index = Some(imports_index);
 
         value.impl_method_index = Some(build_impl_index(&crate_.index).into_inner());
@@ -619,6 +680,19 @@ impl<'a> IndexedCrate<'a> {
         } else {
             Default::default()
         }
+    }
+
+    pub(crate) fn public_api_eligible(&self, item: &Item) -> bool {
+        self.stability_policy.public_api_eligible(item)
+    }
+
+    pub(crate) fn effective_function_constness(
+        &self,
+        item: &'a Item,
+        function: &rustdoc_types::Function,
+    ) -> bool {
+        self.stability_policy
+            .effective_constness(item, function.header.is_const)
     }
 
     /// Return `true` if our analysis indicates the trait is sealed, and `false` otherwise.
@@ -850,6 +924,13 @@ impl<'a> Path<'a> {
 pub struct Modifiers {
     pub(crate) doc_hidden: bool,
     pub(crate) deprecated: bool,
+    pub(crate) unstable: bool,
+}
+
+impl Modifiers {
+    pub(crate) fn public_api(&self) -> bool {
+        !self.unstable && (self.deprecated || !self.doc_hidden)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -860,18 +941,24 @@ pub struct ImportablePath<'a> {
 }
 
 impl<'a> ImportablePath<'a> {
-    pub(crate) fn new(components: Vec<&'a str>, doc_hidden: bool, deprecated: bool) -> Self {
+    pub(crate) fn new(
+        components: Vec<&'a str>,
+        doc_hidden: bool,
+        deprecated: bool,
+        unstable: bool,
+    ) -> Self {
         Self {
             path: Path::new(components),
             modifiers: Modifiers {
                 doc_hidden,
                 deprecated,
+                unstable,
             },
         }
     }
 
     pub(crate) fn public_api(&self) -> bool {
-        self.modifiers.deprecated || !self.modifiers.doc_hidden
+        self.modifiers.public_api()
     }
 }
 
@@ -1111,6 +1198,211 @@ mod tests {
             .expect("exactly one matching name")
     }
 
+    // These tests stay at the indexing layer when they assert rustdoc JSON
+    // invariants or path/reachability facts. Schema-visible behavior belongs
+    // in `src/adapter/tests.rs`.
+    mod rust_std_stability {
+        use super::{ImportablePath, find_item_id};
+        use crate::{PackageIndex, test_util::load_pregenerated_rustdoc};
+
+        const STABILITY_FIXTURE: &str = "rust_std_stability";
+        const CRATE_ROOT: &str = "rust_std_stability";
+
+        fn public_path<'a>(
+            paths: &'a [ImportablePath<'a>],
+            components: &[&str],
+        ) -> &'a ImportablePath<'a> {
+            paths
+                .iter()
+                .find(|path| path.path.components == components)
+                .expect("expected importable path not found")
+        }
+
+        #[test]
+        fn default_policy_has_no_rust_std_structured_stability_to_apply() {
+            let rustdoc = load_pregenerated_rustdoc(STABILITY_FIXTURE);
+            let item_id = find_item_id(&rustdoc, "unstable_function");
+            let package_index = PackageIndex::from_crate(&rustdoc);
+            let paths = package_index.own_crate.publicly_importable_names(item_id);
+
+            assert_eq!(paths.len(), 1);
+            assert!(paths[0].public_api()); // stability info is not present in this rustdoc version
+            assert!(
+                package_index
+                    .own_crate
+                    .public_api_eligible(&rustdoc.index[item_id])
+            );
+        }
+
+        #[test]
+        fn rust_std_policy_treats_items_as_public_when_stability_info_is_absent() {
+            let rustdoc = load_pregenerated_rustdoc(STABILITY_FIXTURE);
+            let item_id = find_item_id(&rustdoc, "unstable_function");
+            let package_index = PackageIndex::from_rust_std_component_crate(&rustdoc);
+            let paths = package_index.own_crate.publicly_importable_names(item_id);
+
+            assert_eq!(paths.len(), 1);
+            assert!(!paths[0].modifiers.unstable); // stability info is not present in this rustdoc version
+            assert!(paths[0].public_api()); // stability info is not present in this rustdoc version
+            assert!(
+                package_index
+                    .own_crate
+                    .public_api_eligible(&rustdoc.index[item_id]) // stability info is not present in this rustdoc version
+            );
+
+            let flags = package_index
+                .own_crate
+                .flags
+                .as_ref()
+                .expect("flags index should exist");
+            assert!(flags[item_id].is_reachable());
+            assert!(flags[item_id].is_pub_reachable()); // stability info is not present in this rustdoc version
+            assert!(!flags[item_id].is_non_pub_api_reachable()); // stability info is not present in this rustdoc version
+        }
+
+        #[test]
+        fn rust_std_storage_constructor_applies_stability_to_own_crate() {
+            let storage =
+                crate::PackageStorage::from_rustdoc(load_pregenerated_rustdoc(STABILITY_FIXTURE));
+            let item_id = find_item_id(&storage.own_crate, "unstable_function");
+            let package_index = PackageIndex::from_rust_std_component_storage(&storage);
+            let paths = package_index.own_crate.publicly_importable_names(item_id);
+
+            assert_eq!(paths.len(), 1);
+            assert!(paths[0].public_api()); // stability info is not present in this rustdoc version
+            assert!(!paths[0].modifiers.unstable); // stability info is not present in this rustdoc version
+        }
+
+        #[test]
+        fn rust_std_policy_treats_stable_item_under_unstable_module_as_non_public_api() {
+            let rustdoc = load_pregenerated_rustdoc(STABILITY_FIXTURE);
+            let item_id = find_item_id(&rustdoc, "stable_inside_unstable_module");
+            let package_index = PackageIndex::from_rust_std_component_crate(&rustdoc);
+            let paths = package_index.own_crate.publicly_importable_names(item_id);
+
+            let path = public_path(
+                &paths,
+                &[
+                    CRATE_ROOT,
+                    "unstable_module",
+                    "stable_inside_unstable_module",
+                ],
+            );
+            assert!(!path.modifiers.unstable); // stability info is not present in this rustdoc version
+            assert!(path.public_api()); // stability info is not present in this rustdoc version
+            assert!(
+                package_index
+                    .own_crate
+                    .public_api_eligible(&rustdoc.index[item_id])
+            );
+        }
+
+        #[test]
+        fn rust_std_policy_allows_stable_reexport_from_unstable_module() {
+            let rustdoc = load_pregenerated_rustdoc(STABILITY_FIXTURE);
+            let item_id = find_item_id(&rustdoc, "stable_reexported_from_unstable_module");
+            let package_index = PackageIndex::from_rust_std_component_crate(&rustdoc);
+            let paths = package_index.own_crate.publicly_importable_names(item_id);
+
+            let stable_reexport_path = public_path(
+                &paths,
+                &[CRATE_ROOT, "stable_reexport_from_unstable_module"],
+            );
+            let unstable_definition_path = public_path(
+                &paths,
+                &[
+                    CRATE_ROOT,
+                    "unstable_reexport_source",
+                    "stable_reexported_from_unstable_module",
+                ],
+            );
+            assert!(stable_reexport_path.public_api());
+            assert!(!stable_reexport_path.modifiers.unstable);
+            assert!(unstable_definition_path.public_api()); // stability info is not present in this rustdoc version
+            assert!(!unstable_definition_path.modifiers.unstable); // stability info is not present in this rustdoc version
+            assert!(
+                package_index
+                    .own_crate
+                    .public_api_eligible(&rustdoc.index[item_id])
+            );
+        }
+
+        #[test]
+        fn rust_std_policy_keeps_public_and_non_public_paths_for_same_item() {
+            let rustdoc = load_pregenerated_rustdoc(STABILITY_FIXTURE);
+            let item_id = find_item_id(&rustdoc, "reexport_target");
+            let package_index = PackageIndex::from_rust_std_component_crate(&rustdoc);
+            let paths = package_index.own_crate.publicly_importable_names(item_id);
+
+            let stable_path = public_path(&paths, &[CRATE_ROOT, "stable_reexport_target"]);
+            let unstable_path = public_path(&paths, &[CRATE_ROOT, "unstable_reexport_target"]);
+            assert!(stable_path.public_api());
+            assert!(!stable_path.modifiers.unstable);
+            assert!(unstable_path.public_api()); // stability info is not present in this rustdoc version
+            assert!(!unstable_path.modifiers.unstable); // stability info is not present in this rustdoc version
+        }
+
+        #[test]
+        fn rust_std_policy_applies_direct_glob_use_stability_to_importable_path() {
+            let rustdoc = load_pregenerated_rustdoc(STABILITY_FIXTURE);
+            let item_id = find_item_id(&rustdoc, "direct_glob_target");
+            let package_index = PackageIndex::from_rust_std_component_crate(&rustdoc);
+            let paths = package_index.own_crate.publicly_importable_names(item_id);
+
+            let module_path = public_path(
+                &paths,
+                &[CRATE_ROOT, "direct_glob_source", "direct_glob_target"],
+            );
+            let glob_path = public_path(&paths, &[CRATE_ROOT, "direct_glob_target"]);
+            assert!(module_path.public_api());
+            assert!(!module_path.modifiers.unstable);
+            assert!(glob_path.public_api()); // stability info is not present in this rustdoc version
+            assert!(!glob_path.modifiers.unstable); // stability info is not present in this rustdoc version
+        }
+
+        #[test]
+        fn rust_std_policy_applies_nested_glob_stability_to_synthesized_paths() {
+            let rustdoc = load_pregenerated_rustdoc(STABILITY_FIXTURE);
+            let item_id = find_item_id(&rustdoc, "nested_glob_target");
+            let package_index = PackageIndex::from_rust_std_component_crate(&rustdoc);
+            let paths = package_index.own_crate.publicly_importable_names(item_id);
+
+            let root_glob_path = public_path(&paths, &[CRATE_ROOT, "nested_glob_target"]);
+            let outer_path =
+                public_path(&paths, &[CRATE_ROOT, "nested_outer", "nested_glob_target"]);
+            let inner_path = public_path(
+                &paths,
+                &[
+                    CRATE_ROOT,
+                    "nested_outer",
+                    "nested_inner",
+                    "nested_glob_target",
+                ],
+            );
+            assert!(root_glob_path.public_api()); // stability info is not present in this rustdoc version
+            assert!(!root_glob_path.modifiers.unstable); // stability info is not present in this rustdoc version
+            assert!(outer_path.public_api()); // stability info is not present in this rustdoc version
+            assert!(!outer_path.modifiers.unstable); // stability info is not present in this rustdoc version
+            assert!(inner_path.public_api());
+            assert!(!inner_path.modifiers.unstable);
+        }
+
+        #[test]
+        fn rust_std_policy_preserves_non_glob_reexport_stability_through_glob() {
+            let rustdoc = load_pregenerated_rustdoc(STABILITY_FIXTURE);
+            let item_id = find_item_id(&rustdoc, "non_glob_target");
+            let package_index = PackageIndex::from_rust_std_component_crate(&rustdoc);
+            let paths = package_index.own_crate.publicly_importable_names(item_id);
+
+            let stable_glob_path = public_path(&paths, &[CRATE_ROOT, "non_glob_target"]);
+            let unstable_glob_path = public_path(&paths, &[CRATE_ROOT, "non_glob_unstable_alias"]);
+            assert!(stable_glob_path.public_api());
+            assert!(!stable_glob_path.modifiers.unstable);
+            assert!(unstable_glob_path.public_api()); // stability info is not present in this rustdoc version
+            assert!(!unstable_glob_path.modifiers.unstable); // stability info is not present in this rustdoc version
+        }
+    }
+
     /// Ensure that methods, consts, and fields within structs are not importable.
     #[test]
     fn structs_are_not_modules() {
@@ -1159,6 +1451,7 @@ mod tests {
         assert_eq!(
             vec![ImportablePath::new(
                 vec!["structs_are_not_modules", "top_level_function"],
+                false,
                 false,
                 false,
             )],
@@ -1233,12 +1526,14 @@ mod tests {
                 vec!["enums_are_not_modules", "top_level_function"],
                 false,
                 false,
+                false,
             )],
             indexed_crate.publicly_importable_names(top_level_function)
         );
         assert_eq!(
             vec![ImportablePath::new(
                 vec!["enums_are_not_modules", "Foo", "Variant"],
+                false,
                 false,
                 false,
             )],
@@ -1313,6 +1608,7 @@ mod tests {
         assert_eq!(
             vec![ImportablePath::new(
                 vec!["unions_are_not_modules", "top_level_function"],
+                false,
                 false,
                 false,
             )],
@@ -2307,6 +2603,7 @@ expected exactly one importable path for `Foo` items in this crate but got: {act
                     vec!["overlapping_glob_of_enum_with_local_item", "Foo", "First"],
                     false,
                     false,
+                    false,
                 )],
                 indexed_crate.publicly_importable_names(&variant_item.id),
             );
@@ -2314,6 +2611,7 @@ expected exactly one importable path for `Foo` items in this crate but got: {act
                 // The struct definition overrides the glob-imported variant here.
                 vec![ImportablePath::new(
                     vec!["overlapping_glob_of_enum_with_local_item", "inner", "First"],
+                    false,
                     false,
                     false,
                 )],

--- a/src/item_flags.rs
+++ b/src/item_flags.rs
@@ -5,6 +5,7 @@ use crate::{
     hashtables::HashMap,
     indexed_crate::{Modifiers, Path},
     sealed_trait,
+    stability::PublicApiStabilityPolicy,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -22,24 +23,24 @@ impl Default for ItemFlag {
 /// +---+---+---+---+---+---+---+---+
 /// | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
 /// +---+---+---+---+---+---+---+---+
-/// | D | S | B | R | R | R | H | P |
+/// | D | S | B | R | R | R | N | P |
 /// +---+---+---+---+---+---+---+---+
 ///
 /// Key:
 /// P = pub reachable item: an item with a publicly importable name,
 ///     or a public API associated item of such an item
-/// H = item publicly importable via a `doc(hidden)` path or an associated item of such an item,
-///     or a `doc(hidden)` associated item of a pub reachable item
+/// N = item reachable through non-public API: either a `#[doc(hidden)]` non-deprecated
+///     path/item or, for Rust standard-library rustdoc, an explicitly unstable path/item
 /// R = reserved for future use
 /// B = trait with blanket impls (`impl<T> Trait for T`, possibly with some bounds on `T`)
 /// S = sealed trait, external crates cannot provide an impl for this trait
-/// D = `doc(hidden)`-sealed trait, providing an impl requires using `doc(hidden)` items
+/// D = public-API-sealed trait, providing an impl requires using non-public or unstable API
 impl ItemFlag {
     const PUB_REACHABLE: Self = Self(1 << 0);
-    const DOC_HIDDEN_REACHABLE: Self = Self(1 << 1);
+    const NON_PUB_API_REACHABLE: Self = Self(1 << 1);
     const TRAIT_BLANKET_IMPLS: Self = Self(1 << 5);
     const TRAIT_SEALED: Self = Self(1 << 6);
-    const TRAIT_DOC_HIDDEN_SEALED: Self = Self(1 << 7);
+    const TRAIT_PUB_API_SEALED: Self = Self(1 << 7);
 
     #[inline]
     pub(crate) fn new() -> Self {
@@ -52,7 +53,7 @@ impl ItemFlag {
     /// Their visibility does not allow them to be accessed, and doing so is a hard compiler error.
     #[inline]
     pub(crate) fn is_reachable(&self) -> bool {
-        (self.0 & (Self::PUB_REACHABLE.0 | Self::DOC_HIDDEN_REACHABLE.0)) != 0
+        (self.0 & (Self::PUB_REACHABLE.0 | Self::NON_PUB_API_REACHABLE.0)) != 0
     }
 
     /// Whether the item is reachable from another crate via the public API of this crate.
@@ -87,7 +88,7 @@ impl ItemFlag {
     /// ```
     #[inline]
     pub(crate) fn is_non_pub_api_reachable(&self) -> bool {
-        (self.0 & Self::DOC_HIDDEN_REACHABLE.0) != 0
+        (self.0 & Self::NON_PUB_API_REACHABLE.0) != 0
     }
 
     #[inline]
@@ -96,8 +97,8 @@ impl ItemFlag {
     }
 
     #[inline]
-    pub(crate) fn set_doc_hidden_reachable(&mut self) {
-        self.0 |= Self::DOC_HIDDEN_REACHABLE.0;
+    pub(crate) fn set_non_pub_api_reachable(&mut self) {
+        self.0 |= Self::NON_PUB_API_REACHABLE.0;
     }
 
     /// Whether the trait has impls like `impl<T> TheTrait for T`, with optional bounds on `T`.
@@ -124,7 +125,7 @@ impl ItemFlag {
     /// [`Self::is_unconditionally_sealed()`] returns `true`.
     #[inline]
     pub(crate) fn is_only_pub_api_sealed(&self) -> bool {
-        (self.0 & Self::TRAIT_DOC_HIDDEN_SEALED.0) != 0
+        (self.0 & Self::TRAIT_PUB_API_SEALED.0) != 0
     }
 
     /// Whether downstream crates can provide impls for this trait within public API.
@@ -132,7 +133,7 @@ impl ItemFlag {
     /// Such impls are then covered by SemVer stability guarantees.
     #[inline]
     pub(crate) fn is_pub_api_implementable(&self) -> bool {
-        (self.0 & (Self::TRAIT_DOC_HIDDEN_SEALED.0 | Self::TRAIT_SEALED.0)) == 0
+        (self.0 & (Self::TRAIT_PUB_API_SEALED.0 | Self::TRAIT_SEALED.0)) == 0
     }
 
     #[inline]
@@ -143,23 +144,23 @@ impl ItemFlag {
     #[inline]
     pub(crate) fn set_unconditionally_sealed(&mut self) {
         // Turn off the "public-API-sealed" bit, since sealed dominates.
-        self.0 &= !Self::TRAIT_DOC_HIDDEN_SEALED.0;
+        self.0 &= !Self::TRAIT_PUB_API_SEALED.0;
         self.0 |= Self::TRAIT_SEALED.0;
     }
 
     #[inline]
     pub(crate) fn set_pub_api_sealed(&mut self) {
         if !self.is_unconditionally_sealed() {
-            self.0 |= Self::TRAIT_DOC_HIDDEN_SEALED.0;
+            self.0 |= Self::TRAIT_PUB_API_SEALED.0;
         }
     }
 
     #[inline]
     fn get_reachability(&self) -> Reachability {
-        let mask = self.0 & (Self::PUB_REACHABLE.0 | Self::DOC_HIDDEN_REACHABLE.0);
+        let mask = self.0 & (Self::PUB_REACHABLE.0 | Self::NON_PUB_API_REACHABLE.0);
         if mask == 0 {
             Reachability::Unreachable
-        } else if mask == Self::DOC_HIDDEN_REACHABLE.0 {
+        } else if mask == Self::NON_PUB_API_REACHABLE.0 {
             Reachability::NonPublicAPI
         } else {
             Reachability::PublicAPI
@@ -170,7 +171,7 @@ impl ItemFlag {
     fn apply_reachability(&mut self, reachability: Reachability) {
         match reachability {
             Reachability::Unreachable => {}
-            Reachability::NonPublicAPI => self.set_doc_hidden_reachable(),
+            Reachability::NonPublicAPI => self.set_non_pub_api_reachable(),
             Reachability::PublicAPI => self.set_pub_reachable(),
         }
     }
@@ -184,7 +185,11 @@ enum Reachability {
 }
 
 impl Reachability {
-    fn from_parent(parent_reachability: Self, item: &Item) -> Self {
+    fn from_parent(
+        parent_reachability: Self,
+        item: &Item,
+        stability_policy: PublicApiStabilityPolicy,
+    ) -> Self {
         match parent_reachability {
             Reachability::Unreachable => parent_reachability,
             Reachability::NonPublicAPI => match item.visibility {
@@ -197,7 +202,9 @@ impl Reachability {
             },
             Reachability::PublicAPI => match item.visibility {
                 rustdoc_types::Visibility::Public | rustdoc_types::Visibility::Default => {
-                    if item.deprecation.is_none() && item.attrs.iter().any(Attribute::is_doc_hidden)
+                    if stability_policy.item_is_unstable(item)
+                        || (item.deprecation.is_none()
+                            && item.attrs.iter().any(Attribute::is_doc_hidden))
                     {
                         Reachability::NonPublicAPI
                     } else {
@@ -215,6 +222,7 @@ impl Reachability {
 pub(crate) fn build_flags_index(
     index: &HashMap<Id, Item>,
     imports_index: &HashMap<Path<'_>, Vec<(&Item, Modifiers)>>,
+    stability_policy: PublicApiStabilityPolicy,
 ) -> HashMap<Id, ItemFlag> {
     let mut flags: HashMap<Id, ItemFlag> =
         index.keys().map(|id| (*id, Default::default())).collect();
@@ -225,10 +233,10 @@ pub(crate) fn build_flags_index(
         .flatten()
         .for_each(|(item, modifiers)| {
             let flag = flags.entry(item.id).or_default();
-            if !modifiers.deprecated && modifiers.doc_hidden {
-                flag.set_doc_hidden_reachable();
-            } else {
+            if modifiers.public_api() {
                 flag.set_pub_reachable();
+            } else {
+                flag.set_non_pub_api_reachable();
             }
         });
 
@@ -241,12 +249,14 @@ pub(crate) fn build_flags_index(
                     inner.fields.iter().filter_map(|id| index.get(id)),
                     &mut flags,
                     parent_reachability,
+                    stability_policy,
                 );
                 set_impl_flags_index(
                     index,
                     inner.impls.iter().filter_map(|id| index.get(id)),
                     &mut flags,
                     parent_reachability,
+                    stability_policy,
                 );
             }
             rustdoc_types::ItemEnum::Struct(inner) => {
@@ -259,6 +269,7 @@ pub(crate) fn build_flags_index(
                                 .filter_map(|id| index.get(id)),
                             &mut flags,
                             parent_reachability,
+                            stability_policy,
                         );
                     }
                     rustdoc_types::StructKind::Plain { fields, .. } => {
@@ -266,6 +277,7 @@ pub(crate) fn build_flags_index(
                             fields.iter().filter_map(|id| index.get(id)),
                             &mut flags,
                             parent_reachability,
+                            stability_policy,
                         );
                     }
                 }
@@ -275,6 +287,7 @@ pub(crate) fn build_flags_index(
                     inner.impls.iter().filter_map(|id| index.get(id)),
                     &mut flags,
                     parent_reachability,
+                    stability_policy,
                 );
             }
             rustdoc_types::ItemEnum::Enum(inner) => {
@@ -283,12 +296,14 @@ pub(crate) fn build_flags_index(
                     inner.variants.iter().filter_map(|id| index.get(id)),
                     &mut flags,
                     parent_reachability,
+                    stability_policy,
                 );
                 set_impl_flags_index(
                     index,
                     inner.impls.iter().filter_map(|id| index.get(id)),
                     &mut flags,
                     parent_reachability,
+                    stability_policy,
                 );
             }
             rustdoc_types::ItemEnum::Trait(inner) => {
@@ -296,6 +311,7 @@ pub(crate) fn build_flags_index(
                     inner.items.iter().filter_map(|id| index.get(id)),
                     &mut flags,
                     parent_reachability,
+                    stability_policy,
                 );
             }
             _ => {}
@@ -311,9 +327,10 @@ fn set_field_flags_index<'a>(
     fields: impl Iterator<Item = &'a Item>,
     flags: &mut HashMap<Id, ItemFlag>,
     parent_reachability: Reachability,
+    stability_policy: PublicApiStabilityPolicy,
 ) {
     fields.for_each(|item| {
-        let reachability = Reachability::from_parent(parent_reachability, item);
+        let reachability = Reachability::from_parent(parent_reachability, item, stability_policy);
         let flag = flags.get_mut(&item.id).expect("missing flag for item");
         flag.apply_reachability(reachability);
     })
@@ -324,9 +341,10 @@ fn set_variant_flags_index<'a>(
     variants: impl Iterator<Item = &'a Item>,
     flags: &mut HashMap<Id, ItemFlag>,
     parent_reachability: Reachability,
+    stability_policy: PublicApiStabilityPolicy,
 ) {
     variants.for_each(|item| {
-        let reachability = Reachability::from_parent(parent_reachability, item);
+        let reachability = Reachability::from_parent(parent_reachability, item, stability_policy);
         let flag = flags.get_mut(&item.id).expect("missing flag for item");
         flag.apply_reachability(reachability);
 
@@ -340,6 +358,7 @@ fn set_variant_flags_index<'a>(
                             .filter_map(|id| index.get(id)),
                         flags,
                         reachability,
+                        stability_policy,
                     );
                 }
                 rustdoc_types::VariantKind::Struct { fields, .. } => {
@@ -347,6 +366,7 @@ fn set_variant_flags_index<'a>(
                         fields.iter().filter_map(|id| index.get(id)),
                         flags,
                         reachability,
+                        stability_policy,
                     );
                 }
             },
@@ -360,9 +380,10 @@ fn set_impl_flags_index<'a>(
     impls: impl Iterator<Item = &'a Item>,
     flags: &mut HashMap<Id, ItemFlag>,
     parent_reachability: Reachability,
+    stability_policy: PublicApiStabilityPolicy,
 ) {
     impls.for_each(|item| {
-        let reachability = Reachability::from_parent(parent_reachability, item);
+        let reachability = Reachability::from_parent(parent_reachability, item, stability_policy);
         let flag = flags.get_mut(&item.id).expect("missing flag for item");
         flag.apply_reachability(reachability);
 
@@ -372,6 +393,7 @@ fn set_impl_flags_index<'a>(
                     impl_inner.items.iter().filter_map(|id| index.get(id)),
                     flags,
                     reachability,
+                    stability_policy,
                 );
             }
             _ => unreachable!("not an impl item: {item:?}"),
@@ -383,9 +405,10 @@ fn set_assoc_item_flags_index<'a>(
     assoc_items: impl Iterator<Item = &'a Item>,
     flags: &mut HashMap<Id, ItemFlag>,
     parent_reachability: Reachability,
+    stability_policy: PublicApiStabilityPolicy,
 ) {
     assoc_items.for_each(|item| {
-        let reachability = Reachability::from_parent(parent_reachability, item);
+        let reachability = Reachability::from_parent(parent_reachability, item, stability_policy);
         let flag = flags.get_mut(&item.id).expect("missing flag for item");
         flag.apply_reachability(reachability);
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod hashtables;
 mod indexed_crate;
 mod item_flags;
 mod sealed_trait;
+mod stability;
 mod visibility_tracker;
 
 #[cfg(test)]

--- a/src/stability.rs
+++ b/src/stability.rs
@@ -1,0 +1,47 @@
+use rustdoc_types::{Item, Visibility};
+
+use crate::attributes::Attribute as ParsedAttribute;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PublicApiStabilityPolicy {
+    Ignore,
+    RustStandardLibrary,
+}
+
+impl PublicApiStabilityPolicy {
+    pub(crate) fn item_is_unstable(self, _item: &Item) -> bool {
+        // Stability info is not present in this rustdoc version.
+        // Treat it as absent, so no item is marked unstable by rustdoc data.
+        false
+    }
+
+    /// This is item-local eligibility, not path reachability.
+    ///
+    /// Eligible items can still be absent from stable public API,
+    /// for example when they are public inside a private module.
+    /// The local rules are:
+    /// - public/default visibility (e.g. enum variants have default visibility), and
+    /// - deprecated or not `#[doc(hidden)]`.
+    ///
+    /// Rustdoc JSON v57 does not expose item stability as structured data, so
+    /// [`PublicApiStabilityPolicy::RustStandardLibrary`] behaves the same as
+    /// [`PublicApiStabilityPolicy::Ignore`] on this branch.
+    pub(crate) fn public_api_eligible(self, item: &Item) -> bool {
+        let is_public = matches!(item.visibility, Visibility::Public | Visibility::Default);
+        let allowed_by_doc_hidden =
+            item.deprecation.is_some() || !item.attrs.iter().any(ParsedAttribute::is_doc_hidden);
+
+        is_public && allowed_by_doc_hidden && !self.item_is_unstable(item)
+    }
+
+    pub(crate) fn effective_constness(self, function_item: &Item, raw_constness: bool) -> bool {
+        assert!(
+            matches!(function_item.inner, rustdoc_types::ItemEnum::Function(..)),
+            "`function_item` was not a function: {function_item:?}"
+        );
+
+        // Stability info is not present in this rustdoc version.
+        // Treat it as absent, so syntactic constness is the effective constness.
+        raw_constness
+    }
+}

--- a/src/visibility_tracker.rs
+++ b/src/visibility_tracker.rs
@@ -7,6 +7,7 @@ use crate::{
     ImportablePath,
     attributes::Attribute,
     hashtables::{HashMap, HashSet},
+    stability::PublicApiStabilityPolicy,
 };
 
 #[derive(Debug, Clone)]
@@ -14,13 +15,20 @@ pub(crate) struct VisibilityTracker<'a> {
     // The crate this represents.
     inner: &'a Crate,
 
+    /// Stability policy used when this tracker's parent-edge modifiers were built.
+    stability_policy: PublicApiStabilityPolicy,
+
     /// For an Id, give the list of parent edges under which it is publicly visible.
     visible_parent_edges: HashMap<u32, Vec<ParentEdge<'a>>>,
 }
 
 impl<'a> VisibilityTracker<'a> {
-    pub(crate) fn from_crate(crate_: &'a Crate) -> Self {
-        let mut visible_parent_edges = compute_parent_edges_for_public_items(crate_);
+    pub(crate) fn from_crate(
+        crate_: &'a Crate,
+        stability_policy: PublicApiStabilityPolicy,
+    ) -> Self {
+        let mut visible_parent_edges =
+            compute_parent_edges_for_public_items(crate_, stability_policy);
 
         #[cfg(feature = "rayon")]
         let iter = visible_parent_edges.par_iter_mut();
@@ -36,6 +44,7 @@ impl<'a> VisibilityTracker<'a> {
 
         Self {
             inner: crate_,
+            stability_policy,
             visible_parent_edges,
         }
     }
@@ -48,21 +57,19 @@ impl<'a> VisibilityTracker<'a> {
             id,
             &mut already_visited_ids,
             &mut vec![],
-            false,
-            false,
+            EdgeModifiers::default(),
             &mut result,
         );
 
         result
     }
 
-    pub(crate) fn collect_publicly_importable_names_inner(
+    fn collect_publicly_importable_names_inner(
         &self,
         next_id: u32,
         already_visited_ids: &mut HashSet<u32>,
         stack: &mut Vec<&'a str>,
-        currently_doc_hidden: bool,
-        currently_deprecated: bool,
+        current_modifiers: EdgeModifiers,
         output: &mut Vec<ImportablePath<'a>>,
     ) {
         if !already_visited_ids.insert(next_id) {
@@ -128,16 +135,14 @@ impl<'a> VisibilityTracker<'a> {
             stack.push(pushed_name);
         }
 
-        let next_doc_hidden =
-            currently_doc_hidden || item.attrs.iter().any(Attribute::is_doc_hidden);
-        let next_deprecated = currently_deprecated || item.deprecation.is_some();
+        let next_modifiers =
+            current_modifiers.union(EdgeModifiers::from_item(item, self.stability_policy));
 
         self.collect_publicly_importable_names_recurse(
             next_id,
             already_visited_ids,
             stack,
-            next_doc_hidden,
-            next_deprecated,
+            next_modifiers,
             output,
         );
 
@@ -160,16 +165,16 @@ impl<'a> VisibilityTracker<'a> {
         next_id: u32,
         already_visited_ids: &mut HashSet<u32>,
         stack: &mut Vec<&'a str>,
-        currently_doc_hidden: bool,
-        currently_deprecated: bool,
+        current_modifiers: EdgeModifiers,
         output: &mut Vec<ImportablePath<'a>>,
     ) {
         if next_id == self.inner.root.0 {
             let final_name = stack.iter().rev().copied().collect();
             output.push(ImportablePath::new(
                 final_name,
-                currently_doc_hidden,
-                currently_deprecated,
+                current_modifiers.doc_hidden,
+                current_modifiers.deprecated,
+                current_modifiers.unstable,
             ));
         } else if let Some(visible_parents) = self.visible_parent_edges.get(&next_id) {
             for parent_edge in visible_parents.iter().copied() {
@@ -185,8 +190,7 @@ impl<'a> VisibilityTracker<'a> {
                     parent_edge.parent_id,
                     already_visited_ids,
                     stack,
-                    currently_doc_hidden || parent_edge.modifiers.doc_hidden,
-                    currently_deprecated || parent_edge.modifiers.deprecated,
+                    current_modifiers.union(parent_edge.modifiers),
                     output,
                 );
 
@@ -211,8 +215,8 @@ pub(super) struct ParentEdge<'a> {
     /// Id of the item whose scope makes the child item visible.
     parent_id: u32,
 
-    /// Visibility metadata from glob `Use` items whose names are synthesized directly
-    /// into the importing module instead of being visited as path nodes.
+    /// Public-API metadata from re-export edges from glob `Use` items,
+    /// where the `Use` item is not visited as a path node.
     modifiers: EdgeModifiers,
 
     /// Replacement path component for glob-created edges.
@@ -227,13 +231,15 @@ pub(super) struct ParentEdge<'a> {
 struct EdgeModifiers {
     doc_hidden: bool,
     deprecated: bool,
+    unstable: bool,
 }
 
 impl EdgeModifiers {
-    fn from_item(item: &Item) -> Self {
+    fn from_item(item: &Item, stability_policy: PublicApiStabilityPolicy) -> Self {
         Self {
             doc_hidden: item.attrs.iter().any(Attribute::is_doc_hidden),
             deprecated: item.deprecation.is_some(),
+            unstable: stability_policy.item_is_unstable(item),
         }
     }
 
@@ -241,11 +247,12 @@ impl EdgeModifiers {
         Self {
             doc_hidden: self.doc_hidden || other.doc_hidden,
             deprecated: self.deprecated || other.deprecated,
+            unstable: self.unstable || other.unstable,
         }
     }
 
     fn public_api(self) -> bool {
-        self.deprecated || !self.doc_hidden
+        !self.unstable && (self.deprecated || !self.doc_hidden)
     }
 
     /// Choose one concrete route among two equivalent glob re-export routes.
@@ -263,6 +270,10 @@ impl EdgeModifiers {
             (true, false) => return self,
             (false, true) => return other,
             _ => {}
+        }
+
+        if self.unstable != other.unstable {
+            return if self.unstable { other } else { self };
         }
 
         if self.doc_hidden != other.doc_hidden {
@@ -316,9 +327,10 @@ struct Definition {
 
     /// Modifiers from glob `Use` items in the module where this name is visible.
     ///
-    /// They are "invisible" because glob re-exports make their resolved names look local to the
-    /// importing module. The `Use` item itself is not part of the final importable path, but its
-    /// `#[doc(hidden)]` and deprecation metadata still apply to that path.
+    /// Glob re-exports make their resolved names look local to the importing module.
+    /// The glob `Use` item itself is not part of the final importable path, and
+    /// neither are non-glob `Use` items inside the target module that supplied the visible name.
+    /// Their `#[doc(hidden)]`, deprecation, and stability still apply to that path, though.
     invisible_glob_modifiers: EdgeModifiers,
 }
 
@@ -370,12 +382,15 @@ struct GlobResolution<'a> {
     duplicated_names: HashSet<NamespacedName<'a>>,
 }
 
-fn compute_parent_edges_for_public_items(crate_: &Crate) -> HashMap<u32, Vec<ParentEdge<'_>>> {
+fn compute_parent_edges_for_public_items(
+    crate_: &Crate,
+    stability_policy: PublicApiStabilityPolicy,
+) -> HashMap<u32, Vec<ParentEdge<'_>>> {
     let root_id = &crate_.root;
 
     if let Some(root_module) = crate_.index.get(root_id) {
         if root_module.visibility == Visibility::Public {
-            let traversal_state = resolve_crate_names(crate_);
+            let traversal_state = resolve_crate_names(crate_, stability_policy);
 
             // Avoid cycles by keeping track of which items we're in the middle of visiting.
             let mut currently_visited_items: HashSet<u32> = Default::default();
@@ -490,7 +505,10 @@ fn get_names_for_item<'a>(
     }
 }
 
-fn resolve_crate_names(crate_: &Crate) -> NameResolution<'_> {
+fn resolve_crate_names<'a>(
+    crate_: &'a Crate,
+    stability_policy: PublicApiStabilityPolicy,
+) -> NameResolution<'a> {
     let mut result = NameResolution::default();
 
     for item in crate_.index.values() {
@@ -531,9 +549,14 @@ fn resolve_crate_names(crate_: &Crate) -> NameResolution<'_> {
                         //
                         // TODO: This only handles within-crate imports. It'll need to be updated
                         //       when we support multiple crates and cross-crate imports.
+                        let mut invisible_glob_modifiers =
+                            EdgeModifiers::from_item(inner_item, stability_policy);
                         let mut underlying_item = target;
                         let final_underlying_id = loop {
                             if let ItemEnum::Use(next_import) = &underlying_item.inner {
+                                invisible_glob_modifiers = invisible_glob_modifiers.union(
+                                    EdgeModifiers::from_item(underlying_item, stability_policy),
+                                );
                                 match next_import.id.as_ref().and_then(|id| crate_.index.get(id)) {
                                     None => break None,
                                     Some(item) => underlying_item = item,
@@ -545,7 +568,10 @@ fn resolve_crate_names(crate_: &Crate) -> NameResolution<'_> {
                         let Some(final_underlying_id) = final_underlying_id else {
                             continue;
                         };
-                        let definition = Definition::new(final_underlying_id.0);
+                        let definition = Definition {
+                            final_underlying_id: final_underlying_id.0,
+                            invisible_glob_modifiers,
+                        };
 
                         result
                             .names_defined_in_module
@@ -602,12 +628,16 @@ fn resolve_crate_names(crate_: &Crate) -> NameResolution<'_> {
         }
     }
 
-    resolve_glob_imported_names(crate_, &mut result);
+    resolve_glob_imported_names(crate_, stability_policy, &mut result);
 
     result
 }
 
-fn resolve_glob_imported_names<'a>(crate_: &'a Crate, traversal_state: &mut NameResolution<'a>) {
+fn resolve_glob_imported_names<'a>(
+    crate_: &'a Crate,
+    stability_policy: PublicApiStabilityPolicy,
+    traversal_state: &mut NameResolution<'a>,
+) {
     for (&module_id, globs) in &traversal_state.modules_with_glob_imports {
         let mut glob_resolution = GlobResolution::default();
 
@@ -619,12 +649,12 @@ fn resolve_glob_imported_names<'a>(crate_: &'a Crate, traversal_state: &mut Name
             // so its attributes affect the path that downstream users can type.
             recursively_compute_visited_names_for_glob(
                 crate_,
+                stability_policy,
                 module_id,
                 glob_id,
                 &*traversal_state,
                 &mut glob_resolution,
                 EdgeModifiers::default(),
-                true,
             );
         }
 
@@ -661,34 +691,26 @@ fn resolve_glob_imported_names<'a>(crate_: &'a Crate, traversal_state: &mut Name
 /// `glob_modifiers` contains modifiers from glob imports that are already known to affect
 /// the path being synthesized in `glob_parent_module_id`.
 ///
-/// Set `include_current_glob_modifiers` to `true` when `glob_id` is one of the glob imports
-/// directly contained in `glob_parent_module_id`: that glob is the edge that exposes names
-/// in the module we're resolving, so its `#[doc(hidden)]` and deprecation metadata must be
-/// attached to the resulting importable paths.
-///
-/// Set it to `false` when following a glob import inside the target module of another glob.
-/// In that case the nested glob is used only to discover which names the target module exports;
-/// downstream users import those names through the outer glob, so the nested glob's own
-/// metadata is not part of the path they can type.
+/// Each glob traversed here is required to expose the synthesized name. Even when an outer
+/// glob creates the final top-level path, a nested glob may be what made that name visible in
+/// the outer glob's target module, so its `#[doc(hidden)]`, deprecation, and stability metadata
+/// must still be attached to the resulting importable path.
 fn recursively_compute_visited_names_for_glob<'a>(
     crate_: &'a Crate,
+    stability_policy: PublicApiStabilityPolicy,
     glob_parent_module_id: u32,
     glob_id: u32,
     traversal_state: &NameResolution<'a>,
     glob_resolution: &mut GlobResolution<'a>,
     glob_modifiers: EdgeModifiers,
-    include_current_glob_modifiers: bool,
 ) {
     let glob_item = &crate_.index[&rustdoc_types::Id(glob_id)];
     let ItemEnum::Use(glob_import) = &glob_item.inner else {
         unreachable!("Id {glob_id:?} was not a glob: {glob_item:?}");
     };
     assert!(glob_import.is_glob, "not a glob import: {glob_import:?}");
-    let glob_modifiers = if include_current_glob_modifiers {
-        glob_modifiers.union(EdgeModifiers::from_item(glob_item))
-    } else {
-        glob_modifiers
-    };
+    let glob_modifiers =
+        glob_modifiers.union(EdgeModifiers::from_item(glob_item, stability_policy));
 
     let module_local_items = traversal_state
         .names_defined_in_module
@@ -750,16 +772,15 @@ fn recursively_compute_visited_names_for_glob<'a>(
     // Recurse into any glob imports defined here.
     if let Some(globs) = traversal_state.modules_with_glob_imports.get(&module_id) {
         for &glob_id in globs {
-            // Nested globs describe the target module's exported names,
-            // but they are not the visible edge from the module currently being resolved.
+            // Nested globs may be part of the chain that makes the final name visible.
             recursively_compute_visited_names_for_glob(
                 crate_,
+                stability_policy,
                 module_id,
                 glob_id,
                 traversal_state,
                 glob_resolution,
                 glob_modifiers,
-                false,
             );
         }
     }

--- a/test_crates/doc_hidden_glob_reexports/Cargo.toml
+++ b/test_crates/doc_hidden_glob_reexports/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "doc_hidden_glob_reexports"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]

--- a/test_crates/doc_hidden_glob_reexports/src/lib.rs
+++ b/test_crates/doc_hidden_glob_reexports/src/lib.rs
@@ -1,0 +1,38 @@
+mod hidden_glob_only_source {
+    pub struct HiddenGlobOnly;
+}
+
+mod hidden_glob_only {
+    #[doc(hidden)]
+    pub use super::hidden_glob_only_source::*;
+}
+
+pub use hidden_glob_only::*;
+
+mod hidden_and_visible_glob_source {
+    pub struct HiddenAndVisibleGlob;
+}
+
+mod hidden_glob_path {
+    #[doc(hidden)]
+    pub use super::hidden_and_visible_glob_source::*;
+}
+
+mod visible_glob_path {
+    pub use super::hidden_and_visible_glob_source::*;
+}
+
+pub use hidden_glob_path::*;
+pub use visible_glob_path::*;
+
+mod direct_use_source {
+    pub struct HiddenGlobAndDirectUse;
+}
+
+mod hidden_glob_for_direct_use {
+    #[doc(hidden)]
+    pub use super::direct_use_source::*;
+}
+
+pub use hidden_glob_for_direct_use::*;
+pub use direct_use_source::HiddenGlobAndDirectUse;

--- a/test_crates/importable_paths/src/lib.rs
+++ b/test_crates/importable_paths/src/lib.rs
@@ -187,10 +187,8 @@ mod nested_glob_layer {
     pub use super::nested_glob_source::*;
 }
 
-// Everything re-exported here is public API.
-// It doesn't matter that the names within the module
-// are imported with `#[doc(hidden)]`.
-// The external user is not relying on those -- they are using a public API item only.
+// Everything re-exported here is reachable but not public API: the hidden glob
+// inside `nested_glob_layer` is what makes the names visible to this glob.
 pub use nested_glob_layer::*;
 
 mod nested_hidden_deprecated_glob_source {
@@ -203,10 +201,8 @@ mod nested_hidden_deprecated_glob_layer {
     pub use super::nested_hidden_deprecated_glob_source::*;
 }
 
-// Everything re-exported here is public API.
-// It doesn't matter that the names within the module
-// are imported with `#[doc(hidden)]` nor `#[deprecated]`.
-// The external user is not relying on those -- they are using a public API item only.
+// Everything re-exported here is still public API because the hidden glob inside
+// `nested_hidden_deprecated_glob_layer` is also deprecated.
 pub use nested_hidden_deprecated_glob_layer::*;
 
 mod plain_glob_source {
@@ -215,13 +211,12 @@ mod plain_glob_source {
 
 pub use plain_glob_source::*;
 
-// A non-hidden re-export of an internally-hidden re-export is public API.
+// A non-hidden per-item re-export of an internally-hidden per-item re-export is public API.
 //
-// For this next batch of re-exports, the fact that the intermediate re-export
-// may be `#[doc(hidden)]` doesn't matter. Items can be made to be non-public API
-// if *either* the item's definition itself is `#[doc(hidden)]`
-// *or* if the path that an external (downstream) user might type involves a `#[doc(hidden)]` name,
-// in each case also accounting for `#[deprecated]` exceptions of course.
+// Glob re-exports are different: the glob `Use` item supplies names without
+// becoming a path component, but its `#[doc(hidden)]` still applies to the path
+// it creates. This next batch covers both cases, including the usual
+// `#[deprecated]` exceptions.
 
 mod top_level_public_api_per_item_sources {
     pub struct HiddenPerItemThenRootPerItem;
@@ -262,6 +257,8 @@ mod hidden_glob_for_root_glob {
     pub use super::hidden_glob_then_root_glob_source::*;
 }
 
+// This glob creates a top-level path, but only because the target module exposes
+// the name via a hidden glob, so the top-level path is not public API.
 pub use hidden_glob_for_root_glob::*;
 
 // Our doc-hidden analysis works even when `#[doc(hidden)]` does not appear verbatim

--- a/test_crates/maybe_const_function_signature/Cargo.toml
+++ b/test_crates/maybe_const_function_signature/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "maybe_const_function_signature"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]

--- a/test_crates/maybe_const_function_signature/src/lib.rs
+++ b/test_crates/maybe_const_function_signature/src/lib.rs
@@ -1,0 +1,10 @@
+#![allow(internal_features)]
+#![feature(const_trait_impl)]
+
+pub const trait MaybeConst {}
+
+pub const fn maybe_const_function_signature(
+    arg: impl [const] MaybeConst,
+) -> impl [const] MaybeConst {
+    arg
+}

--- a/test_crates/rust_std_stability/Cargo.toml
+++ b/test_crates/rust_std_stability/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rust_std_stability"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]

--- a/test_crates/rust_std_stability/src/lib.rs
+++ b/test_crates/rust_std_stability/src/lib.rs
@@ -1,0 +1,157 @@
+// Emit structured stdlib-style stability data by enabling unstable Rust features.
+#![allow(internal_features)]
+#![feature(const_trait_impl)]
+#![feature(rustc_attrs)]
+#![feature(staged_api)]
+#![stable(feature = "rust_std_stability_fixture", since = "1.0.0")]
+
+#[unstable(feature = "unstable_function", issue = "none")]
+pub fn unstable_function() -> u32 {
+    0
+}
+
+#[stable(feature = "stable_const_stable", since = "1.0.0")]
+#[rustc_const_stable(feature = "const_stable", since = "1.0.0")]
+pub const fn stable_const_stable() -> u32 {
+    0
+}
+
+#[stable(feature = "stable_const_unstable", since = "1.0.0")]
+#[rustc_const_unstable(feature = "const_unstable", issue = "none")]
+pub const fn stable_const_unstable() -> u32 {
+    0
+}
+
+#[unstable(feature = "unstable_const_function", issue = "none")]
+pub const fn unstable_const_function() -> u32 {
+    0
+}
+
+#[unstable(feature = "unstable_module", issue = "none")]
+pub mod unstable_module {
+    #[stable(feature = "stable_inside_unstable_module", since = "1.0.0")]
+    pub fn stable_inside_unstable_module() -> u32 {
+        0
+    }
+}
+
+#[unstable(feature = "unstable_reexport_source", issue = "none")]
+pub mod unstable_reexport_source {
+    #[stable(feature = "stable_reexported_from_unstable_module", since = "1.0.0")]
+    pub fn stable_reexported_from_unstable_module() -> u32 {
+        0
+    }
+}
+
+#[stable(feature = "stable_reexport_from_unstable_module", since = "1.0.0")]
+pub use unstable_reexport_source::stable_reexported_from_unstable_module as stable_reexport_from_unstable_module;
+
+#[stable(feature = "reexport_source", since = "1.0.0")]
+pub mod reexport_source {
+    #[stable(feature = "reexport_target", since = "1.0.0")]
+    pub fn reexport_target() -> u32 {
+        0
+    }
+}
+
+#[stable(feature = "stable_reexport", since = "1.0.0")]
+pub use reexport_source::reexport_target as stable_reexport_target;
+
+#[unstable(feature = "unstable_reexport", issue = "none")]
+pub use reexport_source::reexport_target as unstable_reexport_target;
+
+#[stable(feature = "direct_glob_source", since = "1.0.0")]
+pub mod direct_glob_source {
+    #[stable(feature = "direct_glob_target", since = "1.0.0")]
+    pub fn direct_glob_target() -> u32 {
+        0
+    }
+}
+
+#[unstable(feature = "unstable_direct_glob", issue = "none")]
+pub use direct_glob_source::*;
+
+#[stable(feature = "nested_outer", since = "1.0.0")]
+pub mod nested_outer {
+    #[stable(feature = "nested_inner", since = "1.0.0")]
+    pub mod nested_inner {
+        #[stable(feature = "nested_glob_target", since = "1.0.0")]
+        pub fn nested_glob_target() -> u32 {
+            0
+        }
+    }
+
+    #[unstable(feature = "unstable_inner_glob", issue = "none")]
+    pub use nested_inner::*;
+}
+
+#[stable(feature = "stable_outer_glob", since = "1.0.0")]
+pub use nested_outer::*;
+
+#[stable(feature = "non_glob_through_glob_source", since = "1.0.0")]
+pub mod non_glob_through_glob_source {
+    #[stable(feature = "non_glob_target", since = "1.0.0")]
+    pub fn non_glob_target() -> u32 {
+        0
+    }
+
+    #[unstable(feature = "non_glob_unstable_alias", issue = "none")]
+    pub use self::non_glob_target as non_glob_unstable_alias;
+}
+
+#[stable(feature = "stable_glob_with_unstable_alias", since = "1.0.0")]
+pub use non_glob_through_glob_source::*;
+
+#[stable(feature = "item_stability_owner", since = "1.0.0")]
+pub struct ItemStabilityOwner;
+
+#[unstable(feature = "unstable_trait_with_unannotated_method", issue = "none")]
+pub trait UnstableTraitWithUnannotatedMethod {
+    // Rustdoc JSON should propagate the trait's instability onto this method item.
+    // The adapter relies on that item-local `stability` instead of looking up the trait.
+    fn unannotated_method_in_unstable_trait() -> u32;
+}
+
+#[unstable(feature = "unstable_inherent_impl", issue = "none")]
+impl ItemStabilityOwner {
+    // Rustdoc JSON should propagate the impl's instability onto this method item.
+    // The adapter relies on that item-local `stability` instead of looking up the impl.
+    pub fn method_inside_unstable_inherent_impl() -> u32 {
+        0
+    }
+}
+
+#[stable(feature = "const_impl_owner", since = "1.0.0")]
+pub struct ConstImplOwner;
+
+#[stable(feature = "const_inherent_impl", since = "1.0.0")]
+#[rustc_const_unstable(feature = "const_inherent_impl_unstable", issue = "none")]
+const impl ConstImplOwner {
+    // Rustdoc JSON should propagate the impl's const-instability onto this method item.
+    // The adapter relies on that item-local `const_stability` instead of looking up the impl.
+    #[stable(feature = "const_impl_method", since = "1.0.0")]
+    pub fn const_impl_method() -> u32 {
+        0
+    }
+}
+
+#[stable(feature = "fixture_const_trait", since = "1.0.0")]
+#[rustc_const_unstable(feature = "fixture_const_trait_unstable", issue = "none")]
+pub const trait FixtureConstTrait {
+    // This is not syntactically `const`, but rustdoc JSON should still propagate
+    // the trait's const-instability onto the method item.
+    #[stable(feature = "provided", since = "1.0.0")]
+    fn provided() {}
+}
+
+#[stable(feature = "fixture_const_bound", since = "1.0.0")]
+#[rustc_const_unstable(feature = "fixture_const_bound_unstable", issue = "none")]
+pub const trait FixtureConstBound {}
+
+#[stable(feature = "const_trait_marker", since = "1.0.0")]
+#[rustc_const_unstable(feature = "const_trait_marker_unstable", issue = "none")]
+pub const fn const_trait_marker(
+    arg: impl [const] FixtureConstBound,
+) -> impl [const] FixtureConstBound {
+    arg
+}

--- a/test_crates/rust_std_stability/src/lib.rs
+++ b/test_crates/rust_std_stability/src/lib.rs
@@ -121,20 +121,6 @@ impl ItemStabilityOwner {
     }
 }
 
-#[stable(feature = "const_impl_owner", since = "1.0.0")]
-pub struct ConstImplOwner;
-
-#[stable(feature = "const_inherent_impl", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_inherent_impl_unstable", issue = "none")]
-const impl ConstImplOwner {
-    // Rustdoc JSON should propagate the impl's const-instability onto this method item.
-    // The adapter relies on that item-local `const_stability` instead of looking up the impl.
-    #[stable(feature = "const_impl_method", since = "1.0.0")]
-    pub fn const_impl_method() -> u32 {
-        0
-    }
-}
-
 #[stable(feature = "fixture_const_trait", since = "1.0.0")]
 #[rustc_const_unstable(feature = "fixture_const_trait_unstable", issue = "none")]
 pub const trait FixtureConstTrait {


### PR DESCRIPTION
Also ports stability infra, just for API equivalence and without
exposing any stability info since this rustdoc JSON version doesn't
expose it.

This is a backport of #1080.