### PR TITLE
Support default-value stability in rustdoc JSON v60.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,9 +505,9 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustdoc-types"
-version = "0.59.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e25ff539c83e47de65a6a790446186286d3a64bfadc780ed557cc3410d9509"
+checksum = "d5b3f47eac1cf443b5556c2351d68ea609197f7a40735c9725ce7515d6fd5e91"
 dependencies = [
  "rustc-hash",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ indexmap = "2.11.0"
 # Keep this dependency last, its own block, since we change it often via automated means
 # and we'd like to avoid merge conflicts.
 #
-rustdoc-types = "0.59.0"
+rustdoc-types = "0.60.0"
 #
 # No dependencies after this point. Put all dependencies above this section.
 #

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -213,10 +213,10 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
                     properties::resolve_raw_type_property(contexts, property_name)
                 }
                 "AssociatedType" => {
-                    properties::resolve_associated_type_property(contexts, property_name)
+                    properties::resolve_associated_type_property(contexts, property_name, self)
                 }
                 "AssociatedConstant" => {
-                    properties::resolve_associated_constant_property(contexts, property_name)
+                    properties::resolve_associated_constant_property(contexts, property_name, self)
                 }
                 "Constant" => properties::resolve_constant_property(contexts, property_name),
                 "Discriminant" => {

--- a/src/adapter/optimizations/method_lookup.rs
+++ b/src/adapter/optimizations/method_lookup.rs
@@ -12,6 +12,7 @@ use crate::{
     adapter::{Origin, Vertex},
     hashtables::{HashMap, HashSet},
     indexed_crate::ImplEntry,
+    stability::PublicApiStabilityPolicy,
 };
 
 pub(crate) fn resolve_impl_methods<'a, V: AsVertex<Vertex<'a>> + 'a>(
@@ -38,11 +39,18 @@ pub(crate) fn resolve_impl_methods<'a, V: AsVertex<Vertex<'a>> + 'a>(
     } else {
         resolve_neighbors_with(contexts, move |vertex| {
             let origin = vertex.origin;
-            let item_index = &adapter.crate_at_origin(origin).own_crate.inner.index;
+            let indexed_crate = &adapter.crate_at_origin(origin).own_crate;
+            let item_index = &indexed_crate.inner.index;
 
             let impl_item = vertex.as_item().expect("not an Impl item");
             let impl_vertex = vertex.as_impl().expect("not an Impl vertex");
-            resolve_methods_slow_path(impl_item, impl_vertex, origin, item_index)
+            resolve_methods_slow_path(
+                impl_item,
+                impl_vertex,
+                origin,
+                item_index,
+                indexed_crate.stability_policy,
+            )
         })
     }
 }
@@ -81,10 +89,9 @@ fn resolve_method_from_candidate_value<'a>(
     method_name: CandidateValue<FieldValue>,
 ) -> VertexIterator<'a, Vertex<'a>> {
     let origin = vertex.origin;
-    let item_index = &adapter.crate_at_origin(origin).own_crate.inner.index;
-    let impl_index = adapter
-        .crate_at_origin(origin)
-        .own_crate
+    let indexed_crate = &adapter.crate_at_origin(origin).own_crate;
+    let item_index = &indexed_crate.inner.index;
+    let impl_index = indexed_crate
         .impl_method_index
         .as_ref()
         .expect("no impl index provided");
@@ -120,14 +127,26 @@ fn resolve_method_from_candidate_value<'a>(
             _ => {
                 // Fall back to the default slow path.
                 let impl_item = vertex.as_item().expect("not an Impl item");
-                resolve_methods_slow_path(impl_item, impl_vertex, origin, item_index)
+                resolve_methods_slow_path(
+                    impl_item,
+                    impl_vertex,
+                    origin,
+                    item_index,
+                    indexed_crate.stability_policy,
+                )
             }
         }
     } else {
         // We couldn't determine the Id of the item that owns this method.
         // Fall back to the default slow path.
         let impl_item = vertex.as_item().expect("not an Impl item");
-        resolve_methods_slow_path(impl_item, impl_vertex, origin, item_index)
+        resolve_methods_slow_path(
+            impl_item,
+            impl_vertex,
+            origin,
+            item_index,
+            indexed_crate.stability_policy,
+        )
     }
 }
 
@@ -205,6 +224,7 @@ fn resolve_methods_slow_path<'a>(
     impl_vertex: &'a Impl,
     origin: Origin,
     item_index: &'a HashMap<Id, Item>,
+    stability_policy: PublicApiStabilityPolicy,
 ) -> VertexIterator<'a, Vertex<'a>> {
     let provided_methods: Box<dyn Iterator<Item = &Id>> =
         if impl_vertex.provided_trait_methods.is_empty() {
@@ -225,12 +245,18 @@ fn resolve_methods_slow_path<'a>(
             if let Some(trait_item) = trait_item {
                 if let ItemEnum::Trait(trait_item) = &trait_item.inner {
                     Box::new(trait_item.items.iter().filter(move |item_id| {
-                        let next_item = item_index.get(item_id);
-                        if let Some(name) = next_item.and_then(|x| x.name.as_deref()) {
-                            method_names.contains(name)
-                        } else {
-                            false
-                        }
+                        let Some(next_item) = item_index.get(item_id) else {
+                            return false;
+                        };
+                        let rustdoc_types::ItemEnum::Function(function) = &next_item.inner else {
+                            return false;
+                        };
+                        let Some(name) = next_item.name.as_deref() else {
+                            return false;
+                        };
+
+                        method_names.contains(name)
+                            && stability_policy.effective_function_has_body(function)
                     }))
                 } else {
                     unreachable!("found a non-trait type {trait_item:?}");

--- a/src/adapter/properties.rs
+++ b/src/adapter/properties.rs
@@ -279,10 +279,15 @@ pub(super) fn resolve_function_like_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
             contexts,
             field_property!(as_function, header, { header.is_unsafe.into() }),
         ),
-        "has_body" => resolve_property_with(
-            contexts,
-            field_property!(as_function, has_body, { (*has_body).into() }),
-        ),
+        "has_body" => resolve_property_with(contexts, move |vertex| {
+            let function = vertex.as_function().expect("FunctionLike not a function");
+
+            adapter
+                .crate_at_origin(vertex.origin)
+                .own_crate
+                .effective_function_has_body(function)
+                .into()
+        }),
         "signature" => resolve_property_with(contexts, move |vertex| {
             let item = vertex.as_item().expect("FunctionLike not an item");
             let func = vertex.as_function().expect("FunctionLike not a function");
@@ -677,17 +682,18 @@ pub(crate) fn resolve_static_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
 pub(crate) fn resolve_associated_type_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     property_name: &str,
+    adapter: &'a RustdocAdapter<'a>,
 ) -> ContextOutcomeIterator<'a, V, FieldValue> {
     match property_name {
-        "has_default" => resolve_property_with(
-            contexts,
-            field_property!(as_item, inner, {
-                let ItemEnum::AssocType { type_, .. } = &inner else {
-                    unreachable!("expected to have a AssocType")
-                };
-                type_.is_some().into()
-            }),
-        ),
+        "has_default" => resolve_property_with(contexts, move |vertex| {
+            let item = vertex.as_item().expect("AssociatedType not an item");
+
+            adapter
+                .crate_at_origin(vertex.origin)
+                .own_crate
+                .effective_assoc_type_has_default(item)
+                .into()
+        }),
         _ => unreachable!("AssociatedType property {property_name}"),
     }
 }
@@ -695,17 +701,19 @@ pub(crate) fn resolve_associated_type_property<'a, V: AsVertex<Vertex<'a>> + 'a>
 pub(crate) fn resolve_associated_constant_property<'a, V: AsVertex<Vertex<'a>> + 'a>(
     contexts: ContextIterator<'a, V>,
     property_name: &str,
+    adapter: &'a RustdocAdapter<'a>,
 ) -> ContextOutcomeIterator<'a, V, FieldValue> {
     match property_name {
-        "default" => resolve_property_with(
-            contexts,
-            field_property!(as_item, inner, {
-                let ItemEnum::AssocConst { value: default, .. } = &inner else {
-                    unreachable!("expected to have a AssocConst")
-                };
-                default.clone().into()
-            }),
-        ),
+        "default" => resolve_property_with(contexts, move |vertex| {
+            let item = vertex.as_item().expect("AssociatedConstant not an item");
+
+            adapter
+                .crate_at_origin(vertex.origin)
+                .own_crate
+                .effective_assoc_const_default(item)
+                .map(ToString::to_string)
+                .into()
+        }),
         _ => unreachable!("AssociatedConstant property {property_name}"),
     }
 }

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -7106,6 +7106,322 @@ fn default_policy_ignores_rust_std_default_stability() {
 }
 
 #[test]
+fn rust_std_impl_methods_hide_omitted_unstable_defaults() {
+    get_rust_std_test_data!(data, rust_std_stability);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    // This query has no `method.name` filter, so both `ImplOwner.impl`
+    // and nested `Impl.method` use their unfiltered paths.
+    // It checks the complete std-mode method list for an impl that
+    // omits an unstable default and one that overrides it.
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Struct {
+                owner: name @filter(op: "one_of", value: ["$owners"]) @output
+
+                impl {
+                    implemented_trait {
+                        bare_name @filter(op: "=", value: ["$trait"])
+                    }
+
+                    method {
+                        method_name: name @output
+                        has_body @output
+                    }
+                }
+            }
+        }
+    }
+}
+    "#;
+    let variables = btreemap! {
+        "owners" => FieldValue::List(vec![
+            FieldValue::String("DefaultStabilityImplOmittingDefaults".into()),
+            FieldValue::String("DefaultStabilityImplOverridingDefault".into()),
+        ].into()),
+        "trait" => FieldValue::String("DefaultStabilityTrait".into()),
+    };
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        owner: String,
+        method_name: String,
+        has_body: bool,
+    }
+
+    let mut results: Vec<Output> = trustfall::execute_query(&schema, adapter, query, variables)
+        .expect("failed to run query")
+        .map(|row| row.try_into_struct().expect("shape mismatch"))
+        .collect();
+    results.sort_unstable();
+
+    let mut expected_results = vec![
+        Output {
+            owner: "DefaultStabilityImplOmittingDefaults".into(),
+            method_name: "required_method".into(),
+            has_body: true,
+        },
+        Output {
+            owner: "DefaultStabilityImplOmittingDefaults".into(),
+            method_name: "stable_default_method".into(),
+            has_body: true,
+        },
+        Output {
+            owner: "DefaultStabilityImplOverridingDefault".into(),
+            method_name: "required_method".into(),
+            has_body: true,
+        },
+        Output {
+            owner: "DefaultStabilityImplOverridingDefault".into(),
+            method_name: "stable_default_method".into(),
+            has_body: true,
+        },
+        Output {
+            owner: "DefaultStabilityImplOverridingDefault".into(),
+            method_name: "unstable_default_method".into(),
+            has_body: true,
+        },
+    ];
+    expected_results.sort_unstable();
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
+#[test]
+fn rust_std_impl_method_lookup_hides_omitted_unstable_default() {
+    get_rust_std_test_data!(data, rust_std_stability);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    // This uses a mandatory `method.name` filter, so the owner-side
+    // `ImplOwner.impl` method-name optimization may discard impls whose
+    // matching method is absent before the nested `Impl.method` resolver runs.
+    // Under std mode, the impl that omits the unstable default should disappear.
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Struct {
+                owner: name @filter(op: "one_of", value: ["$owners"]) @output
+
+                impl {
+                    implemented_trait {
+                        bare_name @filter(op: "=", value: ["$trait"])
+                    }
+
+                    method {
+                        method_name: name @filter(op: "=", value: ["$method"]) @output
+                    }
+                }
+            }
+        }
+    }
+}
+    "#;
+    let variables = btreemap! {
+        "owners" => FieldValue::List(vec![
+            FieldValue::String("DefaultStabilityImplOmittingDefaults".into()),
+            FieldValue::String("DefaultStabilityImplOverridingDefault".into()),
+        ].into()),
+        "trait" => FieldValue::String("DefaultStabilityTrait".into()),
+        "method" => FieldValue::String("unstable_default_method".into()),
+    };
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        owner: String,
+        method_name: String,
+    }
+
+    let results: Vec<Output> = trustfall::execute_query(&schema, adapter, query, variables)
+        .expect("failed to run query")
+        .map(|row| row.try_into_struct().expect("shape mismatch"))
+        .collect();
+
+    similar_asserts::assert_eq!(
+        vec![Output {
+            owner: "DefaultStabilityImplOverridingDefault".into(),
+            method_name: "unstable_default_method".into(),
+        }],
+        results,
+    );
+}
+
+#[test]
+fn default_policy_impl_method_lookup_includes_omitted_unstable_default() {
+    let rustdoc = crate::test_util::load_pregenerated_rustdoc("rust_std_stability");
+    let data = PackageIndex::from_crate(&rustdoc);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    // This is the same owner-side method-name optimization shape as
+    // the std-policy test above, but under the default indexing policy.
+    // Ordinary crates should ignore std default-body stability and keep the
+    // omitted unstable default visible.
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Struct {
+                owner: name @filter(op: "one_of", value: ["$owners"]) @output
+
+                impl {
+                    implemented_trait {
+                        bare_name @filter(op: "=", value: ["$trait"])
+                    }
+
+                    method {
+                        method_name: name @filter(op: "=", value: ["$method"]) @output
+                    }
+                }
+            }
+        }
+    }
+}
+    "#;
+    let variables = btreemap! {
+        "owners" => FieldValue::List(vec![
+            FieldValue::String("DefaultStabilityImplOmittingDefaults".into()),
+            FieldValue::String("DefaultStabilityImplOverridingDefault".into()),
+        ].into()),
+        "trait" => FieldValue::String("DefaultStabilityTrait".into()),
+        "method" => FieldValue::String("unstable_default_method".into()),
+    };
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        owner: String,
+        method_name: String,
+    }
+
+    let mut results: Vec<Output> = trustfall::execute_query(&schema, adapter, query, variables)
+        .expect("failed to run query")
+        .map(|row| row.try_into_struct().expect("shape mismatch"))
+        .collect();
+    results.sort_unstable();
+
+    let mut expected_results = vec![
+        Output {
+            owner: "DefaultStabilityImplOmittingDefaults".into(),
+            method_name: "unstable_default_method".into(),
+        },
+        Output {
+            owner: "DefaultStabilityImplOverridingDefault".into(),
+            method_name: "unstable_default_method".into(),
+        },
+    ];
+    expected_results.sort_unstable();
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
+#[test]
+fn impl_method_name_lookup_applies_default_body_stability_policy() {
+    let rustdoc = crate::test_util::load_pregenerated_rustdoc("rust_std_stability");
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    // The folded `method` edge keeps impls whose matching-method count is zero,
+    // so the owner-side `ImplOwner.impl` method-name optimization cannot remove
+    // those impls before the nested `Impl.method` resolver runs.
+    // This pins down the behavior of the name-filtered `Impl.method` path itself:
+    // std mode hides omitted unstable defaults, while default mode keeps them visible.
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Struct {
+                owner: name @filter(op: "one_of", value: ["$owners"]) @output
+
+                impl {
+                    implemented_trait {
+                        bare_name @filter(op: "=", value: ["$trait"])
+                    }
+
+                    method @fold @transform(op: "count") @output(name: "matching_methods") {
+                        name @filter(op: "=", value: ["$method"])
+                    }
+                }
+            }
+        }
+    }
+}
+    "#;
+    let variables = btreemap! {
+        "owners" => FieldValue::List(vec![
+            FieldValue::String("DefaultStabilityImplOmittingDefaults".into()),
+            FieldValue::String("DefaultStabilityImplOverridingDefault".into()),
+        ].into()),
+        "trait" => FieldValue::String("DefaultStabilityTrait".into()),
+        "method" => FieldValue::String("unstable_default_method".into()),
+    };
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        owner: String,
+        matching_methods: u64,
+    }
+
+    let data = PackageIndex::from_rust_std_component_crate(&rustdoc);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+    let mut rust_std_results: Vec<Output> =
+        trustfall::execute_query(&schema, adapter, query, variables.clone())
+            .expect("failed to run std policy query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    rust_std_results.sort_unstable();
+
+    similar_asserts::assert_eq!(
+        vec![
+            Output {
+                owner: "DefaultStabilityImplOmittingDefaults".into(),
+                matching_methods: 0,
+            },
+            Output {
+                owner: "DefaultStabilityImplOverridingDefault".into(),
+                matching_methods: 1,
+            },
+        ],
+        rust_std_results,
+    );
+
+    let data = PackageIndex::from_crate(&rustdoc);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+    let mut default_results: Vec<Output> =
+        trustfall::execute_query(&schema, adapter, query, variables)
+            .expect("failed to run default policy query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    default_results.sort_unstable();
+
+    similar_asserts::assert_eq!(
+        vec![
+            Output {
+                owner: "DefaultStabilityImplOmittingDefaults".into(),
+                matching_methods: 1,
+            },
+            Output {
+                owner: "DefaultStabilityImplOverridingDefault".into(),
+                matching_methods: 1,
+            },
+        ],
+        default_results,
+    );
+}
+
+#[test]
 fn rust_std_unstable_defaults_affect_public_api_sealing() {
     get_rust_std_test_data!(data, rust_std_stability);
     let adapter = RustdocAdapter::new(&data, None);

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -6723,6 +6723,459 @@ fn default_policy_ignores_rust_std_const_stability() {
 }
 
 #[test]
+fn rust_std_default_facets_report_stable_guarantee() {
+    get_rust_std_test_data!(data, rust_std_stability);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    let trait_name = FieldValue::String("DefaultStabilityTrait".into());
+
+    let method_query = r#"
+{
+    Crate {
+        item {
+            ... on Trait {
+                name @filter(op: "=", value: ["$trait"])
+
+                method {
+                    name @filter(op: "one_of", value: ["$methods"]) @output
+                    has_body @output
+                    public_api_eligible @output
+                }
+            }
+        }
+    }
+}
+    "#;
+    let variables = btreemap! {
+        "trait" => trait_name.clone(),
+        "methods" => FieldValue::List(vec![
+            FieldValue::String("stable_default_method".into()),
+            FieldValue::String("unstable_default_method".into()),
+            FieldValue::String("required_method".into()),
+        ].into()),
+    };
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct MethodOutput {
+        name: String,
+        has_body: bool,
+        public_api_eligible: bool,
+    }
+
+    let mut results: Vec<MethodOutput> =
+        trustfall::execute_query(&schema, adapter.clone(), method_query, variables)
+            .expect("failed to run method query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    let mut expected_results = vec![
+        MethodOutput {
+            name: "stable_default_method".into(),
+            has_body: true,
+            public_api_eligible: true,
+        },
+        MethodOutput {
+            name: "unstable_default_method".into(),
+            has_body: false,
+            public_api_eligible: true,
+        },
+        MethodOutput {
+            name: "required_method".into(),
+            has_body: false,
+            public_api_eligible: true,
+        },
+    ];
+    expected_results.sort_unstable();
+    similar_asserts::assert_eq!(expected_results, results);
+
+    let associated_type_query = r#"
+{
+    Crate {
+        item {
+            ... on Trait {
+                name @filter(op: "=", value: ["$trait"])
+
+                associated_type {
+                    name @filter(op: "one_of", value: ["$types"]) @output
+                    has_default @output
+                    public_api_eligible @output
+                }
+            }
+        }
+    }
+}
+    "#;
+    let variables = btreemap! {
+        "trait" => trait_name.clone(),
+        "types" => FieldValue::List(vec![
+            FieldValue::String("StableDefaultType".into()),
+            FieldValue::String("UnstableDefaultType".into()),
+            FieldValue::String("RequiredType".into()),
+        ].into()),
+    };
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct AssociatedTypeOutput {
+        name: String,
+        has_default: bool,
+        public_api_eligible: bool,
+    }
+
+    let mut results: Vec<AssociatedTypeOutput> =
+        trustfall::execute_query(&schema, adapter.clone(), associated_type_query, variables)
+            .expect("failed to run associated type query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    let mut expected_results = vec![
+        AssociatedTypeOutput {
+            name: "StableDefaultType".into(),
+            has_default: true,
+            public_api_eligible: true,
+        },
+        AssociatedTypeOutput {
+            name: "UnstableDefaultType".into(),
+            has_default: false,
+            public_api_eligible: true,
+        },
+        AssociatedTypeOutput {
+            name: "RequiredType".into(),
+            has_default: false,
+            public_api_eligible: true,
+        },
+    ];
+    expected_results.sort_unstable();
+    similar_asserts::assert_eq!(expected_results, results);
+
+    let associated_const_query = r#"
+{
+    Crate {
+        item {
+            ... on Trait {
+                name @filter(op: "=", value: ["$trait"])
+
+                associated_constant {
+                    name @filter(op: "one_of", value: ["$consts"]) @output
+                    default @output
+                    public_api_eligible @output
+                }
+            }
+        }
+    }
+}
+    "#;
+    let variables = btreemap! {
+        "trait" => trait_name,
+        "consts" => FieldValue::List(vec![
+            FieldValue::String("STABLE_DEFAULT_CONST".into()),
+            FieldValue::String("UNSTABLE_DEFAULT_CONST".into()),
+            FieldValue::String("REQUIRED_CONST".into()),
+        ].into()),
+    };
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct AssociatedConstOutput {
+        name: String,
+        default: Option<String>,
+        public_api_eligible: bool,
+    }
+
+    let mut results: Vec<AssociatedConstOutput> =
+        trustfall::execute_query(&schema, adapter, associated_const_query, variables)
+            .expect("failed to run associated const query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    let mut expected_results = vec![
+        AssociatedConstOutput {
+            name: "STABLE_DEFAULT_CONST".into(),
+            default: Some("1".into()),
+            public_api_eligible: true,
+        },
+        AssociatedConstOutput {
+            name: "UNSTABLE_DEFAULT_CONST".into(),
+            default: None,
+            public_api_eligible: true,
+        },
+        AssociatedConstOutput {
+            name: "REQUIRED_CONST".into(),
+            default: None,
+            public_api_eligible: true,
+        },
+    ];
+    expected_results.sort_unstable();
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
+#[test]
+fn default_policy_ignores_rust_std_default_stability() {
+    let rustdoc = crate::test_util::load_pregenerated_rustdoc("rust_std_stability");
+    let data = PackageIndex::from_crate(&rustdoc);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    let trait_name = FieldValue::String("DefaultStabilityTrait".into());
+
+    let method_query = r#"
+{
+    Crate {
+        item {
+            ... on Trait {
+                name @filter(op: "=", value: ["$trait"])
+
+                method {
+                    name @filter(op: "one_of", value: ["$methods"]) @output
+                    has_body @output
+                    public_api_eligible @output
+                }
+            }
+        }
+    }
+}
+    "#;
+    let variables = btreemap! {
+        "trait" => trait_name.clone(),
+        "methods" => FieldValue::List(vec![
+            FieldValue::String("stable_default_method".into()),
+            FieldValue::String("unstable_default_method".into()),
+            FieldValue::String("required_method".into()),
+        ].into()),
+    };
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct MethodOutput {
+        name: String,
+        has_body: bool,
+        public_api_eligible: bool,
+    }
+
+    let mut results: Vec<MethodOutput> =
+        trustfall::execute_query(&schema, adapter.clone(), method_query, variables)
+            .expect("failed to run method query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    let mut expected_results = vec![
+        MethodOutput {
+            name: "stable_default_method".into(),
+            has_body: true,
+            public_api_eligible: true,
+        },
+        MethodOutput {
+            name: "unstable_default_method".into(),
+            has_body: true,
+            public_api_eligible: true,
+        },
+        MethodOutput {
+            name: "required_method".into(),
+            has_body: false,
+            public_api_eligible: true,
+        },
+    ];
+    expected_results.sort_unstable();
+    similar_asserts::assert_eq!(expected_results, results);
+
+    let associated_type_query = r#"
+{
+    Crate {
+        item {
+            ... on Trait {
+                name @filter(op: "=", value: ["$trait"])
+
+                associated_type {
+                    name @filter(op: "one_of", value: ["$types"]) @output
+                    has_default @output
+                    public_api_eligible @output
+                }
+            }
+        }
+    }
+}
+    "#;
+    let variables = btreemap! {
+        "trait" => trait_name.clone(),
+        "types" => FieldValue::List(vec![
+            FieldValue::String("StableDefaultType".into()),
+            FieldValue::String("UnstableDefaultType".into()),
+            FieldValue::String("RequiredType".into()),
+        ].into()),
+    };
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct AssociatedTypeOutput {
+        name: String,
+        has_default: bool,
+        public_api_eligible: bool,
+    }
+
+    let mut results: Vec<AssociatedTypeOutput> =
+        trustfall::execute_query(&schema, adapter.clone(), associated_type_query, variables)
+            .expect("failed to run associated type query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    let mut expected_results = vec![
+        AssociatedTypeOutput {
+            name: "StableDefaultType".into(),
+            has_default: true,
+            public_api_eligible: true,
+        },
+        AssociatedTypeOutput {
+            name: "UnstableDefaultType".into(),
+            has_default: true,
+            public_api_eligible: true,
+        },
+        AssociatedTypeOutput {
+            name: "RequiredType".into(),
+            has_default: false,
+            public_api_eligible: true,
+        },
+    ];
+    expected_results.sort_unstable();
+    similar_asserts::assert_eq!(expected_results, results);
+
+    let associated_const_query = r#"
+{
+    Crate {
+        item {
+            ... on Trait {
+                name @filter(op: "=", value: ["$trait"])
+
+                associated_constant {
+                    name @filter(op: "one_of", value: ["$consts"]) @output
+                    default @output
+                    public_api_eligible @output
+                }
+            }
+        }
+    }
+}
+    "#;
+    let variables = btreemap! {
+        "trait" => trait_name,
+        "consts" => FieldValue::List(vec![
+            FieldValue::String("STABLE_DEFAULT_CONST".into()),
+            FieldValue::String("UNSTABLE_DEFAULT_CONST".into()),
+            FieldValue::String("REQUIRED_CONST".into()),
+        ].into()),
+    };
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct AssociatedConstOutput {
+        name: String,
+        default: Option<String>,
+        public_api_eligible: bool,
+    }
+
+    let mut results: Vec<AssociatedConstOutput> =
+        trustfall::execute_query(&schema, adapter, associated_const_query, variables)
+            .expect("failed to run associated const query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    let mut expected_results = vec![
+        AssociatedConstOutput {
+            name: "STABLE_DEFAULT_CONST".into(),
+            default: Some("1".into()),
+            public_api_eligible: true,
+        },
+        AssociatedConstOutput {
+            name: "UNSTABLE_DEFAULT_CONST".into(),
+            default: Some("2".into()),
+            public_api_eligible: true,
+        },
+        AssociatedConstOutput {
+            name: "REQUIRED_CONST".into(),
+            default: None,
+            public_api_eligible: true,
+        },
+    ];
+    expected_results.sort_unstable();
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
+#[test]
+fn rust_std_unstable_defaults_affect_public_api_sealing() {
+    get_rust_std_test_data!(data, rust_std_stability);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Trait {
+                name @filter(op: "one_of", value: ["$traits"]) @output
+                unconditionally_sealed @output
+                public_api_sealed @output
+            }
+        }
+    }
+}
+    "#;
+    let variables = btreemap! {
+        "traits" => FieldValue::List(vec![
+            FieldValue::String("StableHiddenDefaultIsNotSealed".into()),
+            FieldValue::String("UnstableHiddenMethodDefaultIsPublicApiSealed".into()),
+            FieldValue::String("UnstableHiddenAssocConstDefaultIsPublicApiSealed".into()),
+            FieldValue::String("UnstableHiddenAssocTypeDefaultIsPublicApiSealed".into()),
+        ].into()),
+    };
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        unconditionally_sealed: bool,
+        public_api_sealed: bool,
+    }
+
+    let mut results: Vec<Output> = trustfall::execute_query(&schema, adapter, query, variables)
+        .expect("failed to run query")
+        .map(|row| row.try_into_struct().expect("shape mismatch"))
+        .collect();
+    results.sort_unstable();
+
+    let mut expected_results = vec![
+        Output {
+            name: "StableHiddenDefaultIsNotSealed".into(),
+            unconditionally_sealed: false,
+            public_api_sealed: false,
+        },
+        Output {
+            name: "UnstableHiddenMethodDefaultIsPublicApiSealed".into(),
+            unconditionally_sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "UnstableHiddenAssocConstDefaultIsPublicApiSealed".into(),
+            unconditionally_sealed: false,
+            public_api_sealed: true,
+        },
+        Output {
+            name: "UnstableHiddenAssocTypeDefaultIsPublicApiSealed".into(),
+            unconditionally_sealed: false,
+            public_api_sealed: true,
+        },
+    ];
+    expected_results.sort_unstable();
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
+#[test]
 fn rust_std_const_impl_methods_use_inherited_const_stability() {
     get_rust_std_test_data!(data, rust_std_stability);
     let adapter = RustdocAdapter::new(&data, None);

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -471,7 +471,10 @@ impl<K: std::cmp::Eq + std::hash::Hash, V> MapList<K, V> {
 ///
 /// When compiled using the `rayon` feature, build it in parallel. Specifically, this paralelizes
 /// the work of gathering all of the impls for the items in the index.
-fn build_impl_index(index: &HashMap<Id, Item>) -> MapList<ImplEntry<'_>, (&Item, &Item)> {
+fn build_impl_index(
+    index: &HashMap<Id, Item>,
+    stability_policy: PublicApiStabilityPolicy,
+) -> MapList<ImplEntry<'_>, (&Item, &Item)> {
     #[cfg(feature = "rayon")]
     let iter = index.par_iter();
     #[cfg(not(feature = "rayon"))]
@@ -560,10 +563,16 @@ fn build_impl_index(index: &HashMap<Id, Item>) -> MapList<ImplEntry<'_>, (&Item,
             let trait_provided_items = trait_items
                 .filter_map(|id| index.get(id))
                 .filter(move |item| {
+                    let rustdoc_types::ItemEnum::Function(function) = &item.inner else {
+                        return false;
+                    };
+
                     item.name
                         .as_deref()
                         .map(|name| {
-                            trait_provided_methods.contains(name) && !impl_item_names.contains(name)
+                            trait_provided_methods.contains(name)
+                                && !impl_item_names.contains(name)
+                                && stability_policy.effective_function_has_body(function)
                         })
                         .unwrap_or_default()
                 })
@@ -664,7 +673,8 @@ impl<'a> IndexedCrate<'a> {
         ));
         value.imports_index = Some(imports_index);
 
-        value.impl_method_index = Some(build_impl_index(&crate_.index).into_inner());
+        value.impl_method_index =
+            Some(build_impl_index(&crate_.index, value.stability_policy).into_inner());
         value.fn_owner_index = Some(fn_owner_index);
         value.export_name_index = Some(build_export_name_index(&crate_.index));
         value.variant_name_index = Some(build_variant_name_index(&crate_.index));

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -695,6 +695,18 @@ impl<'a> IndexedCrate<'a> {
             .effective_constness(item, function.header.is_const)
     }
 
+    pub(crate) fn effective_function_has_body(&self, function: &rustdoc_types::Function) -> bool {
+        self.stability_policy.effective_function_has_body(function)
+    }
+
+    pub(crate) fn effective_assoc_type_has_default(&self, item: &'a Item) -> bool {
+        self.stability_policy.effective_assoc_type_has_default(item)
+    }
+
+    pub(crate) fn effective_assoc_const_default<'b>(&self, item: &'b Item) -> Option<&'b str> {
+        self.stability_policy.effective_assoc_const_default(item)
+    }
+
     /// Return `true` if our analysis indicates the trait is sealed, and `false` otherwise.
     ///
     /// Our analysis is conservative: it has false-negatives but no false-positives.

--- a/src/item_flags.rs
+++ b/src/item_flags.rs
@@ -318,7 +318,7 @@ pub(crate) fn build_flags_index(
         }
     });
 
-    sealed_trait::compute_trait_flags(index, &mut flags);
+    sealed_trait::compute_trait_flags(index, &mut flags, stability_policy);
 
     flags
 }

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -1151,7 +1151,12 @@ type Impl implements Item & GenericItem {
   # blanket: GenericType
 
   """
-  Methods defined in this impl.
+  Methods defined directly in this impl, plus trait-provided default methods that this impl uses
+  without overriding.
+
+  When indexing Rust standard-library rustdoc JSON with standard-library stability rules,
+  unstable trait-provided default methods are reported as absent unless this impl provides
+  its own implementations for them.
   """
   method: [Method!]
 

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -1372,6 +1372,9 @@ interface FunctionLike {
   For example, `fn example() {}` has a body (an empty one), whereas a trait function that
   does not supply a default implementation does not have a body. If the trait function includes
   a default implementation, that implementation is the body.
+
+  When indexing Rust standard-library rustdoc JSON with standard-library stability rules,
+  an unstable provided default implementation is reported as absent.
   """
   has_body: Boolean!
 
@@ -1482,6 +1485,9 @@ interface ExportableFunction implements Item & FunctionLike {
   For example, `fn example() {}` has a body (an empty one), whereas a trait function that
   does not supply a default implementation does not have a body. If the trait function includes
   a default implementation, that implementation is the body.
+
+  When indexing Rust standard-library rustdoc JSON with standard-library stability rules,
+  an unstable provided default implementation is reported as absent.
   """
   has_body: Boolean!
 
@@ -1730,6 +1736,9 @@ type Function implements Item & FunctionLike & Importable & ExportableFunction &
   For example, `fn example() {}` has a body (an empty one), whereas a trait function that
   does not supply a default implementation does not have a body. If the trait function includes
   a default implementation, that implementation is the body.
+
+  When indexing Rust standard-library rustdoc JSON with standard-library stability rules,
+  an unstable provided default implementation is reported as absent.
   """
   has_body: Boolean!
 
@@ -1898,6 +1907,9 @@ type Method implements Item & FunctionLike & GenericItem {
   For example, `fn example() {}` has a body (an empty one), whereas a trait function that
   does not supply a default implementation does not have a body. If the trait function includes
   a default implementation, that implementation is the body.
+
+  When indexing Rust standard-library rustdoc JSON with standard-library stability rules,
+  an unstable provided default implementation is reported as absent.
   """
   has_body: Boolean!
 
@@ -2575,6 +2587,9 @@ type AssociatedType implements Item {
   ```
 
   Associated type defaults are currently unstable: https://github.com/rust-lang/rust/issues/29661
+
+  When indexing Rust standard-library rustdoc JSON with standard-library stability rules,
+  an unstable associated type default is reported as absent.
   """
   has_default: Boolean!
 
@@ -2658,6 +2673,9 @@ type AssociatedConstant implements Item {
   ```
 
   If the associated constant is on a type's inherent impl, `default` is always required to be set.
+
+  When indexing Rust standard-library rustdoc JSON with standard-library stability rules,
+  an unstable associated constant default is reported as absent.
 
   If the associated constant is set:
 

--- a/src/sealed_trait.rs
+++ b/src/sealed_trait.rs
@@ -3,14 +3,19 @@ use rustdoc_types::{GenericBound, Id, Item, Trait};
 use crate::{
     hashtables::{HashMap, HashSet},
     item_flags::ItemFlag,
+    stability::PublicApiStabilityPolicy,
 };
 
 /// Update the `flags` with trait sealing and blanket impls information.
 ///
 /// # Preconditions
 /// - `flags` must contain complete reachability information,
-///   including info on `doc(hidden)` importable paths.
-pub(crate) fn compute_trait_flags(index: &HashMap<Id, Item>, flags: &mut HashMap<Id, ItemFlag>) {
+///   including info on non-public API importable paths.
+pub(crate) fn compute_trait_flags(
+    index: &HashMap<Id, Item>,
+    flags: &mut HashMap<Id, ItemFlag>,
+    stability_policy: PublicApiStabilityPolicy,
+) {
     let mut possibly_sealed = Vec::with_capacity(128);
     let mut definitely_not_fully_sealed: HashSet<Id> = HashSet::default();
     for (id, item) in index.iter() {
@@ -76,7 +81,7 @@ pub(crate) fn compute_trait_flags(index: &HashMap<Id, Item>, flags: &mut HashMap
         //
         // This method applies the flags internally, and returns `true` only if
         // the trait is unconditionally sealed, meaning that we can skip further analysis for it.
-        if is_method_or_item_sealed(index, id, trait_inner, flags) {
+        if is_method_or_item_sealed(index, id, trait_inner, flags, stability_policy) {
             continue;
         }
 
@@ -403,6 +408,7 @@ fn is_method_or_item_sealed(
     trait_id: &Id,
     trait_inner: &Trait,
     flags: &mut HashMap<Id, ItemFlag>,
+    stability_policy: PublicApiStabilityPolicy,
 ) -> bool {
     for inner_item_id in &trait_inner.items {
         let inner_item = &index.get(inner_item_id);
@@ -418,8 +424,8 @@ fn is_method_or_item_sealed(
 
         match &inner_item.inner {
             rustdoc_types::ItemEnum::Function(func) => {
-                if func.has_body {
-                    // This trait function has a default implementation.
+                if stability_policy.effective_function_has_body(func) {
+                    // This trait function has a stable default implementation.
                     // An implementation is not required in order to implement this trait on a type.
                     // Therefore, it cannot on its own cause the trait to be sealed.
                     continue;
@@ -475,9 +481,9 @@ fn is_method_or_item_sealed(
                     };
                 }
             }
-            rustdoc_types::ItemEnum::AssocType { type_, .. }
-                if type_.is_none()
-                // Associated types without a default can cause a trait to be public-API-sealed.
+            rustdoc_types::ItemEnum::AssocType { .. }
+                if !stability_policy.effective_assoc_type_has_default(inner_item)
+                // Associated types without a stable default can cause a trait to be public-API-sealed.
 
                 && !assoc_item_flag.is_pub_reachable() && assoc_item_flag.is_non_pub_api_reachable() =>
             {
@@ -488,8 +494,12 @@ fn is_method_or_item_sealed(
                     .expect("no flags entry for trait item ID")
                     .set_pub_api_sealed();
             }
-            rustdoc_types::ItemEnum::AssocConst { type_, value } if value.is_none() => {
-                // Associated constants without a default can cause a trait to be sealed,
+            rustdoc_types::ItemEnum::AssocConst { type_, .. }
+                if stability_policy
+                    .effective_assoc_const_default(inner_item)
+                    .is_none() =>
+            {
+                // Associated constants without a stable default can cause a trait to be sealed,
                 // either unconditionally or just public-API-sealed.
 
                 if !assoc_item_flag.is_pub_reachable() && assoc_item_flag.is_non_pub_api_reachable()

--- a/src/stability.rs
+++ b/src/stability.rs
@@ -53,6 +53,46 @@ impl PublicApiStabilityPolicy {
         // We have a test to make sure upstream doesn't stop emitting that data.
         !is_explicitly_unstable(function_item.const_stability.as_deref())
     }
+
+    pub(crate) fn effective_function_has_body(self, function: &rustdoc_types::Function) -> bool {
+        if !function.has_body || self == Self::Ignore {
+            return function.has_body;
+        }
+
+        // Rustdoc JSON emits `default_unstable` only for unstable provided defaults.
+        // In std mode, expose the stable guarantee by treating those defaults as absent.
+        function.default_unstable.is_none()
+    }
+
+    pub(crate) fn effective_assoc_type_has_default(self, item: &Item) -> bool {
+        let rustdoc_types::ItemEnum::AssocType {
+            type_,
+            default_unstable,
+            ..
+        } = &item.inner
+        else {
+            unreachable!("`item` was not an associated type: {item:?}");
+        };
+
+        type_.is_some() && (self == Self::Ignore || default_unstable.is_none())
+    }
+
+    pub(crate) fn effective_assoc_const_default(self, item: &Item) -> Option<&str> {
+        let rustdoc_types::ItemEnum::AssocConst {
+            value,
+            default_unstable,
+            ..
+        } = &item.inner
+        else {
+            unreachable!("`item` was not an associated constant: {item:?}");
+        };
+
+        if self == Self::RustStandardLibrary && default_unstable.is_some() {
+            None
+        } else {
+            value.as_deref()
+        }
+    }
 }
 
 fn is_explicitly_unstable(stability: Option<&Stability>) -> bool {

--- a/test_crates/rust_std_stability/src/lib.rs
+++ b/test_crates/rust_std_stability/src/lib.rs
@@ -1,5 +1,6 @@
 // Emit structured stdlib-style stability data by enabling unstable Rust features.
 #![allow(internal_features)]
+#![feature(associated_type_defaults)]
 #![feature(const_trait_impl)]
 #![feature(rustc_attrs)]
 #![feature(staged_api)]
@@ -154,4 +155,77 @@ pub const fn const_trait_marker(
     arg: impl [const] FixtureConstBound,
 ) -> impl [const] FixtureConstBound {
     arg
+}
+
+#[stable(feature = "default_stability_trait", since = "1.0.0")]
+pub trait DefaultStabilityTrait {
+    #[stable(feature = "stable_default_method", since = "1.0.0")]
+    fn stable_default_method() {}
+
+    #[stable(feature = "unstable_default_method", since = "1.0.0")]
+    #[rustc_default_body_unstable(feature = "unstable_default_method_body", issue = "none")]
+    fn unstable_default_method() {}
+
+    #[stable(feature = "required_default_stability_method", since = "1.0.0")]
+    fn required_method();
+
+    #[stable(feature = "stable_default_const", since = "1.0.0")]
+    const STABLE_DEFAULT_CONST: usize = 1;
+
+    #[stable(feature = "unstable_default_const", since = "1.0.0")]
+    #[rustc_default_body_unstable(feature = "unstable_default_const_value", issue = "none")]
+    const UNSTABLE_DEFAULT_CONST: usize = 2;
+
+    #[stable(feature = "required_default_stability_const", since = "1.0.0")]
+    const REQUIRED_CONST: usize;
+
+    #[stable(feature = "stable_default_type", since = "1.0.0")]
+    type StableDefaultType = u8;
+
+    #[stable(feature = "unstable_default_type", since = "1.0.0")]
+    #[rustc_default_body_unstable(feature = "unstable_default_type_value", issue = "none")]
+    type UnstableDefaultType = u16;
+
+    #[stable(feature = "required_default_stability_type", since = "1.0.0")]
+    type RequiredType;
+}
+
+#[stable(feature = "stable_hidden_default_is_not_sealed", since = "1.0.0")]
+pub trait StableHiddenDefaultIsNotSealed {
+    #[doc(hidden)]
+    #[stable(feature = "hidden_stable_default_method", since = "1.0.0")]
+    fn hidden_stable_default_method() {}
+}
+
+#[stable(
+    feature = "unstable_hidden_method_default_is_public_api_sealed",
+    since = "1.0.0"
+)]
+pub trait UnstableHiddenMethodDefaultIsPublicApiSealed {
+    #[doc(hidden)]
+    #[stable(feature = "hidden_unstable_default_method", since = "1.0.0")]
+    #[rustc_default_body_unstable(feature = "hidden_unstable_default_method_body", issue = "none")]
+    fn hidden_unstable_default_method() {}
+}
+
+#[stable(
+    feature = "unstable_hidden_assoc_const_default_is_public_api_sealed",
+    since = "1.0.0"
+)]
+pub trait UnstableHiddenAssocConstDefaultIsPublicApiSealed {
+    #[doc(hidden)]
+    #[stable(feature = "hidden_unstable_default_const", since = "1.0.0")]
+    #[rustc_default_body_unstable(feature = "hidden_unstable_default_const_value", issue = "none")]
+    const HIDDEN_UNSTABLE_DEFAULT_CONST: usize = 0;
+}
+
+#[stable(
+    feature = "unstable_hidden_assoc_type_default_is_public_api_sealed",
+    since = "1.0.0"
+)]
+pub trait UnstableHiddenAssocTypeDefaultIsPublicApiSealed {
+    #[doc(hidden)]
+    #[stable(feature = "hidden_unstable_default_type", since = "1.0.0")]
+    #[rustc_default_body_unstable(feature = "hidden_unstable_default_type_value", issue = "none")]
+    type HiddenUnstableDefaultType = usize;
 }

--- a/test_crates/rust_std_stability/src/lib.rs
+++ b/test_crates/rust_std_stability/src/lib.rs
@@ -190,6 +190,38 @@ pub trait DefaultStabilityTrait {
     type RequiredType;
 }
 
+#[stable(feature = "default_stability_impl_omitting_defaults", since = "1.0.0")]
+pub struct DefaultStabilityImplOmittingDefaults;
+
+#[stable(
+    feature = "default_stability_impl_omitting_defaults_impl",
+    since = "1.0.0"
+)]
+impl DefaultStabilityTrait for DefaultStabilityImplOmittingDefaults {
+    fn required_method() {}
+
+    const REQUIRED_CONST: usize = 3;
+
+    type RequiredType = u32;
+}
+
+#[stable(feature = "default_stability_impl_overriding_default", since = "1.0.0")]
+pub struct DefaultStabilityImplOverridingDefault;
+
+#[stable(
+    feature = "default_stability_impl_overriding_default_impl",
+    since = "1.0.0"
+)]
+impl DefaultStabilityTrait for DefaultStabilityImplOverridingDefault {
+    fn unstable_default_method() {}
+
+    fn required_method() {}
+
+    const REQUIRED_CONST: usize = 4;
+
+    type RequiredType = u64;
+}
+
 #[stable(feature = "stable_hidden_default_is_not_sealed", since = "1.0.0")]
 pub trait StableHiddenDefaultIsNotSealed {
     #[doc(hidden)]


### PR DESCRIPTION
Unstable default values, such as provided function bodies in trait definitions, associated type defaults, and default values for associated constants, are treated as not present when indexing rustdoc JSON in "standard library mode".

This additionally has implications on trait sealing: a stable implementation of a trait may be forced to provide a value or implementation for associated items, which can cause some traits to be considered public API sealed within the stable public API. See the test cases for examples of this.