### PR TITLE
Normalize parent, item, and higher-ranked generics separately.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,9 @@ All new schema additions must be tested by adding a new test crate (or when appr
 existing one that is thematically related) in `test_crate` to expose the Rust construct being added
 to the schema, then adding tests to `src/adapter/tests.rs` that make use of the new schema in
 querying the test crate and assert that the returned results are correct.
+Never construct `rustdoc_types` values by hand in tests; use a test crate to make rustdoc produce
+the construct instead. Prefer to test them by querying that crate through Trustfall whenever
+possible and pragmatic, rather than manipulating `rustdoc_types` values directly.
 
 ## Basics
 

--- a/src/adapter/normalize/context.rs
+++ b/src/adapter/normalize/context.rs
@@ -4,7 +4,7 @@ use crate::{PackageIndex, adapter::vertex::FunctionContext};
 
 use super::{
     names::{Names, is_synthetic_type_param},
-    parameter_impl_trait::{self, FnParameterImplTraits, ParameterImplTraitCursor},
+    parameter_impl_trait::{self, FnParameterImplTraits},
 };
 
 /// Per-function state used while rendering one normalized signature.
@@ -25,18 +25,19 @@ impl<'a> FnNormalizationContext<'a> {
     pub(super) fn new(crate_: &'a PackageIndex<'a>, fn_ctx: FunctionContext<'a>) -> Self {
         let mut names = Names::default();
 
-        // Parent generics must be introduced before function generics so
-        // normalized numbering follows the source-visible outer-to-inner scope.
+        // Parent and function generics use distinct placeholder families, but
+        // they share lookup maps. Rust rejects shadowing across nested generic scopes
+        // so there's no possibility of collisions.
         if let Some(item) = fn_ctx.parent {
             match &item.inner {
                 ItemEnum::Trait(trait_) => {
                     for param in &trait_.generics.params {
-                        names.add_param(param);
+                        names.add_parent_param(param);
                     }
                 }
                 ItemEnum::Impl(impl_) => {
                     for param in &impl_.generics.params {
-                        names.add_param(param);
+                        names.add_parent_param(param);
                     }
                 }
                 _ => unreachable!("function parent was not a trait or impl: {item:?}"),
@@ -57,10 +58,10 @@ impl<'a> FnNormalizationContext<'a> {
                 // parameter list as a whole.
                 continue;
             }
-            names.add_param(param);
+            names.add_item_param(param);
         }
         let parameter_impl_traits =
-            parameter_impl_trait::compute_for_function(crate_, function_inner, &names);
+            parameter_impl_trait::compute_for_function(crate_, &names, function_inner);
 
         Self {
             crate_,
@@ -69,17 +70,28 @@ impl<'a> FnNormalizationContext<'a> {
         }
     }
 
-    pub(super) fn with_params(&self, params: &'a [GenericParamDef]) -> Self {
-        // HRTB and function-pointer binders add a nested scope. Clone the
-        // context so outer generic mappings remain available while nested
-        // parameters get fresh canonical names.
-        // TODO: If this cloning becomes a bottleneck, we can probably design
-        // a hierarchical name structure, since we don't expect deep levels of nesting.
-        let mut value = self.clone();
+    pub(super) fn with_higher_ranked_params<R>(
+        &mut self,
+        params: &'a [GenericParamDef],
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        // HRTB and function-pointer binders add a nested scope, but their
+        // placeholder counters are monotonic across the whole signature,
+        // to disambiguate in case another HRTB or function-pointer binder is introduced.
+        // Keep the counters on this context and remove only the temporary lookup mappings
+        // after the binder body has been formatted.
+        let mut lifetime_keys = Vec::with_capacity(params.len());
         for param in params {
-            value.names.add_param(param);
+            lifetime_keys.push(self.names.add_higher_ranked_param(param));
         }
-        value
+        let result = f(self);
+        for key in lifetime_keys {
+            self.names
+                .lifetimes
+                .remove(key)
+                .expect("higher-ranked lifetime param was not in scope");
+        }
+        result
     }
 
     pub(super) fn crate_(&self) -> &'a PackageIndex<'a> {
@@ -90,10 +102,7 @@ impl<'a> FnNormalizationContext<'a> {
         &self.names
     }
 
-    pub(super) fn impl_trait_cursor_for_parameter(
-        &self,
-        position: std::num::NonZeroUsize,
-    ) -> ParameterImplTraitCursor<'_> {
-        self.parameter_impl_traits.cursor_for_parameter(position)
+    pub(super) fn parameter_impl_traits(&self) -> &FnParameterImplTraits {
+        &self.parameter_impl_traits
     }
 }

--- a/src/adapter/normalize/function_pointer.rs
+++ b/src/adapter/normalize/function_pointer.rs
@@ -1,0 +1,47 @@
+//! Shared rendering for function-pointer syntax.
+
+use rustdoc_types::{Abi, FunctionHeader};
+
+pub(super) fn format_fn_pointer_header(header: &FunctionHeader, output: &mut String) {
+    if header.is_const {
+        // As of Rust 1.96, function pointer types cannot use hypothetical
+        // `const fn(...)` syntax, so there is no normalized signature
+        // to produce for this header shape.
+        unreachable!("found const function pointer header: {header:?}");
+    }
+    if header.is_async {
+        // As of Rust 1.96, function pointer types cannot use hypothetical
+        // `async fn(...)` syntax, so there is no normalized signature
+        // to produce for this header shape.
+        unreachable!("found async function pointer header: {header:?}");
+    }
+    if header.is_unsafe {
+        output.push_str("unsafe ");
+    }
+
+    match &header.abi {
+        Abi::Rust => {}
+        Abi::C { unwind } => push_abi(output, "C", *unwind),
+        Abi::Cdecl { unwind } => push_abi(output, "cdecl", *unwind),
+        Abi::Stdcall { unwind } => push_abi(output, "stdcall", *unwind),
+        Abi::Fastcall { unwind } => push_abi(output, "fastcall", *unwind),
+        Abi::Aapcs { unwind } => push_abi(output, "aapcs", *unwind),
+        Abi::Win64 { unwind } => push_abi(output, "win64", *unwind),
+        Abi::SysV64 { unwind } => push_abi(output, "sysv64", *unwind),
+        Abi::System { unwind } => push_abi(output, "system", *unwind),
+        Abi::Other(other) => {
+            output.push_str("extern \"");
+            output.push_str(other);
+            output.push_str("\" ");
+        }
+    }
+}
+
+fn push_abi(output: &mut String, name: &str, unwind: bool) {
+    output.push_str("extern \"");
+    output.push_str(name);
+    if unwind {
+        output.push_str("-unwind");
+    }
+    output.push_str("\" ");
+}

--- a/src/adapter/normalize/mod.rs
+++ b/src/adapter/normalize/mod.rs
@@ -8,6 +8,7 @@
 //! normalized-signature vertex; we do not perform any kind of eager normalization.
 
 mod context;
+mod function_pointer;
 mod names;
 mod parameter_impl_trait;
 mod paths;
@@ -25,12 +26,14 @@ pub(super) fn fn_param_or_return_type_signature<'a>(
     component: TypeSignatureComponent,
     type_: Option<&'a rustdoc_types::Type>,
 ) -> String {
-    let context = context::FnNormalizationContext::new(crate_, function);
+    let mut context = context::FnNormalizationContext::new(crate_, function);
     match (component, type_) {
         (TypeSignatureComponent::FunctionParameter(position), Some(type_)) => {
-            types::format_parameter_type(&context, position, type_)
+            types::format_parameter_type(&mut context, position, type_)
         }
-        (TypeSignatureComponent::ReturnValue, Some(type_)) => types::format_type(&context, type_),
+        (TypeSignatureComponent::ReturnValue, Some(type_)) => {
+            types::format_type(&mut context, type_)
+        }
         (_, None) => "()".to_string(), // empty fn return values hit this branch
     }
 }

--- a/src/adapter/normalize/names.rs
+++ b/src/adapter/normalize/names.rs
@@ -3,9 +3,14 @@ use std::{borrow::Cow, collections::BTreeMap};
 use rustdoc_types::{GenericParamDef, GenericParamDefKind};
 
 // Avoid allocations for common amounts of generics: 8 of each kind.
-const LIFETIME_NAMES: [&str; 8] = ["'a", "'b", "'c", "'d", "'e", "'f", "'g", "'h"];
-const TYPE_NAMES: [&str; 8] = ["T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8"];
-const CONST_NAMES: [&str; 8] = ["C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8"];
+const ITEM_LIFETIME_NAMES: [&str; 8] = ["'a", "'b", "'c", "'d", "'e", "'f", "'g", "'h"];
+const ITEM_TYPE_NAMES: [&str; 8] = ["T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8"];
+const ITEM_CONST_NAMES: [&str; 8] = ["C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8"];
+const PARENT_LIFETIME_NAMES: [&str; 8] = ["'o1", "'o2", "'o3", "'o4", "'o5", "'o6", "'o7", "'o8"];
+const PARENT_TYPE_NAMES: [&str; 8] = ["TO1", "TO2", "TO3", "TO4", "TO5", "TO6", "TO7", "TO8"];
+const PARENT_CONST_NAMES: [&str; 8] = ["CO1", "CO2", "CO3", "CO4", "CO5", "CO6", "CO7", "CO8"];
+const HIGHER_RANKED_LIFETIME_NAMES: [&str; 8] =
+    ["'b1", "'b2", "'b3", "'b4", "'b5", "'b6", "'b7", "'b8"];
 const FIRST_IMPL_TRAIT_PLACEHOLDER_BY_PARAMETER: [&str; 8] = [
     "IT1_1", "IT2_1", "IT3_1", "IT4_1", "IT5_1", "IT6_1", "IT7_1", "IT8_1",
 ];
@@ -23,67 +28,91 @@ const FIRST_IMPL_TRAIT_PLACEHOLDER_BY_PARAMETER: [&str; 8] = [
 /// parameter names.
 #[derive(Clone, Debug, Default)]
 pub(super) struct Names<'a> {
-    lifetimes: BTreeMap<&'a str, Cow<'static, str>>,
+    pub(super) lifetimes: BTreeMap<&'a str, Cow<'static, str>>,
     types: BTreeMap<&'a str, Cow<'static, str>>,
     consts: BTreeMap<&'a str, Cow<'static, str>>,
+    next_item_lifetime: usize,
+    next_item_type: usize,
+    next_item_const: usize,
+    next_parent_lifetime: usize,
+    next_parent_type: usize,
+    next_parent_const: usize,
+    next_higher_ranked_lifetime: usize,
 }
 
 impl<'a> Names<'a> {
-    /// Adds one source-visible generic parameter to this normalized name scope.
-    ///
-    /// Rustdoc also creates synthetic function-level type params for
-    /// parameter-position `impl Trait`. Those params are intentionally rejected
-    /// here because their placeholders are scoped to the containing function
-    /// parameter and are assigned by `parameter_impl_trait` instead.
-    pub(super) fn add_param(&mut self, param: &'a GenericParamDef) {
-        match param.kind {
+    /// Adds one source-visible generic parameter from a containing `trait` or `impl`.
+    pub(super) fn add_parent_param(&mut self, param: &'a GenericParamDef) {
+        match &param.kind {
             GenericParamDefKind::Lifetime { .. } => {
-                let index = self.lifetimes.len();
-                let normalized = LIFETIME_NAMES
-                    .get(index)
-                    .copied()
-                    .map(Cow::Borrowed)
-                    .unwrap_or_else(|| Cow::Owned(format!("'{}", letter_name(index))));
-                let existing = self.lifetimes.insert(lifetime_key(&param.name), normalized);
-                assert!(
-                    existing.is_none(),
-                    "duplicate lifetime parameter `{}`",
-                    param.name,
-                );
+                let name =
+                    numbered_name(&mut self.next_parent_lifetime, &PARENT_LIFETIME_NAMES, "'o");
+                self.insert_lifetime_param(param, name);
             }
             GenericParamDefKind::Type { is_synthetic, .. } => {
                 assert!(
                     !is_synthetic,
                     "parameter-position impl Trait params must be handled by parameter_impl_trait",
                 );
-                let index = self.types.len();
-                let number = index + 1;
-                let normalized = TYPE_NAMES
-                    .get(index)
-                    .copied()
-                    .map(Cow::Borrowed)
-                    .unwrap_or_else(|| Cow::Owned(format!("T{number}")));
-                let existing = self.types.insert(param.name.as_str(), normalized);
-                assert!(
-                    existing.is_none(),
-                    "duplicate type parameter `{}`",
-                    param.name,
-                );
+                let name = numbered_name(&mut self.next_parent_type, &PARENT_TYPE_NAMES, "TO");
+                self.insert_type_param(param, name);
             }
             GenericParamDefKind::Const { .. } => {
-                let index = self.consts.len();
-                let number = index + 1;
-                let normalized = CONST_NAMES
+                let name = numbered_name(&mut self.next_parent_const, &PARENT_CONST_NAMES, "CO");
+                self.insert_const_param(param, name);
+            }
+        }
+    }
+
+    /// Adds one source-visible generic parameter from the item being normalized.
+    ///
+    /// Rustdoc also creates synthetic function-level type params for
+    /// parameter-position `impl Trait`. Those params are intentionally rejected
+    /// here because their placeholders are scoped to the containing function
+    /// parameter and are assigned by `parameter_impl_trait` instead.
+    pub(super) fn add_item_param(&mut self, param: &'a GenericParamDef) {
+        match &param.kind {
+            GenericParamDefKind::Lifetime { .. } => {
+                let index = self.next_item_lifetime;
+                self.next_item_lifetime += 1;
+                let name = ITEM_LIFETIME_NAMES
                     .get(index)
                     .copied()
                     .map(Cow::Borrowed)
-                    .unwrap_or_else(|| Cow::Owned(format!("C{number}")));
-                let existing = self.consts.insert(param.name.as_str(), normalized);
+                    .unwrap_or_else(|| Cow::Owned(format!("'{}", letter_name(index))));
+                self.insert_lifetime_param(param, name);
+            }
+            GenericParamDefKind::Type { is_synthetic, .. } => {
                 assert!(
-                    existing.is_none(),
-                    "duplicate const parameter `{}`",
-                    param.name,
+                    !is_synthetic,
+                    "parameter-position impl Trait params must be handled by parameter_impl_trait",
                 );
+                let name = numbered_name(&mut self.next_item_type, &ITEM_TYPE_NAMES, "T");
+                self.insert_type_param(param, name);
+            }
+            GenericParamDefKind::Const { .. } => {
+                let name = numbered_name(&mut self.next_item_const, &ITEM_CONST_NAMES, "C");
+                self.insert_const_param(param, name);
+            }
+        }
+    }
+
+    /// Adds one lifetime parameter from a higher-ranked binder.
+    pub(super) fn add_higher_ranked_param(&mut self, param: &'a GenericParamDef) -> &'a str {
+        match &param.kind {
+            GenericParamDefKind::Lifetime { .. } => {
+                let name = numbered_name(
+                    &mut self.next_higher_ranked_lifetime,
+                    &HIGHER_RANKED_LIFETIME_NAMES,
+                    "'b",
+                );
+                self.insert_lifetime_param(param, name)
+            }
+            GenericParamDefKind::Type { .. } => {
+                unreachable!("found type generic param definition in HRTB position: {param:?}")
+            }
+            GenericParamDefKind::Const { .. } => {
+                unreachable!("found const generic param definition in HRTB position: {param:?}")
             }
         }
     }
@@ -127,6 +156,41 @@ impl<'a> Names<'a> {
             None => Cow::Borrowed(expr),
         }
     }
+
+    fn insert_lifetime_param(
+        &mut self,
+        param: &'a GenericParamDef,
+        normalized: Cow<'static, str>,
+    ) -> &'a str {
+        let key = lifetime_key(&param.name);
+        let existing = self.lifetimes.insert(key, normalized);
+        assert!(
+            existing.is_none(),
+            "duplicate lifetime parameter `{}`",
+            param.name,
+        );
+        key
+    }
+
+    fn insert_type_param(&mut self, param: &'a GenericParamDef, normalized: Cow<'static, str>) {
+        let key = param.name.as_str();
+        let existing = self.types.insert(key, normalized);
+        assert!(
+            existing.is_none(),
+            "duplicate type parameter `{}`",
+            param.name,
+        );
+    }
+
+    fn insert_const_param(&mut self, param: &'a GenericParamDef, normalized: Cow<'static, str>) {
+        let key = param.name.as_str();
+        let existing = self.consts.insert(key, normalized);
+        assert!(
+            existing.is_none(),
+            "duplicate const parameter `{}`",
+            param.name,
+        );
+    }
 }
 
 pub(super) fn parameter_impl_trait_placeholder(
@@ -165,6 +229,20 @@ fn lifetime_key(name: &str) -> &str {
     name.strip_prefix('\'').unwrap_or(name)
 }
 
+fn numbered_name(
+    counter: &mut usize,
+    precomputed: &'static [&'static str],
+    fallback_prefix: &'static str,
+) -> Cow<'static, str> {
+    let index = *counter;
+    *counter += 1;
+    precomputed
+        .get(index)
+        .copied()
+        .map(Cow::Borrowed)
+        .unwrap_or_else(|| Cow::Owned(format!("{fallback_prefix}{}", index + 1)))
+}
+
 fn letter_name(mut index: usize) -> String {
     let mut output = String::new();
 
@@ -178,89 +256,4 @@ fn letter_name(mut index: usize) -> String {
     }
 
     output
-}
-
-#[cfg(test)]
-mod tests {
-    use std::borrow::Cow;
-
-    use rustdoc_types::{GenericParamDef, GenericParamDefKind, Type};
-
-    use super::Names;
-
-    #[test]
-    fn type_param_names_use_static_prefix() {
-        let params = (0..9)
-            .map(|index| type_param(format!("InputT{index}")))
-            .collect::<Vec<_>>();
-        let mut names = Names::default();
-        for param in &params {
-            names.add_param(param);
-        }
-
-        assert!(matches!(names.type_name("InputT0"), Cow::Borrowed("T1")));
-        assert!(matches!(names.type_name("InputT7"), Cow::Borrowed("T8")));
-        assert!(matches!(names.type_name("InputT8"), Cow::Owned(value) if value == "T9"));
-    }
-
-    #[test]
-    fn lifetime_and_const_names_use_static_prefix() {
-        let params = (0..9)
-            .map(|index| lifetime_param(format!("'lt{index}")))
-            .chain((0..9).map(|index| const_param(format!("N{index}"))))
-            .collect::<Vec<_>>();
-        let mut names = Names::default();
-        for param in &params {
-            names.add_param(param);
-        }
-
-        assert!(matches!(names.lifetime("'lt0"), Cow::Borrowed("'a")));
-        assert!(matches!(names.lifetime("'lt7"), Cow::Borrowed("'h")));
-        assert!(matches!(names.lifetime("'lt8"), Cow::Owned(value) if value == "'i"));
-        assert!(matches!(
-            names.type_or_const_name("N0"),
-            Cow::Borrowed("C1")
-        ));
-        assert!(matches!(
-            names.type_or_const_name("N7"),
-            Cow::Borrowed("C8")
-        ));
-        assert!(matches!(names.type_or_const_name("N8"), Cow::Owned(value) if value == "C9"));
-        assert!(matches!(names.const_expr("N0"), Cow::Borrowed("C1")));
-        assert!(matches!(names.const_expr("N8"), Cow::Owned(value) if value == "C9"));
-
-        let expression = String::from("N0 + 1");
-        assert!(matches!(
-            names.const_expr(&expression),
-            Cow::Borrowed(value) if value == expression
-        ));
-    }
-
-    fn lifetime_param(name: String) -> GenericParamDef {
-        GenericParamDef {
-            name,
-            kind: GenericParamDefKind::Lifetime { outlives: vec![] },
-        }
-    }
-
-    fn type_param(name: String) -> GenericParamDef {
-        GenericParamDef {
-            name,
-            kind: GenericParamDefKind::Type {
-                bounds: vec![],
-                default: None,
-                is_synthetic: false,
-            },
-        }
-    }
-
-    fn const_param(name: String) -> GenericParamDef {
-        GenericParamDef {
-            name,
-            kind: GenericParamDefKind::Const {
-                type_: Type::Primitive("usize".into()),
-                default: None,
-            },
-        }
-    }
 }

--- a/src/adapter/normalize/parameter_impl_trait.rs
+++ b/src/adapter/normalize/parameter_impl_trait.rs
@@ -30,7 +30,7 @@ use crate::PackageIndex;
 
 use super::{
     names::{Names, is_synthetic_type_param, parameter_impl_trait_placeholder},
-    paths, sort_key,
+    sort_key,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -55,8 +55,9 @@ pub(super) struct FnParameterImplTraits {
 /// `Type::ImplTrait` consumes the next name from this cursor. Return-position
 /// `impl Trait` formatting does not use this cursor, so it remains an opaque
 /// `impl` type rather than becoming a synthetic generic placeholder.
-pub(super) struct ParameterImplTraitCursor<'a> {
-    names: &'a [Cow<'static, str>],
+#[derive(Clone, Copy)]
+pub(super) struct ParameterImplTraitCursor {
+    parameter_index: usize,
     next: usize,
 }
 
@@ -67,51 +68,62 @@ impl FnParameterImplTraits {
     /// nodes in that parameter. Placeholder assignment itself may have used a
     /// canonical ordering first, so callers should not index into
     /// `by_parameter` directly.
-    pub(super) fn cursor_for_parameter(
-        &self,
-        position: NonZeroUsize,
-    ) -> ParameterImplTraitCursor<'_> {
-        let index = position.get() - 1;
-        let names = self
-            .by_parameter
-            .get(index)
+    pub(super) fn cursor_for_parameter(&self, position: NonZeroUsize) -> ParameterImplTraitCursor {
+        let parameter_index = position.get() - 1;
+        self.by_parameter
+            .get(parameter_index)
             .expect("function parameter position was out of bounds");
-        ParameterImplTraitCursor { names, next: 0 }
+        ParameterImplTraitCursor {
+            parameter_index,
+            next: 0,
+        }
     }
 }
 
-impl<'a> ParameterImplTraitCursor<'a> {
-    pub(super) fn next(&mut self) -> &str {
-        let name = self.names.get(self.next).unwrap_or_else(|| {
+impl ParameterImplTraitCursor {
+    pub(super) fn next<'a>(&mut self, impl_traits: &'a FnParameterImplTraits) -> &'a str {
+        let names = impl_traits
+            .by_parameter
+            .get(self.parameter_index)
+            .expect("parameter impl Trait cursor had an invalid parameter index");
+        let name = names.get(self.next).unwrap_or_else(|| {
             unreachable!(
                 "parameter-position impl Trait had no matching synthetic generic parameter: \
                 next={}, names={:?}",
-                self.next, self.names,
+                self.next, names,
             )
         });
         self.next += 1;
         name.as_ref()
     }
 
-    pub(super) fn assert_finished(&self) {
+    pub(super) fn next_index(&self) -> usize {
+        self.next
+    }
+
+    pub(super) fn assert_finished(&self, impl_traits: &FnParameterImplTraits) {
+        let names = impl_traits
+            .by_parameter
+            .get(self.parameter_index)
+            .expect("parameter impl Trait cursor had an invalid parameter index");
         assert_eq!(
             self.next,
-            self.names.len(),
+            names.len(),
             "not all parameter-position impl Trait synthetic generic parameters were used",
         );
     }
 }
 
 fn collect_type_impl_trait_params<'a>(
-    type_: &'a Type,
+    crate_: &PackageIndex<'_>,
     names: &Names<'a>,
-    normalize_path: &impl Fn(&Path) -> String,
+    type_: &'a Type,
     synthetic_params: &mut impl Iterator<Item = SyntheticTypeParam>,
     output: &mut Vec<SyntheticTypeParam>,
 ) {
     match type_ {
         Type::ResolvedPath(path) => {
-            collect_path_impl_trait_params(path, names, normalize_path, synthetic_params, output);
+            collect_path_impl_trait_params(crate_, names, path, synthetic_params, output);
         }
         Type::DynTrait(dyn_trait) => {
             let mut traits = Vec::new();
@@ -121,17 +133,20 @@ fn collect_type_impl_trait_params<'a>(
                 // we can look to replace it with an immutable hierarchical design instead.
                 let mut scoped_names = names.clone();
                 for param in &trait_.generic_params {
-                    scoped_names.add_param(param);
+                    scoped_names.add_higher_ranked_param(param);
                 }
                 let mut params = Vec::new();
                 collect_path_impl_trait_params(
-                    &trait_.trait_,
+                    crate_,
                     &scoped_names,
-                    normalize_path,
+                    &trait_.trait_,
                     synthetic_params,
                     &mut params,
                 );
-                traits.push((sort_key::poly_trait(names, trait_, normalize_path), params));
+                traits.push((
+                    sort_key::parameter_poly_trait(crate_, names, trait_),
+                    params,
+                ));
             }
             traits.sort_unstable_by(|a, b| a.0.cmp(&b.0));
             for (_, params) in traits {
@@ -143,43 +158,26 @@ fn collect_type_impl_trait_params<'a>(
         }
         Type::FunctionPointer(pointer) => {
             assert_supported_hrtb_generic_params(&pointer.generic_params);
-            // TODO: If this cloning ends up being expensive,
-            // we can look to replace it with an immutable hierarchical design instead.
-            let mut scoped_names = names.clone();
-            for param in &pointer.generic_params {
-                scoped_names.add_param(param);
-            }
-
             // As of Rust 1.96, `impl Trait` nested in `fn` pointer signatures is
             // rejected, so there are no parameter-position synthetic params to
             // collect inside `pointer.sig`.
         }
         Type::Tuple(types) => {
             for type_ in types {
-                collect_type_impl_trait_params(
-                    type_,
-                    names,
-                    normalize_path,
-                    synthetic_params,
-                    output,
-                );
+                collect_type_impl_trait_params(crate_, names, type_, synthetic_params, output);
             }
         }
         Type::Slice(type_) | Type::Array { type_, .. } => {
-            collect_type_impl_trait_params(type_, names, normalize_path, synthetic_params, output);
+            collect_type_impl_trait_params(crate_, names, type_, synthetic_params, output);
         }
         Type::ImplTrait(bounds) => {
-            collect_bounds_impl_trait_params(
-                bounds,
-                names,
-                normalize_path,
-                synthetic_params,
-                output,
-            );
-            output.push(next_synthetic_impl_trait_param(synthetic_params));
+            collect_bounds_impl_trait_params(crate_, names, bounds, synthetic_params, output);
+            output.push(synthetic_params.next().expect(
+                "parameter-position impl Trait had no matching synthetic generic parameter",
+            ));
         }
         Type::RawPointer { type_, .. } | Type::BorrowedRef { type_, .. } => {
-            collect_type_impl_trait_params(type_, names, normalize_path, synthetic_params, output);
+            collect_type_impl_trait_params(crate_, names, type_, synthetic_params, output);
         }
         Type::QualifiedPath {
             args,
@@ -187,27 +185,15 @@ fn collect_type_impl_trait_params<'a>(
             trait_,
             ..
         } => {
-            collect_type_impl_trait_params(
-                self_type,
-                names,
-                normalize_path,
-                synthetic_params,
-                output,
-            );
+            collect_type_impl_trait_params(crate_, names, self_type, synthetic_params, output);
             if let Some(trait_) = trait_ {
-                collect_path_impl_trait_params(
-                    trait_,
-                    names,
-                    normalize_path,
-                    synthetic_params,
-                    output,
-                );
+                collect_path_impl_trait_params(crate_, names, trait_, synthetic_params, output);
             }
             if let Some(args) = args.as_deref() {
                 collect_generic_args_impl_trait_params(
-                    args,
+                    crate_,
                     names,
-                    normalize_path,
+                    args,
                     synthetic_params,
                     output,
                 );
@@ -239,27 +225,21 @@ fn assert_supported_hrtb_generic_params(params: &[GenericParamDef]) {
 }
 
 fn collect_path_impl_trait_params<'a>(
-    path: &'a Path,
+    crate_: &PackageIndex<'_>,
     names: &Names<'a>,
-    normalize_path: &impl Fn(&Path) -> String,
+    path: &'a Path,
     synthetic_params: &mut impl Iterator<Item = SyntheticTypeParam>,
     output: &mut Vec<SyntheticTypeParam>,
 ) {
     if let Some(args) = path.args.as_deref() {
-        collect_generic_args_impl_trait_params(
-            args,
-            names,
-            normalize_path,
-            synthetic_params,
-            output,
-        );
+        collect_generic_args_impl_trait_params(crate_, names, args, synthetic_params, output);
     }
 }
 
 fn collect_generic_args_impl_trait_params<'a>(
-    args: &'a GenericArgs,
+    crate_: &PackageIndex<'_>,
     names: &Names<'a>,
-    normalize_path: &impl Fn(&Path) -> String,
+    args: &'a GenericArgs,
     synthetic_params: &mut impl Iterator<Item = SyntheticTypeParam>,
     output: &mut Vec<SyntheticTypeParam>,
 ) {
@@ -269,9 +249,9 @@ fn collect_generic_args_impl_trait_params<'a>(
                 match arg {
                     GenericArg::Type(type_) => {
                         collect_type_impl_trait_params(
-                            type_,
+                            crate_,
                             names,
-                            normalize_path,
+                            type_,
                             synthetic_params,
                             output,
                         );
@@ -284,14 +264,14 @@ fn collect_generic_args_impl_trait_params<'a>(
             for constraint in constraints {
                 let mut params = Vec::new();
                 collect_assoc_item_constraint_impl_trait_params_raw(
-                    constraint,
+                    crate_,
                     names,
-                    normalize_path,
+                    constraint,
                     synthetic_params,
                     &mut params,
                 );
                 constraint_params.push((
-                    sort_key::assoc_item_constraint(names, constraint, normalize_path),
+                    sort_key::parameter_assoc_item_constraint(crate_, names, constraint),
                     params,
                 ));
             }
@@ -310,42 +290,30 @@ fn collect_generic_args_impl_trait_params<'a>(
 }
 
 fn collect_assoc_item_constraint_impl_trait_params_raw<'a>(
-    constraint: &'a AssocItemConstraint,
+    crate_: &PackageIndex<'_>,
     names: &Names<'a>,
-    normalize_path: &impl Fn(&Path) -> String,
+    constraint: &'a AssocItemConstraint,
     synthetic_params: &mut impl Iterator<Item = SyntheticTypeParam>,
     output: &mut Vec<SyntheticTypeParam>,
 ) {
     if let Some(args) = constraint.args.as_deref() {
-        collect_generic_args_impl_trait_params(
-            args,
-            names,
-            normalize_path,
-            synthetic_params,
-            output,
-        );
+        collect_generic_args_impl_trait_params(crate_, names, args, synthetic_params, output);
     }
 
     match &constraint.binding {
         AssocItemConstraintKind::Constraint(bounds) => {
-            collect_bounds_impl_trait_params(
-                bounds,
-                names,
-                normalize_path,
-                synthetic_params,
-                output,
-            );
+            collect_bounds_impl_trait_params(crate_, names, bounds, synthetic_params, output);
         }
         AssocItemConstraintKind::Equality(term) => {
-            collect_term_impl_trait_params(term, names, normalize_path, synthetic_params, output);
+            collect_term_impl_trait_params(crate_, names, term, synthetic_params, output);
         }
     }
 }
 
 fn collect_bounds_impl_trait_params<'a>(
-    bounds: &'a [GenericBound],
+    crate_: &PackageIndex<'_>,
     names: &Names<'a>,
-    normalize_path: &impl Fn(&Path) -> String,
+    bounds: &'a [GenericBound],
     synthetic_params: &mut impl Iterator<Item = SyntheticTypeParam>,
     output: &mut Vec<SyntheticTypeParam>,
 ) {
@@ -363,12 +331,12 @@ fn collect_bounds_impl_trait_params<'a>(
                 // we can look to replace it with an immutable hierarchical design instead.
                 let mut scoped_names = names.clone();
                 for param in generic_params {
-                    scoped_names.add_param(param);
+                    scoped_names.add_higher_ranked_param(param);
                 }
                 collect_path_impl_trait_params(
-                    trait_,
+                    crate_,
                     &scoped_names,
-                    normalize_path,
+                    trait_,
                     synthetic_params,
                     &mut params,
                 );
@@ -376,7 +344,7 @@ fn collect_bounds_impl_trait_params<'a>(
             GenericBound::Outlives(_) | GenericBound::Use(_) => {}
         }
         bound_params.push((
-            sort_key::generic_bound(names, bound, normalize_path),
+            sort_key::parameter_generic_bound(crate_, names, bound),
             params,
         ));
     }
@@ -388,15 +356,15 @@ fn collect_bounds_impl_trait_params<'a>(
 }
 
 fn collect_term_impl_trait_params<'a>(
-    term: &'a Term,
+    crate_: &PackageIndex<'_>,
     names: &Names<'a>,
-    normalize_path: &impl Fn(&Path) -> String,
+    term: &'a Term,
     synthetic_params: &mut impl Iterator<Item = SyntheticTypeParam>,
     output: &mut Vec<SyntheticTypeParam>,
 ) {
     match term {
         Term::Type(type_) => {
-            collect_type_impl_trait_params(type_, names, normalize_path, synthetic_params, output);
+            collect_type_impl_trait_params(crate_, names, type_, synthetic_params, output);
         }
         Term::Constant(constant) => {
             // As of Rust 1.96, associated const equality constraints such as
@@ -405,14 +373,6 @@ fn collect_term_impl_trait_params<'a>(
             unreachable!("found associated const equality constraint term: {constant:?}");
         }
     }
-}
-
-fn next_synthetic_impl_trait_param(
-    synthetic_params: &mut impl Iterator<Item = SyntheticTypeParam>,
-) -> SyntheticTypeParam {
-    synthetic_params
-        .next()
-        .expect("parameter-position impl Trait had no matching synthetic generic parameter")
 }
 
 /// Computes the parameter-position `impl Trait` placeholders for one function.
@@ -424,17 +384,8 @@ fn next_synthetic_impl_trait_param(
 /// new `impl Trait` is added elsewhere in the same function signature.
 pub(super) fn compute_for_function<'a>(
     crate_: &'a PackageIndex<'a>,
-    function: &'a rustdoc_types::Function,
     names: &Names<'a>,
-) -> FnParameterImplTraits {
-    let normalize_path = |path: &Path| paths::normalized_path(crate_, path);
-    compute_for_function_with_path_normalizer(function, names, &normalize_path)
-}
-
-fn compute_for_function_with_path_normalizer<'a>(
     function: &'a rustdoc_types::Function,
-    names: &Names<'a>,
-    normalize_path: &impl Fn(&Path) -> String,
 ) -> FnParameterImplTraits {
     let synthetic_params = function
         .generics
@@ -465,9 +416,9 @@ fn compute_for_function_with_path_normalizer<'a>(
         let mut canonical_synthetic_params = synthetic_params.clone();
         let mut canonical_params = Vec::new();
         collect_type_impl_trait_params(
-            type_,
+            crate_,
             names,
-            normalize_path,
+            type_,
             &mut canonical_synthetic_params,
             &mut canonical_params,
         );
@@ -625,7 +576,9 @@ fn collect_type_impl_trait_names(
                 output,
                 false,
             );
-            let param = next_synthetic_impl_trait_param(synthetic_params);
+            let param = synthetic_params.next().expect(
+                "parameter-position impl Trait had no matching synthetic generic parameter",
+            );
             if emit {
                 let names = synthetic_names_by_index.expect(
                     "parameter-position impl Trait name emission requires precomputed names",

--- a/src/adapter/normalize/sort_key.rs
+++ b/src/adapter/normalize/sort_key.rs
@@ -1,101 +1,197 @@
-//! Temporary canonical sort keys for rustdoc type subtrees.
+//! Canonical sort keys for unordered rustdoc type subtrees.
 //!
-//! Parameter-position `impl Trait` placeholders are assigned before final type
-//! formatting is possible. These helpers render enough of the relevant rustdoc
-//! subtrees to sort bounds and constraints deterministically during that
-//! precomputation. They are not user-facing normalized signatures.
+//! Rustdoc preserves source/traversal order for semantically unordered groups,
+//! such as trait bounds and associated-item constraints. These internal strings
+//! let the formatter sort those groups before rendering them. Sort keys
+//! normalize paths and generic names like final formatting does. These keys
+//! are not user-facing normalized signatures.
 //!
-//! Sort keys deliberately use the same path and generic-name normalization as
-//! final formatting. `Type::ImplTrait` nodes still render as `impl _` markers
-//! because the enclosing associated item, generic arg, or bound determines
-//! sort order; the nested `impl Trait` bounds are consumed separately for
-//! placeholder assignment and do not affect that enclosing sort key. Skipping
-//! those bounds here is a small optimization based on that invariant.
+//! Parameter-position `impl Trait` needs a separate key mode because rustdoc
+//! reports each use site separately from its synthetic generic param.
+//! Parameter type signatures render those use sites as `IT...` placeholders,
+//! so their nested bounds are erased from the enclosing key. Final output
+//! renders the same nodes as opaque `impl ...` types, keeping their bounds
+//! in the key. That avoids falling back to rustdoc/source order for otherwise
+//! equal components.
 
 use rustdoc_types::{
     AssocItemConstraint, AssocItemConstraintKind, FunctionSignature, GenericArg, GenericArgs,
     GenericBound, GenericParamDef, GenericParamDefKind, Path, Term, TraitBoundModifier, Type,
 };
 
-use super::names::Names;
+use crate::PackageIndex;
 
-/// Returns the canonical sort key for a poly-trait bound.
-pub(super) fn poly_trait<'a>(
+use super::{function_pointer, names::Names, paths};
+
+#[derive(Clone, Copy)]
+enum ImplTraitSortMode {
+    /// Parameter sort keys render `impl Trait` use sites as `impl _`,
+    /// because `impl Trait` parameters are normalized as synthetic generics
+    /// whose bounds are reported separately on the synthetic generic itself.
+    /// Including nested bounds would make sort order depend on details erased
+    /// from the containing parameter type signature; see the module comment.
+    EraseNestedBounds,
+    /// Final-output sort keys include opaque `impl ...` bounds so that
+    /// otherwise-equal components do not fall back to rustdoc/source order.
+    IncludeNestedBounds,
+}
+
+/// Returns the canonical sort key for a poly-trait bound in parameter type mode.
+pub(super) fn parameter_poly_trait<'a>(
+    crate_: &PackageIndex<'_>,
     names: &Names<'a>,
     poly_trait: &'a rustdoc_types::PolyTrait,
-    normalize_path: &impl Fn(&Path) -> String,
+) -> String {
+    poly_trait_key(
+        crate_,
+        names,
+        poly_trait,
+        ImplTraitSortMode::EraseNestedBounds,
+    )
+}
+
+/// Returns the canonical sort key for a poly-trait bound in final output mode.
+pub(super) fn output_poly_trait<'a>(
+    crate_: &PackageIndex<'_>,
+    names: &Names<'a>,
+    poly_trait: &'a rustdoc_types::PolyTrait,
+) -> String {
+    poly_trait_key(
+        crate_,
+        names,
+        poly_trait,
+        ImplTraitSortMode::IncludeNestedBounds,
+    )
+}
+
+fn poly_trait_key<'a>(
+    crate_: &PackageIndex<'_>,
+    names: &Names<'a>,
+    poly_trait: &'a rustdoc_types::PolyTrait,
+    impl_trait_sort_mode: ImplTraitSortMode,
 ) -> String {
     let mut output = String::new();
     // TODO: If this cloning ends up being expensive,
     // we can look to replace it with an immutable hierarchical design instead.
     let mut scoped_names = names.clone();
     for param in &poly_trait.generic_params {
-        scoped_names.add_param(param);
+        scoped_names.add_higher_ranked_param(param);
     }
     format_generic_params(&scoped_names, &poly_trait.generic_params, &mut output);
     format_path(
+        crate_,
         &scoped_names,
         &poly_trait.trait_,
-        normalize_path,
+        impl_trait_sort_mode,
         &mut output,
     );
     output
 }
 
-/// Returns the canonical sort key for an associated item constraint.
-pub(super) fn assoc_item_constraint<'a>(
+/// Returns the canonical sort key for an associated item constraint
+/// in parameter type mode.
+pub(super) fn parameter_assoc_item_constraint<'a>(
+    crate_: &PackageIndex<'_>,
     names: &Names<'a>,
     constraint: &'a AssocItemConstraint,
-    normalize_path: &impl Fn(&Path) -> String,
+) -> String {
+    assoc_item_constraint_key(
+        crate_,
+        names,
+        constraint,
+        ImplTraitSortMode::EraseNestedBounds,
+    )
+}
+
+/// Returns the canonical sort key for an associated item constraint
+/// in final output mode.
+pub(super) fn output_assoc_item_constraint<'a>(
+    crate_: &PackageIndex<'_>,
+    names: &Names<'a>,
+    constraint: &'a AssocItemConstraint,
+) -> String {
+    assoc_item_constraint_key(
+        crate_,
+        names,
+        constraint,
+        ImplTraitSortMode::IncludeNestedBounds,
+    )
+}
+
+fn assoc_item_constraint_key<'a>(
+    crate_: &PackageIndex<'_>,
+    names: &Names<'a>,
+    constraint: &'a AssocItemConstraint,
+    impl_trait_sort_mode: ImplTraitSortMode,
 ) -> String {
     let mut output = String::new();
-    format_assoc_item_constraint(names, constraint, normalize_path, &mut output);
+    format_assoc_item_constraint(crate_, names, constraint, impl_trait_sort_mode, &mut output);
     output
 }
 
-/// Returns the canonical sort key for a generic bound.
-pub(super) fn generic_bound<'a>(
+/// Returns the canonical sort key for a generic bound in parameter type mode.
+pub(super) fn parameter_generic_bound<'a>(
+    crate_: &PackageIndex<'_>,
     names: &Names<'a>,
     bound: &'a GenericBound,
-    normalize_path: &impl Fn(&Path) -> String,
+) -> String {
+    generic_bound_key(crate_, names, bound, ImplTraitSortMode::EraseNestedBounds)
+}
+
+/// Returns the canonical sort key for a generic bound in final output mode.
+pub(super) fn output_generic_bound<'a>(
+    crate_: &PackageIndex<'_>,
+    names: &Names<'a>,
+    bound: &'a GenericBound,
+) -> String {
+    generic_bound_key(crate_, names, bound, ImplTraitSortMode::IncludeNestedBounds)
+}
+
+fn generic_bound_key<'a>(
+    crate_: &PackageIndex<'_>,
+    names: &Names<'a>,
+    bound: &'a GenericBound,
+    impl_trait_sort_mode: ImplTraitSortMode,
 ) -> String {
     let mut output = String::new();
-    format_generic_bound(names, bound, normalize_path, &mut output);
+    format_generic_bound(crate_, names, bound, impl_trait_sort_mode, &mut output);
     output
 }
 
 fn format_assoc_item_constraint<'a>(
+    crate_: &PackageIndex<'_>,
     names: &Names<'a>,
     constraint: &'a AssocItemConstraint,
-    normalize_path: &impl Fn(&Path) -> String,
+    impl_trait_sort_mode: ImplTraitSortMode,
     output: &mut String,
 ) {
     output.push_str(&constraint.name);
     if let Some(args) = constraint.args.as_deref() {
-        format_generic_args(names, args, normalize_path, output);
+        format_generic_args(crate_, names, args, impl_trait_sort_mode, output);
     }
 
     match &constraint.binding {
         AssocItemConstraintKind::Constraint(bounds) => {
             output.push_str(": ");
-            format_bounds(names, bounds, normalize_path, output);
+            format_bounds(crate_, names, bounds, impl_trait_sort_mode, output);
         }
         AssocItemConstraintKind::Equality(term) => {
             output.push_str(" = ");
-            format_term(names, term, normalize_path, output);
+            format_term(crate_, names, term, impl_trait_sort_mode, output);
         }
     }
 }
 
 fn format_bounds<'a>(
+    crate_: &PackageIndex<'_>,
     names: &Names<'a>,
     bounds: &'a [GenericBound],
-    normalize_path: &impl Fn(&Path) -> String,
+    impl_trait_sort_mode: ImplTraitSortMode,
     output: &mut String,
 ) {
     let mut bounds = bounds
         .iter()
-        .map(|bound| generic_bound(names, bound, normalize_path))
+        .map(|bound| generic_bound_key(crate_, names, bound, impl_trait_sort_mode))
         .collect::<Vec<_>>();
     bounds.sort_unstable();
     let mut bounds_iter = bounds.iter();
@@ -109,9 +205,10 @@ fn format_bounds<'a>(
 }
 
 fn format_generic_bound<'a>(
+    crate_: &PackageIndex<'_>,
     names: &Names<'a>,
     bound: &'a GenericBound,
-    normalize_path: &impl Fn(&Path) -> String,
+    impl_trait_sort_mode: ImplTraitSortMode,
     output: &mut String,
 ) {
     match bound {
@@ -124,48 +221,62 @@ fn format_generic_bound<'a>(
             // we can look to replace it with an immutable hierarchical design instead.
             let mut scoped_names = names.clone();
             for param in generic_params {
-                scoped_names.add_param(param);
+                scoped_names.add_higher_ranked_param(param);
             }
             format_generic_params(&scoped_names, generic_params, output);
             match modifier {
                 TraitBoundModifier::None => {}
                 TraitBoundModifier::Maybe => output.push('?'),
-                TraitBoundModifier::MaybeConst => output.push_str("~const "),
+                // The final normalized signature hides nightly-only const-trait
+                // markers, so canonical sort keys must ignore them too.
+                TraitBoundModifier::MaybeConst => {}
             }
-            format_path(&scoped_names, trait_, normalize_path, output);
+            format_path(crate_, &scoped_names, trait_, impl_trait_sort_mode, output);
         }
         GenericBound::Outlives(lifetime) => {
             let lifetime = names.lifetime(lifetime);
             output.push_str(lifetime.as_ref());
         }
         GenericBound::Use(args) => {
-            // Sort keys are used only while assigning parameter-position
-            // `impl Trait` placeholders. As of Rust 1.96, hypothetical
-            // `fn f(_: impl Trait + use<T>)` syntax is rejected, so precise
-            // capture bounds cannot appear here.
-            unreachable!(
-                "found precise-capture `use<...>` bound in parameter-position impl Trait: {args:?}"
-            );
+            output.push_str("use<");
+            for (index, arg) in args.iter().enumerate() {
+                if index != 0 {
+                    output.push_str(", ");
+                }
+                match arg {
+                    rustdoc_types::PreciseCapturingArg::Lifetime(lifetime) => {
+                        let lifetime = names.lifetime(lifetime);
+                        output.push_str(lifetime.as_ref());
+                    }
+                    rustdoc_types::PreciseCapturingArg::Param(param) => {
+                        let param = names.type_or_const_name(param);
+                        output.push_str(param.as_ref());
+                    }
+                }
+            }
+            output.push('>');
         }
     }
 }
 
 fn format_path<'a>(
+    crate_: &PackageIndex<'_>,
     names: &Names<'a>,
     path: &'a Path,
-    normalize_path: &impl Fn(&Path) -> String,
+    impl_trait_sort_mode: ImplTraitSortMode,
     output: &mut String,
 ) {
-    output.push_str(&normalize_path(path));
+    output.push_str(&paths::normalized_path(crate_, path));
     if let Some(args) = path.args.as_deref() {
-        format_generic_args(names, args, normalize_path, output);
+        format_generic_args(crate_, names, args, impl_trait_sort_mode, output);
     }
 }
 
 fn format_generic_args<'a>(
+    crate_: &PackageIndex<'_>,
     names: &Names<'a>,
     args: &'a GenericArgs,
-    normalize_path: &impl Fn(&Path) -> String,
+    impl_trait_sort_mode: ImplTraitSortMode,
     output: &mut String,
 ) {
     match args {
@@ -180,13 +291,15 @@ fn format_generic_args<'a>(
                 if needs_separator {
                     output.push_str(", ");
                 }
-                format_generic_arg(names, arg, normalize_path, output);
+                format_generic_arg(crate_, names, arg, impl_trait_sort_mode, output);
                 needs_separator = true;
             }
 
             let mut constraints = constraints
                 .iter()
-                .map(|constraint| assoc_item_constraint(names, constraint, normalize_path))
+                .map(|constraint| {
+                    assoc_item_constraint_key(crate_, names, constraint, impl_trait_sort_mode)
+                })
                 .collect::<Vec<_>>();
             constraints.sort_unstable();
             for constraint in constraints {
@@ -207,12 +320,12 @@ fn format_generic_args<'a>(
                 if index != 0 {
                     output.push_str(", ");
                 }
-                format_type(names, type_, normalize_path, output);
+                format_type(crate_, names, type_, impl_trait_sort_mode, output);
             }
             output.push(')');
             if let Some(return_type) = return_type {
                 output.push_str(" -> ");
-                format_type(names, return_type, normalize_path, output);
+                format_type(crate_, names, return_type, impl_trait_sort_mode, output);
             }
         }
         GenericArgs::ReturnTypeNotation => output.push_str("(..)"),
@@ -220,9 +333,10 @@ fn format_generic_args<'a>(
 }
 
 fn format_generic_arg<'a>(
+    crate_: &PackageIndex<'_>,
     names: &Names<'a>,
     arg: &'a GenericArg,
-    normalize_path: &impl Fn(&Path) -> String,
+    impl_trait_sort_mode: ImplTraitSortMode,
     output: &mut String,
 ) {
     match arg {
@@ -230,24 +344,29 @@ fn format_generic_arg<'a>(
             let lifetime = names.lifetime(lifetime);
             output.push_str(lifetime.as_ref());
         }
-        GenericArg::Type(type_) => format_type(names, type_, normalize_path, output),
+        GenericArg::Type(type_) => {
+            format_type(crate_, names, type_, impl_trait_sort_mode, output);
+        }
         GenericArg::Const(constant) => format_constant(names, constant, output),
         GenericArg::Infer => output.push('_'),
     }
 }
 
 fn format_term<'a>(
+    crate_: &PackageIndex<'_>,
     names: &Names<'a>,
     term: &'a Term,
-    normalize_path: &impl Fn(&Path) -> String,
+    impl_trait_sort_mode: ImplTraitSortMode,
     output: &mut String,
 ) {
     match term {
-        Term::Type(type_) => format_type(names, type_, normalize_path, output),
+        Term::Type(type_) => {
+            format_type(crate_, names, type_, impl_trait_sort_mode, output);
+        }
         Term::Constant(constant) => {
             // As of Rust 1.96, associated const equality constraints such as
-            // `T: Trait<N = 3>` are incomplete and rejected, so there is no sort
-            // key to compute for such a term.
+            // `T: Trait<N = 3>` are incomplete and rejected.
+            // No sort key can be computed for such a term.
             unreachable!("found associated const equality constraint term: {constant:?}");
         }
     }
@@ -264,19 +383,22 @@ fn format_constant<'a>(
 }
 
 fn format_type<'a>(
+    crate_: &PackageIndex<'_>,
     names: &Names<'a>,
     type_: &'a Type,
-    normalize_path: &impl Fn(&Path) -> String,
+    impl_trait_sort_mode: ImplTraitSortMode,
     output: &mut String,
 ) {
     match type_ {
-        Type::ResolvedPath(path) => format_path(names, path, normalize_path, output),
+        Type::ResolvedPath(path) => {
+            format_path(crate_, names, path, impl_trait_sort_mode, output);
+        }
         Type::DynTrait(dyn_trait) => {
             output.push_str("dyn ");
             let mut traits = dyn_trait
                 .traits
                 .iter()
-                .map(|trait_| poly_trait(names, trait_, normalize_path))
+                .map(|trait_| poly_trait_key(crate_, names, trait_, impl_trait_sort_mode))
                 .collect::<Vec<_>>();
             traits.sort_unstable();
             let mut traits_iter = traits.iter();
@@ -305,11 +427,18 @@ fn format_type<'a>(
         Type::FunctionPointer(pointer) => {
             let mut scoped_names = names.clone();
             for param in &pointer.generic_params {
-                scoped_names.add_param(param);
+                scoped_names.add_higher_ranked_param(param);
             }
             format_generic_params(&scoped_names, &pointer.generic_params, output);
+            function_pointer::format_fn_pointer_header(&pointer.header, output);
             output.push_str("fn");
-            format_function_signature(&scoped_names, &pointer.sig, normalize_path, output);
+            format_function_signature(
+                crate_,
+                &scoped_names,
+                &pointer.sig,
+                impl_trait_sort_mode,
+                output,
+            );
         }
         Type::Tuple(types) => {
             output.push('(');
@@ -317,7 +446,7 @@ fn format_type<'a>(
                 if index != 0 {
                     output.push_str(", ");
                 }
-                format_type(names, type_, normalize_path, output);
+                format_type(crate_, names, type_, impl_trait_sort_mode, output);
             }
             if types.len() == 1 {
                 output.push(',');
@@ -326,26 +455,24 @@ fn format_type<'a>(
         }
         Type::Slice(type_) => {
             output.push('[');
-            format_type(names, type_, normalize_path, output);
+            format_type(crate_, names, type_, impl_trait_sort_mode, output);
             output.push(']');
         }
         Type::Array { type_, len } => {
             output.push('[');
-            format_type(names, type_, normalize_path, output);
+            format_type(crate_, names, type_, impl_trait_sort_mode, output);
             output.push_str("; ");
             let len = names.const_expr(len);
             output.push_str(len.as_ref());
             output.push(']');
         }
-        Type::ImplTrait(_) => {
-            // Nested `impl Trait` bounds are consumed separately and receive
-            // placeholders after the enclosing associated item, generic arg, or
-            // bound has been placed in canonical order. Including those bounds
-            // here would make sort order depend on details that are erased from
-            // the containing parameter type signature, so `impl _` also avoids
-            // formatting data that cannot affect ordering.
-            output.push_str("impl _");
-        }
+        Type::ImplTrait(bounds) => match impl_trait_sort_mode {
+            ImplTraitSortMode::EraseNestedBounds => output.push_str("impl _"),
+            ImplTraitSortMode::IncludeNestedBounds => {
+                output.push_str("impl ");
+                format_bounds(crate_, names, bounds, impl_trait_sort_mode, output);
+            }
+        },
         Type::Infer => output.push('_'),
         Type::RawPointer { is_mutable, type_ } => {
             if *is_mutable {
@@ -353,7 +480,7 @@ fn format_type<'a>(
             } else {
                 output.push_str("*const ");
             }
-            format_type(names, type_, normalize_path, output);
+            format_type(crate_, names, type_, impl_trait_sort_mode, output);
         }
         Type::BorrowedRef {
             lifetime,
@@ -369,7 +496,7 @@ fn format_type<'a>(
             if *is_mutable {
                 output.push_str("mut ");
             }
-            format_type(names, type_, normalize_path, output);
+            format_type(crate_, names, type_, impl_trait_sort_mode, output);
         }
         Type::QualifiedPath {
             name,
@@ -378,38 +505,49 @@ fn format_type<'a>(
             trait_,
         } => {
             output.push('<');
-            format_type(names, self_type, normalize_path, output);
+            format_type(crate_, names, self_type, impl_trait_sort_mode, output);
             if let Some(trait_) = trait_ {
                 output.push_str(" as ");
-                format_path(names, trait_, normalize_path, output);
+                format_path(crate_, names, trait_, impl_trait_sort_mode, output);
             }
             output.push_str(">::");
             output.push_str(name);
             if let Some(args) = args.as_deref() {
-                format_generic_args(names, args, normalize_path, output);
+                format_generic_args(crate_, names, args, impl_trait_sort_mode, output);
             }
         }
-        Type::Pat { type_, .. } => format_type(names, type_, normalize_path, output),
+        Type::Pat { type_, .. } => {
+            format_type(crate_, names, type_, impl_trait_sort_mode, output);
+        }
     }
 }
 
 fn format_function_signature<'a>(
+    crate_: &PackageIndex<'_>,
     names: &Names<'a>,
     signature: &'a FunctionSignature,
-    normalize_path: &impl Fn(&Path) -> String,
+    impl_trait_sort_mode: ImplTraitSortMode,
     output: &mut String,
 ) {
     output.push('(');
-    for (index, (_, type_)) in signature.inputs.iter().enumerate() {
-        if index != 0 {
+    let mut needs_separator = false;
+    for (_, type_) in &signature.inputs {
+        if needs_separator {
             output.push_str(", ");
         }
-        format_type(names, type_, normalize_path, output);
+        format_type(crate_, names, type_, impl_trait_sort_mode, output);
+        needs_separator = true;
+    }
+    if signature.is_c_variadic {
+        if needs_separator {
+            output.push_str(", ");
+        }
+        output.push_str("...");
     }
     output.push(')');
     if let Some(return_type) = &signature.output {
         output.push_str(" -> ");
-        format_type(names, return_type, normalize_path, output);
+        format_type(crate_, names, return_type, impl_trait_sort_mode, output);
     }
 }
 
@@ -444,14 +582,14 @@ fn format_hrtb_generic_param_def<'a>(
         }
         GenericParamDefKind::Type { .. } => {
             // HRTB generic params model `for<...>` binders. As of Rust 1.96,
-            // hypothetical `for<T>` binders are rejected, so there is no sort
-            // key to compute for such a parameter.
+            // hypothetical `for<T>` binders are rejected.
+            // No sort key can be computed for such a parameter.
             unreachable!("found type generic param definition in HRTB position: {param:?}");
         }
         GenericParamDefKind::Const { .. } => {
             // HRTB generic params model `for<...>` binders. As of Rust 1.96,
-            // hypothetical `for<const N: usize>` binders are rejected, so there
-            // is no sort key to compute for such a parameter.
+            // hypothetical `for<const N: usize>` binders are rejected.
+            // No sort key can be computed for such a parameter.
             unreachable!("found const generic param definition in HRTB position: {param:?}");
         }
     }

--- a/src/adapter/normalize/types.rs
+++ b/src/adapter/normalize/types.rs
@@ -1,23 +1,28 @@
 use std::num::NonZeroUsize;
 
 use rustdoc_types::{
-    Abi, AssocItemConstraint, AssocItemConstraintKind, FunctionHeader, GenericArg, GenericBound,
-    GenericParamDef, GenericParamDefKind, Term, TraitBoundModifier, Type,
+    AssocItemConstraint, AssocItemConstraintKind, GenericArg, GenericBound, GenericParamDef,
+    GenericParamDefKind, Term, TraitBoundModifier, Type,
 };
 
 use super::{
-    context::FnNormalizationContext, parameter_impl_trait::ParameterImplTraitCursor, paths,
+    context::FnNormalizationContext, function_pointer,
+    parameter_impl_trait::ParameterImplTraitCursor, paths, sort_key,
 };
 
 /// Output a normalized parameter type.
 ///
 /// In parameters, `impl Trait` is normalized to a synthetic generic type, not an opaque type.
 pub(super) fn format_parameter_type<'a>(
-    context: &FnNormalizationContext<'a>,
+    context: &mut FnNormalizationContext<'a>,
     position: NonZeroUsize,
     type_: &'a Type,
 ) -> String {
-    let mut parameter_impl_trait_cursor = Some(context.impl_trait_cursor_for_parameter(position));
+    let mut parameter_impl_trait_cursor = Some(
+        context
+            .parameter_impl_traits()
+            .cursor_for_parameter(position),
+    );
     let mut output = String::new();
     format_type_inner(
         context,
@@ -29,14 +34,14 @@ pub(super) fn format_parameter_type<'a>(
     parameter_impl_trait_cursor
         .as_ref()
         .expect("parameter impl Trait cursor disappeared")
-        .assert_finished();
+        .assert_finished(context.parameter_impl_traits());
     output
 }
 
 /// Output a normalized type for positions other than parameter position.
 ///
 /// In non-parameters, `impl Trait` is normalized to an opaque type, not a synthetic generic type.
-pub(super) fn format_type<'a>(context: &FnNormalizationContext<'a>, type_: &'a Type) -> String {
+pub(super) fn format_type<'a>(context: &mut FnNormalizationContext<'a>, type_: &'a Type) -> String {
     let mut parameter_impl_trait_cursor = None;
     let mut output = String::new();
     format_type_inner(
@@ -50,10 +55,10 @@ pub(super) fn format_type<'a>(context: &FnNormalizationContext<'a>, type_: &'a T
 }
 
 fn format_type_inner<'a>(
-    context: &FnNormalizationContext<'a>,
+    context: &mut FnNormalizationContext<'a>,
     type_: &'a Type,
     wrap_before_bounds: bool,
-    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor<'_>>,
+    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor>,
     output: &mut String,
 ) {
     match type_ {
@@ -66,34 +71,100 @@ fn format_type_inner<'a>(
             }
             output.push_str("dyn ");
 
-            let mut traits = dyn_trait
-                .traits
-                .iter()
-                .map(|poly_trait| {
-                    let mut formatted = String::new();
+            let wrap_trait_before_bounds =
+                dyn_trait.traits.len() + usize::from(dyn_trait.lifetime.is_some()) > 1;
+            if parameter_impl_trait_cursor.is_none() {
+                let mut traits = dyn_trait
+                    .traits
+                    .iter()
+                    .map(|trait_| {
+                        (
+                            sort_key::output_poly_trait(context.crate_(), context.names(), trait_),
+                            trait_,
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                // We can't use `sort_unstable_by_key()` here because its signature doesn't allow
+                // borrowing the sort key from the item. Recall that items are moved during sorting.
+                traits.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+                let mut traits_iter = traits.into_iter();
+                if let Some((_, trait_)) = traits_iter.next() {
                     format_poly_trait(
                         context,
-                        poly_trait,
-                        dyn_trait.traits.len() + usize::from(dyn_trait.lifetime.is_some()) > 1,
+                        trait_,
+                        wrap_trait_before_bounds,
                         parameter_impl_trait_cursor,
-                        &mut formatted,
+                        output,
                     );
-                    formatted
-                })
-                .collect::<Vec<_>>();
-            traits.sort_unstable();
+                }
+                for (_, trait_) in traits_iter {
+                    output.push_str(" + ");
+                    format_poly_trait(
+                        context,
+                        trait_,
+                        wrap_trait_before_bounds,
+                        parameter_impl_trait_cursor,
+                        output,
+                    );
+                }
+            } else {
+                // `parameter_impl_trait_cursor` being `Some` means we are formatting
+                // a function parameter, where parameter-position `impl Trait` is rendered
+                // as `IT...`. The cursor must be consumed in rustdoc traversal order,
+                // but higher-ranked placeholders inside this unordered group must be
+                // assigned in canonical output order. Walk once with a cloned context
+                // to advance the cursor and record the assignments, then render sorted
+                // components with the real context.
+                let mut traversal_context = context.clone();
+                let mut traits = Vec::with_capacity(dyn_trait.traits.len());
+                let mut scratch = String::new();
+                for trait_ in &dyn_trait.traits {
+                    let cursor_before = *parameter_impl_trait_cursor;
+                    scratch.clear();
+                    format_poly_trait(
+                        &mut traversal_context,
+                        trait_,
+                        wrap_trait_before_bounds,
+                        parameter_impl_trait_cursor,
+                        &mut scratch,
+                    );
+                    let cursor_after_next = parameter_impl_trait_cursor
+                        .as_ref()
+                        .map(ParameterImplTraitCursor::next_index);
+                    let key =
+                        sort_key::parameter_poly_trait(context.crate_(), context.names(), trait_);
+                    traits.push((key, trait_, cursor_before, cursor_after_next));
+                }
+                // We can't use `sort_unstable_by_key()` here because its signature doesn't allow
+                // borrowing the sort key from the item. Recall that items are moved during sorting.
+                traits.sort_unstable_by(|a, b| a.0.cmp(&b.0));
 
-            let mut traits_iter = traits.iter();
-            if let Some(trait_) = traits_iter.next() {
-                output.push_str(trait_);
-            }
-            for trait_ in traits_iter {
-                output.push_str(" + ");
-                output.push_str(trait_);
+                let mut traits_iter = traits.into_iter();
+                if let Some((_, trait_, mut cursor, cursor_after_next)) = traits_iter.next() {
+                    format_poly_trait(
+                        context,
+                        trait_,
+                        wrap_trait_before_bounds,
+                        &mut cursor,
+                        output,
+                    );
+                    assert_cursor_checkpoint(&cursor, cursor_after_next, "trait-bound");
+                }
+                for (_, trait_, mut cursor, cursor_after_next) in traits_iter {
+                    output.push_str(" + ");
+                    format_poly_trait(
+                        context,
+                        trait_,
+                        wrap_trait_before_bounds,
+                        &mut cursor,
+                        output,
+                    );
+                    assert_cursor_checkpoint(&cursor, cursor_after_next, "trait-bound");
+                }
             }
             if let Some(lifetime) = &dyn_trait.lifetime {
                 assert!(
-                    !traits.is_empty(),
+                    !dyn_trait.traits.is_empty(),
                     "trait object lifetime bound cannot appear without a trait bound",
                 );
                 output.push_str(" + ");
@@ -110,19 +181,18 @@ fn format_type_inner<'a>(
         }
         Type::Primitive(name) => output.push_str(name),
         Type::FunctionPointer(pointer) => {
-            // Function-pointer ABI and safety are part of the type being
-            // normalized, unlike ABI and safety on the containing function.
-            let pointer_context = context.with_params(&pointer.generic_params);
-            format_scoped_generic_params(&pointer_context, &pointer.generic_params, output);
-            format_function_header(&pointer.header, output);
-            output.push_str("fn");
-            format_function_signature(
-                &pointer_context,
-                &pointer.sig,
-                wrap_before_bounds,
-                parameter_impl_trait_cursor,
-                output,
-            );
+            context.with_higher_ranked_params(&pointer.generic_params, |context| {
+                format_scoped_generic_params(context, &pointer.generic_params, output);
+                function_pointer::format_fn_pointer_header(&pointer.header, output);
+                output.push_str("fn");
+                format_function_signature(
+                    context,
+                    &pointer.sig,
+                    wrap_before_bounds,
+                    parameter_impl_trait_cursor,
+                    output,
+                );
+            });
         }
         Type::Tuple(types) => format_tuple(context, types, parameter_impl_trait_cursor, output),
         Type::Slice(type_) => {
@@ -140,11 +210,11 @@ fn format_type_inner<'a>(
         }
         Type::Pat { .. } => unimplemented!("Type::Pat is unstable"),
         Type::ImplTrait(bounds) => {
-            if let Some(names) = parameter_impl_trait_cursor.as_mut() {
-                // We're in parameter mode, output a synthetic generic.
-                output.push_str(names.next());
+            if let Some(cursor) = parameter_impl_trait_cursor.as_mut() {
+                // We are formatting a function parameter, so output a synthetic generic.
+                output.push_str(cursor.next(context.parameter_impl_traits()));
             } else {
-                // We're in non-parameter mode, output an opaque (`impl Trait`).
+                // We are formatting a non-parameter position, so output an opaque (`impl Trait`).
                 if wrap_before_bounds {
                     output.push('(');
                 }
@@ -242,9 +312,9 @@ fn format_type_inner<'a>(
 }
 
 fn format_tuple<'a>(
-    context: &FnNormalizationContext<'a>,
+    context: &mut FnNormalizationContext<'a>,
     types: &'a [Type],
-    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor<'_>>,
+    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor>,
     output: &mut String,
 ) {
     match types {
@@ -268,28 +338,29 @@ fn format_tuple<'a>(
 }
 
 fn format_poly_trait<'a>(
-    context: &FnNormalizationContext<'a>,
+    context: &mut FnNormalizationContext<'a>,
     poly_trait: &'a rustdoc_types::PolyTrait,
     wrap_before_bounds: bool,
-    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor<'_>>,
+    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor>,
     output: &mut String,
 ) {
-    let context = context.with_params(&poly_trait.generic_params);
-    format_scoped_generic_params(&context, &poly_trait.generic_params, output);
-    format_path(
-        &context,
-        &poly_trait.trait_,
-        wrap_before_bounds,
-        parameter_impl_trait_cursor,
-        output,
-    );
+    context.with_higher_ranked_params(&poly_trait.generic_params, |context| {
+        format_scoped_generic_params(context, &poly_trait.generic_params, output);
+        format_path(
+            context,
+            &poly_trait.trait_,
+            wrap_before_bounds,
+            parameter_impl_trait_cursor,
+            output,
+        );
+    });
 }
 
 fn format_path<'a>(
-    context: &FnNormalizationContext<'a>,
+    context: &mut FnNormalizationContext<'a>,
     path: &'a rustdoc_types::Path,
     wrap_args_before_bounds: bool,
-    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor<'_>>,
+    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor>,
     output: &mut String,
 ) {
     output.push_str(&paths::normalized_path(context.crate_(), path));
@@ -305,10 +376,10 @@ fn format_path<'a>(
 }
 
 fn format_generic_args<'a>(
-    context: &FnNormalizationContext<'a>,
+    context: &mut FnNormalizationContext<'a>,
     args: &'a rustdoc_types::GenericArgs,
     wrap_output_before_bounds: bool,
-    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor<'_>>,
+    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor>,
     output: &mut String,
 ) {
     match args {
@@ -327,31 +398,105 @@ fn format_generic_args<'a>(
                 needs_separator = true;
             }
 
-            let mut constraints = constraints
-                .iter()
-                .map(|constraint| {
-                    let mut formatted = String::new();
-                    format_assoc_item_constraint(
-                        context,
-                        constraint,
-                        parameter_impl_trait_cursor,
-                        &mut formatted,
-                    );
-                    formatted
-                })
-                .collect::<Vec<_>>();
-            constraints.sort_unstable();
             if !constraints.is_empty() {
                 if needs_separator {
                     output.push_str(", ");
                 }
-                let mut constraints_iter = constraints.iter();
-                if let Some(constraint) = constraints_iter.next() {
-                    output.push_str(constraint);
-                }
-                for constraint in constraints_iter {
-                    output.push_str(", ");
-                    output.push_str(constraint);
+                if parameter_impl_trait_cursor.is_none() {
+                    let mut constraints = constraints
+                        .iter()
+                        .map(|constraint| {
+                            (
+                                sort_key::output_assoc_item_constraint(
+                                    context.crate_(),
+                                    context.names(),
+                                    constraint,
+                                ),
+                                constraint,
+                            )
+                        })
+                        .collect::<Vec<_>>();
+                    // We can't use `sort_unstable_by_key()` here because its signature
+                    // doesn't allow borrowing the sort key from the item.
+                    // Recall that items are moved during sorting.
+                    constraints.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+                    let mut constraints_iter = constraints.into_iter();
+                    if let Some((_, constraint)) = constraints_iter.next() {
+                        format_assoc_item_constraint(
+                            context,
+                            constraint,
+                            parameter_impl_trait_cursor,
+                            output,
+                        );
+                    }
+                    for (_, constraint) in constraints_iter {
+                        output.push_str(", ");
+                        format_assoc_item_constraint(
+                            context,
+                            constraint,
+                            parameter_impl_trait_cursor,
+                            output,
+                        );
+                    }
+                } else {
+                    // `parameter_impl_trait_cursor` being `Some` means we are formatting
+                    // a function parameter, where parameter-position `impl Trait` is rendered
+                    // as `IT...`. The cursor must be consumed in rustdoc traversal order,
+                    // but higher-ranked placeholders inside this unordered group must be
+                    // assigned in canonical output order. Walk once with a cloned context
+                    // to advance the cursor and record checkpoints, then render sorted
+                    // components with the real context.
+                    let mut traversal_context = context.clone();
+                    let mut constraints_by_key = Vec::new();
+                    let mut scratch = String::new();
+                    for constraint in constraints {
+                        let cursor_before = *parameter_impl_trait_cursor;
+                        scratch.clear();
+                        format_assoc_item_constraint(
+                            &mut traversal_context,
+                            constraint,
+                            parameter_impl_trait_cursor,
+                            &mut scratch,
+                        );
+                        let cursor_after_next = parameter_impl_trait_cursor
+                            .as_ref()
+                            .map(ParameterImplTraitCursor::next_index);
+                        let key = sort_key::parameter_assoc_item_constraint(
+                            context.crate_(),
+                            context.names(),
+                            constraint,
+                        );
+                        constraints_by_key.push((
+                            key,
+                            constraint,
+                            cursor_before,
+                            cursor_after_next,
+                        ));
+                    }
+                    // We can't use `sort_unstable_by_key()` here because its signature
+                    // doesn't allow borrowing the sort key from the item.
+                    // Recall that items are moved during sorting.
+                    constraints_by_key.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+                    let mut constraints_iter = constraints_by_key.into_iter();
+                    if let Some((_, constraint, mut cursor, cursor_after_next)) =
+                        constraints_iter.next()
+                    {
+                        format_assoc_item_constraint(context, constraint, &mut cursor, output);
+                        assert_cursor_checkpoint(
+                            &cursor,
+                            cursor_after_next,
+                            "associated-constraint",
+                        );
+                    }
+                    for (_, constraint, mut cursor, cursor_after_next) in constraints_iter {
+                        output.push_str(", ");
+                        format_assoc_item_constraint(context, constraint, &mut cursor, output);
+                        assert_cursor_checkpoint(
+                            &cursor,
+                            cursor_after_next,
+                            "associated-constraint",
+                        );
+                    }
                 }
             }
             output.push('>');
@@ -385,9 +530,9 @@ fn format_generic_args<'a>(
 }
 
 fn format_generic_arg<'a>(
-    context: &FnNormalizationContext<'a>,
+    context: &mut FnNormalizationContext<'a>,
     arg: &'a GenericArg,
-    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor<'_>>,
+    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor>,
     output: &mut String,
 ) {
     match arg {
@@ -404,9 +549,9 @@ fn format_generic_arg<'a>(
 }
 
 fn format_assoc_item_constraint<'a>(
-    context: &FnNormalizationContext<'a>,
+    context: &mut FnNormalizationContext<'a>,
     constraint: &'a AssocItemConstraint,
-    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor<'_>>,
+    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor>,
     output: &mut String,
 ) {
     output.push_str(&constraint.name);
@@ -427,41 +572,105 @@ fn format_assoc_item_constraint<'a>(
 }
 
 fn format_bounds<'a>(
-    context: &FnNormalizationContext<'a>,
+    context: &mut FnNormalizationContext<'a>,
     bounds: &'a [GenericBound],
-    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor<'_>>,
+    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor>,
     output: &mut String,
 ) {
-    let mut bounds = bounds
-        .iter()
-        .map(|bound| {
-            let mut formatted = String::new();
+    if parameter_impl_trait_cursor.is_none() {
+        let mut bounds = bounds
+            .iter()
+            .map(|bound| {
+                (
+                    sort_key::output_generic_bound(context.crate_(), context.names(), bound),
+                    bound,
+                )
+            })
+            .collect::<Vec<_>>();
+        let bounds_len = bounds.len();
+        // We can't use `sort_unstable_by_key()` here because its signature doesn't allow
+        // borrowing the sort key from the item. Recall that items are moved during sorting.
+        bounds.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        let mut bounds_iter = bounds.into_iter();
+        if let Some((_, bound)) = bounds_iter.next() {
             format_generic_bound(
                 context,
                 bound,
-                bounds.len() > 1,
+                bounds_len > 1,
                 parameter_impl_trait_cursor,
-                &mut formatted,
+                output,
             );
-            formatted
-        })
-        .collect::<Vec<_>>();
-    bounds.sort_unstable();
-    let mut bounds_iter = bounds.iter();
-    if let Some(bound) = bounds_iter.next() {
-        output.push_str(bound);
-    }
-    for bound in bounds_iter {
-        output.push_str(" + ");
-        output.push_str(bound);
+        }
+        for (_, bound) in bounds_iter {
+            output.push_str(" + ");
+            format_generic_bound(
+                context,
+                bound,
+                bounds_len > 1,
+                parameter_impl_trait_cursor,
+                output,
+            );
+        }
+    } else {
+        // `parameter_impl_trait_cursor` being `Some` means we are formatting
+        // a function parameter, where parameter-position `impl Trait` is rendered
+        // as `IT...`. The cursor must be consumed in rustdoc traversal order,
+        // but higher-ranked placeholders inside this unordered group must be
+        // assigned in canonical output order. Walk once with a cloned context
+        // to advance the cursor and record checkpoints, then render sorted
+        // components with the real context.
+        let mut traversal_context = context.clone();
+        let mut bounds_by_key = Vec::new();
+        let mut scratch = String::new();
+        for bound in bounds {
+            let cursor_before = *parameter_impl_trait_cursor;
+            scratch.clear();
+            format_generic_bound(
+                &mut traversal_context,
+                bound,
+                false,
+                parameter_impl_trait_cursor,
+                &mut scratch,
+            );
+            let cursor_after_next = parameter_impl_trait_cursor
+                .as_ref()
+                .map(ParameterImplTraitCursor::next_index);
+            let key = sort_key::parameter_generic_bound(context.crate_(), context.names(), bound);
+            bounds_by_key.push((key, bound, cursor_before, cursor_after_next));
+        }
+        // We can't use `sort_unstable_by_key()` here because its signature doesn't allow
+        // borrowing the sort key from the item. Recall that items are moved during sorting.
+        bounds_by_key.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        let mut bounds_iter = bounds_by_key.into_iter();
+        if let Some((_, bound, mut cursor, cursor_after_next)) = bounds_iter.next() {
+            format_generic_bound(context, bound, false, &mut cursor, output);
+            assert_cursor_checkpoint(&cursor, cursor_after_next, "generic-bound");
+        }
+        for (_, bound, mut cursor, cursor_after_next) in bounds_iter {
+            output.push_str(" + ");
+            format_generic_bound(context, bound, false, &mut cursor, output);
+            assert_cursor_checkpoint(&cursor, cursor_after_next, "generic-bound");
+        }
     }
 }
 
+fn assert_cursor_checkpoint(
+    cursor: &Option<ParameterImplTraitCursor>,
+    expected_next: Option<usize>,
+    component: &str,
+) {
+    assert_eq!(
+        cursor.as_ref().map(ParameterImplTraitCursor::next_index),
+        expected_next,
+        "canonical {component} formatting consumed a different number of parameter-position impl Trait nodes",
+    );
+}
+
 fn format_generic_bound<'a>(
-    context: &FnNormalizationContext<'a>,
+    context: &mut FnNormalizationContext<'a>,
     bound: &'a GenericBound,
     wrap_before_or_after_bounds: bool,
-    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor<'_>>,
+    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor>,
     output: &mut String,
 ) {
     match bound {
@@ -470,22 +679,23 @@ fn format_generic_bound<'a>(
             generic_params,
             modifier,
         } => {
-            let context = context.with_params(generic_params);
-            format_scoped_generic_params(&context, generic_params, output);
-            match modifier {
-                TraitBoundModifier::None => {}
-                TraitBoundModifier::Maybe => output.push('?'),
-                // The schema has no separate const-trait facet. Render the stable
-                // ordinary-bound view instead of leaking nightly-only `[const]` syntax.
-                TraitBoundModifier::MaybeConst => {}
-            }
-            format_path(
-                &context,
-                trait_,
-                wrap_before_or_after_bounds,
-                parameter_impl_trait_cursor,
-                output,
-            );
+            context.with_higher_ranked_params(generic_params, |context| {
+                format_scoped_generic_params(context, generic_params, output);
+                match modifier {
+                    TraitBoundModifier::None => {}
+                    TraitBoundModifier::Maybe => output.push('?'),
+                    // The schema has no separate const-trait facet. Render the stable
+                    // ordinary-bound view instead of leaking nightly-only `[const]` syntax.
+                    TraitBoundModifier::MaybeConst => {}
+                }
+                format_path(
+                    context,
+                    trait_,
+                    wrap_before_or_after_bounds,
+                    parameter_impl_trait_cursor,
+                    output,
+                );
+            });
         }
         GenericBound::Outlives(lifetime) => {
             let lifetime = context.names().lifetime(lifetime);
@@ -514,7 +724,7 @@ fn format_generic_bound<'a>(
 }
 
 fn format_scoped_generic_params<'a>(
-    context: &FnNormalizationContext<'a>,
+    context: &mut FnNormalizationContext<'a>,
     params: &'a [GenericParamDef],
     output: &mut String,
 ) {
@@ -533,7 +743,7 @@ fn format_scoped_generic_params<'a>(
 }
 
 fn format_generic_param_def<'a>(
-    context: &FnNormalizationContext<'a>,
+    context: &mut FnNormalizationContext<'a>,
     param: &'a GenericParamDef,
     output: &mut String,
 ) {
@@ -560,10 +770,10 @@ fn format_generic_param_def<'a>(
 }
 
 fn format_function_signature<'a>(
-    context: &FnNormalizationContext<'a>,
+    context: &mut FnNormalizationContext<'a>,
     signature: &'a rustdoc_types::FunctionSignature,
     wrap_output_before_bounds: bool,
-    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor<'_>>,
+    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor>,
     output: &mut String,
 ) {
     output.push('(');
@@ -595,52 +805,8 @@ fn format_function_signature<'a>(
     }
 }
 
-fn format_function_header(header: &FunctionHeader, output: &mut String) {
-    if header.is_const {
-        // As of Rust 1.96, function pointer types cannot use hypothetical
-        // `const fn(...)` syntax, so there is no normalized signature text to
-        // produce for this header shape.
-        unreachable!("found const function pointer header: {header:?}");
-    }
-    if header.is_async {
-        // As of Rust 1.96, function pointer types cannot use hypothetical
-        // `async fn(...)` syntax, so there is no normalized signature text to
-        // produce for this header shape.
-        unreachable!("found async function pointer header: {header:?}");
-    }
-    if header.is_unsafe {
-        output.push_str("unsafe ");
-    }
-
-    match &header.abi {
-        Abi::Rust => {}
-        Abi::C { unwind } => push_abi(output, "C", *unwind),
-        Abi::Cdecl { unwind } => push_abi(output, "cdecl", *unwind),
-        Abi::Stdcall { unwind } => push_abi(output, "stdcall", *unwind),
-        Abi::Fastcall { unwind } => push_abi(output, "fastcall", *unwind),
-        Abi::Aapcs { unwind } => push_abi(output, "aapcs", *unwind),
-        Abi::Win64 { unwind } => push_abi(output, "win64", *unwind),
-        Abi::SysV64 { unwind } => push_abi(output, "sysv64", *unwind),
-        Abi::System { unwind } => push_abi(output, "system", *unwind),
-        Abi::Other(other) => {
-            output.push_str("extern \"");
-            output.push_str(other);
-            output.push_str("\" ");
-        }
-    }
-}
-
-fn push_abi(output: &mut String, name: &str, unwind: bool) {
-    output.push_str("extern \"");
-    output.push_str(name);
-    if unwind {
-        output.push_str("-unwind");
-    }
-    output.push_str("\" ");
-}
-
 fn format_constant<'a>(
-    context: &FnNormalizationContext<'a>,
+    context: &mut FnNormalizationContext<'a>,
     constant: &'a rustdoc_types::Constant,
     output: &mut String,
 ) {
@@ -650,9 +816,9 @@ fn format_constant<'a>(
 }
 
 fn format_term<'a>(
-    context: &FnNormalizationContext<'a>,
+    context: &mut FnNormalizationContext<'a>,
     term: &'a Term,
-    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor<'_>>,
+    parameter_impl_trait_cursor: &mut Option<ParameterImplTraitCursor>,
     output: &mut String,
 ) {
     match term {

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -4401,13 +4401,19 @@ fn defaulted_trait_items_overridden_in_impls_when_looked_up_by_name() {
     }
 
     let mut expected_results = vec![
-        // We *must* only get one result here.
+        // We *must* only get one result for `Example` here.
         //
         // If we get two, we've erroneously returned both
         // the trait's provided default impl for the method
         // and the `impl Trait for Example` override for the method.
         Output {
             name: "Example".into(),
+            method: "method".into(),
+        },
+        // `SameNameExample` has a same-named associated type but no method override;
+        // the provided method should still be discoverable.
+        Output {
+            name: "SameNameExample".into(),
             method: "method".into(),
         },
     ];
@@ -12355,7 +12361,11 @@ fn function_return_normalized_type_signature_handles_assoc_constraint_bound() {
             },
             Output {
                 name: "return_nested_dyn_bound".into(),
-                signature: "impl ::assoc_constraint_order::HasItem<Item: ::core::clone::Clone + ::core::ops::function::Fn() -> (dyn ::assoc_constraint_order::RealTrait + ::core::marker::Send)>".into(),
+                signature: "impl ::assoc_constraint_order::HasItem<Item = dyn ::assoc_constraint_order::RealTrait + ::core::marker::Send>".into(),
+            },
+            Output {
+                name: "return_nested_parenthesized_dyn_bound".into(),
+                signature: "impl ::assoc_constraint_order::HasItem<Item = fn() -> *const (dyn ::assoc_constraint_order::RealTrait + ::core::marker::Send)>".into(),
             },
             Output {
                 name: "return_nested_opaque_bound_clone_then_copy".into(),

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -12354,6 +12354,10 @@ fn function_return_normalized_type_signature_handles_assoc_constraint_bound() {
                         .into(),
             },
             Output {
+                name: "return_nested_dyn_bound".into(),
+                signature: "impl ::assoc_constraint_order::HasItem<Item: ::core::clone::Clone + ::core::ops::function::Fn() -> (dyn ::assoc_constraint_order::RealTrait + ::core::marker::Send)>".into(),
+            },
+            Output {
                 name: "return_nested_opaque_bound_clone_then_copy".into(),
                 signature: "impl ::assoc_constraint_order::HasItem<Item: ::assoc_constraint_order::Takes<impl ::core::clone::Clone> + ::assoc_constraint_order::Takes<impl ::core::marker::Copy>>".into(),
             },

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -7604,6 +7604,66 @@ fn rust_std_signatures_hide_const_trait_markers() {
     similar_asserts::assert_eq!(expected_results, results);
 }
 
+/// `const Trait` isn't stable yet, so don't show the const impls in the normalization.
+#[test]
+fn function_return_normalized_type_signatures_hide_const_trait_markers_before_sorting() {
+    get_test_data!(data, maybe_const_function_signature);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Function {
+                name @output
+
+                return_value {
+                    normalized_type_signature {
+                        signature @output
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+    let variables: BTreeMap<&str, FieldValue> = BTreeMap::default();
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        signature: String,
+    }
+
+    let mut expected_results = vec![
+        Output {
+            name: "maybe_const_function_signature".into(),
+            signature: "impl ::maybe_const_function_signature::MaybeConst".into(),
+        },
+        Output {
+            name: "maybe_const_return_bound_const_then_plain".into(),
+            signature: "impl ::maybe_const_function_signature::MaybeConst + ::maybe_const_function_signature::Plain".into(),
+        },
+        Output {
+            name: "maybe_const_return_bound_plain_then_const".into(),
+            signature: "impl ::maybe_const_function_signature::MaybeConst + ::maybe_const_function_signature::Plain".into(),
+        },
+    ];
+    expected_results.sort_unstable();
+
+    let mut results: Vec<Output> = trustfall::execute_query(&schema, adapter, query, variables)
+        .expect("failed to run query")
+        .map(|row| row.try_into_struct().expect("shape mismatch"))
+        .collect();
+    results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
 #[test]
 fn function_signatures() {
     get_test_data!(data, raw_type_json);
@@ -10974,6 +11034,10 @@ fn function_parameters() {
             params: vec!["value".into()],
         },
         Output {
+            name: "two_lifetimes".into(),
+            params: vec!["first".into(), "second".into()],
+        },
+        Output {
             name: "const_array".into(),
             params: vec!["value".into()],
         },
@@ -11093,6 +11157,14 @@ fn function_parameters() {
             params: vec![],
         },
         Output {
+            name: "sorted_higher_ranked_return_bounds".into(),
+            params: vec![],
+        },
+        Output {
+            name: "repeated_higher_ranked_lifetime_name_return".into(),
+            params: vec![],
+        },
+        Output {
             name: "raw_pointer_impl_trait".into(),
             params: vec!["value".into(), "mutable".into()],
         },
@@ -11106,6 +11178,10 @@ fn function_parameters() {
         },
         Output {
             name: "higher_ranked_fn_pointer".into(),
+            params: vec!["callback".into()],
+        },
+        Output {
+            name: "nested_higher_ranked_fn_pointer".into(),
             params: vec!["callback".into()],
         },
         Output {
@@ -11135,6 +11211,19 @@ fn function_parameters() {
         Output {
             name: "generic_assoc_arg".into(),
             params: vec!["pair".into()],
+        },
+        Output {
+            name: "parent_and_method".into(),
+            params: vec![
+                "self".into(),
+                "owner".into(),
+                "extra".into(),
+                "method".into(),
+            ],
+        },
+        Output {
+            name: "parent_lifetime_const".into(),
+            params: vec!["self".into(), "owner".into(), "method".into()],
         },
         Output {
             name: "add_method".into(),
@@ -11302,6 +11391,10 @@ fn function_return_value() {
             is_unit: false,
         },
         Output {
+            name: "two_lifetimes".into(),
+            is_unit: false,
+        },
+        Output {
             name: "const_array".into(),
             is_unit: false,
         },
@@ -11410,6 +11503,14 @@ fn function_return_value() {
             is_unit: false,
         },
         Output {
+            name: "sorted_higher_ranked_return_bounds".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "repeated_higher_ranked_lifetime_name_return".into(),
+            is_unit: false,
+        },
+        Output {
             name: "raw_pointer_impl_trait".into(),
             is_unit: true,
         },
@@ -11423,6 +11524,10 @@ fn function_return_value() {
         },
         Output {
             name: "higher_ranked_fn_pointer".into(),
+            is_unit: true,
+        },
+        Output {
+            name: "nested_higher_ranked_fn_pointer".into(),
             is_unit: true,
         },
         Output {
@@ -11452,6 +11557,14 @@ fn function_return_value() {
         Output {
             name: "generic_assoc_arg".into(),
             is_unit: true,
+        },
+        Output {
+            name: "parent_and_method".into(),
+            is_unit: false,
+        },
+        Output {
+            name: "parent_lifetime_const".into(),
+            is_unit: false,
         },
         Output {
             name: "add_method".into(),
@@ -11599,6 +11712,18 @@ fn function_parameter_normalized_type_signatures() {
             signature: "&'a str".into(),
         },
         Output {
+            name: "two_lifetimes".into(),
+            position: 1,
+            param_name: "first".into(),
+            signature: "&'a u8".into(),
+        },
+        Output {
+            name: "two_lifetimes".into(),
+            position: 2,
+            param_name: "second".into(),
+            signature: "&'b u8".into(),
+        },
+        Output {
             name: "const_array".into(),
             position: 1,
             param_name: "value".into(),
@@ -11639,13 +11764,13 @@ fn function_parameter_normalized_type_signatures() {
             name: "function_pointer".into(),
             position: 1,
             param_name: "callback".into(),
-            signature: "for<'a> unsafe fn(&'a u8) -> &'a u8".into(),
+            signature: "for<'b1> unsafe fn(&'b1 u8) -> &'b1 u8".into(),
         },
         Output {
             name: "function_pointer_nested_generics".into(),
             position: 1,
             param_name: "callback".into(),
-            signature: "for<'b> fn(&'a T1, &'b [T1; C1]) -> &'b T1".into(),
+            signature: "for<'b1> fn(&'a T1, &'b1 [T1; C1]) -> &'b1 T1".into(),
         },
         Output {
             name: "dyn_trait_lifetime".into(),
@@ -11896,7 +12021,13 @@ fn function_parameter_normalized_type_signatures() {
             name: "higher_ranked_fn_pointer".into(),
             position: 1,
             param_name: "callback".into(),
-            signature: "for<'a> fn(&'a u8) -> &'a u8".into(),
+            signature: "for<'b1> fn(&'b1 u8) -> &'b1 u8".into(),
+        },
+        Output {
+            name: "nested_higher_ranked_fn_pointer".into(),
+            position: 1,
+            param_name: "callback".into(),
+            signature: "for<'b1> fn(&'b1 (), for<'b2> fn(&'b2 ()))".into(),
         },
         Output {
             name: "unsafe_c_variadic_pointer".into(),
@@ -12046,11 +12177,11 @@ fn function_parameter_normalized_type_signature_handles_assoc_constraint_impl_tr
         },
         Output {
             name: "complex_constraint_a_then_b".into(),
-            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = ::alloc::boxed::Box<dyn for<'b> ::core::ops::function::Fn(&'b u8) -> &'b u8 + 'a>, B = IT1_1>>".into(),
+            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = ::alloc::boxed::Box<dyn for<'b1> ::core::ops::function::Fn(&'b1 u8) -> &'b1 u8 + 'a>, B = IT1_1>>".into(),
         },
         Output {
             name: "complex_constraint_b_then_a".into(),
-            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = ::alloc::boxed::Box<dyn for<'b> ::core::ops::function::Fn(&'b u8) -> &'b u8 + 'a>, B = IT1_1>>".into(),
+            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = ::alloc::boxed::Box<dyn for<'b1> ::core::ops::function::Fn(&'b1 u8) -> &'b1 u8 + 'a>, B = IT1_1>>".into(),
         },
         Output {
             name: "constraint_type_shapes".into(),
@@ -12062,11 +12193,15 @@ fn function_parameter_normalized_type_signature_handles_assoc_constraint_impl_tr
         },
         Output {
             name: "constraint_higher_ranked_function_pointer".into(),
-            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = for<'a> fn(&'a u8) -> &'a u8, B = IT1_1>>".into(),
+            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = for<'b1> fn(&'b1 u8) -> &'b1 u8, B = IT1_1>>".into(),
         },
         Output {
             name: "constraint_two_lifetime_function_pointer".into(),
-            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = for<'a, 'b> fn(&'a u8, &'b u8) -> &'b u8, B = IT1_1>>".into(),
+            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = for<'b1, 'b2> fn(&'b1 u8, &'b2 u8) -> &'b2 u8, B = IT1_1>>".into(),
+        },
+        Output {
+            name: "constraint_higher_ranked_two_constraints_b_then_a".into(),
+            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = for<'b1> fn(&'b1 u8) -> &'b1 u8, B = for<'b2> fn(&'b2 u16) -> &'b2 u16>>".into(),
         },
         Output {
             name: "constraint_dyn_fn_trait_two_args".into(),
@@ -12106,6 +12241,10 @@ fn function_parameter_normalized_type_signature_handles_assoc_constraint_impl_tr
         },
         Output {
             name: "constraint_dyn_multi_trait".into(),
+            signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = ::alloc::boxed::Box<dyn ::core::marker::Send + ::core::marker::Sync + 'a>, B = IT1_1>>".into(),
+        },
+        Output {
+            name: "constraint_dyn_multi_trait_reverse".into(),
             signature: "::alloc::boxed::Box<dyn ::assoc_constraint_order::AssocConstraintOrder<A = ::alloc::boxed::Box<dyn ::core::marker::Send + ::core::marker::Sync + 'a>, B = IT1_1>>".into(),
         },
     ];
@@ -12176,6 +12315,7 @@ fn function_return_normalized_type_signature_handles_assoc_constraint_bound() {
         "constraint_function_pointer",
         "constraint_higher_ranked_function_pointer",
         "constraint_two_lifetime_function_pointer",
+        "constraint_higher_ranked_two_constraints_b_then_a",
         "constraint_dyn_fn_trait_two_args",
         "constraint_qualified_path",
         "where_bound_after_input_impl_trait",
@@ -12185,6 +12325,7 @@ fn function_return_normalized_type_signature_handles_assoc_constraint_bound() {
         "constraint_mutable_reference",
         "constraint_single_tuple",
         "constraint_dyn_multi_trait",
+        "constraint_dyn_multi_trait_reverse",
     ];
 
     let mut expected_results = unit_return_functions
@@ -12211,6 +12352,42 @@ fn function_return_normalized_type_signature_handles_assoc_constraint_bound() {
                 signature:
                     "impl ::assoc_constraint_order::HasGenericItem<Item<u8>: ::core::clone::Clone + ::core::marker::Copy>"
                         .into(),
+            },
+            Output {
+                name: "return_nested_opaque_bound_clone_then_copy".into(),
+                signature: "impl ::assoc_constraint_order::HasItem<Item: ::assoc_constraint_order::Takes<impl ::core::clone::Clone> + ::assoc_constraint_order::Takes<impl ::core::marker::Copy>>".into(),
+            },
+            Output {
+                name: "return_nested_opaque_bound_copy_then_clone".into(),
+                signature: "impl ::assoc_constraint_order::HasItem<Item: ::assoc_constraint_order::Takes<impl ::core::clone::Clone> + ::assoc_constraint_order::Takes<impl ::core::marker::Copy>>".into(),
+            },
+            Output {
+                name: "return_function_pointer_bound_safe_then_unsafe".into(),
+                signature: "impl ::assoc_constraint_order::Takes<fn(u8) -> u8> + ::assoc_constraint_order::Takes<unsafe extern \"C\" fn(u8, ...) -> u8>".into(),
+            },
+            Output {
+                name: "return_function_pointer_bound_unsafe_then_safe".into(),
+                signature: "impl ::assoc_constraint_order::Takes<fn(u8) -> u8> + ::assoc_constraint_order::Takes<unsafe extern \"C\" fn(u8, ...) -> u8>".into(),
+            },
+            Output {
+                name: "return_assoc_constraints_b_then_a".into(),
+                signature: "impl ::assoc_constraint_order::AssocConstraintOrder<A = u8, B = u8>".into(),
+            },
+            Output {
+                name: "return_const_arg_sort_key".into(),
+                signature: "impl ::assoc_constraint_order::TakesConst<1> + ::assoc_constraint_order::TakesConst<2>".into(),
+            },
+            Output {
+                name: "return_function_pointer_signature_sort_key".into(),
+                signature: "impl ::assoc_constraint_order::Takes<fn(u16)> + ::assoc_constraint_order::Takes<fn(u8)>".into(),
+            },
+            Output {
+                name: "return_function_pointer_header_sort_key".into(),
+                signature: "impl ::assoc_constraint_order::Takes<fn(u8)> + ::assoc_constraint_order::Takes<unsafe fn(u8)>".into(),
+            },
+            Output {
+                name: "return_function_pointer_abi_sort_key".into(),
+                signature: "impl ::assoc_constraint_order::Takes<unsafe extern \"C\" fn(u8)> + ::assoc_constraint_order::Takes<unsafe extern \"C-unwind\" fn(u8)>".into(),
             },
         ])
         .collect::<Vec<_>>();
@@ -12282,6 +12459,10 @@ fn function_return_normalized_type_signatures() {
             signature: "&'a str".into(),
         },
         Output {
+            name: "two_lifetimes".into(),
+            signature: "(&'a u8, &'b u8)".into(),
+        },
+        Output {
             name: "const_array".into(),
             signature: "[u8; C1]".into(),
         },
@@ -12300,11 +12481,15 @@ fn function_return_normalized_type_signatures() {
         },
         Output {
             name: "function_pointer".into(),
-            signature: "for<'a> unsafe fn(&'a u8) -> &'a u8".into(),
+            signature: "for<'b1> unsafe fn(&'b1 u8) -> &'b1 u8".into(),
         },
         Output {
             name: "function_pointer_nested_generics".into(),
-            signature: "for<'b> fn(&'a T1, &'b [T1; C1]) -> &'b T1".into(),
+            signature: "for<'b1> fn(&'a T1, &'b1 [T1; C1]) -> &'b1 T1".into(),
+        },
+        Output {
+            name: "nested_higher_ranked_fn_pointer".into(),
+            signature: "()".into(),
         },
         Output {
             name: "dyn_trait_lifetime".into(),
@@ -12394,6 +12579,18 @@ fn function_return_normalized_type_signatures() {
                     .into(),
         },
         Output {
+            name: "sorted_higher_ranked_return_bounds".into(),
+            signature:
+                "impl for<'b1> ::function_params_and_return_value::BinderTraitA<&'b1 ()> + for<'b2> ::function_params_and_return_value::BinderTraitB<&'b2 ()>"
+                    .into(),
+        },
+        Output {
+            name: "repeated_higher_ranked_lifetime_name_return".into(),
+            signature:
+                "impl for<'b1> ::function_params_and_return_value::BinderTraitA<&'b1 ()> + for<'b2> ::function_params_and_return_value::BinderTraitB<&'b2 ()>"
+                    .into(),
+        },
+        Output {
             name: "raw_pointer_impl_trait".into(),
             signature: "()".into(),
         },
@@ -12436,6 +12633,68 @@ fn function_return_normalized_type_signatures() {
         Output {
             name: "generic_assoc_arg".into(),
             signature: "()".into(),
+        },
+    ];
+    expected_results.sort_unstable();
+
+    let mut results: Vec<Output> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables)
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    similar_asserts::assert_eq!(expected_results, results);
+}
+
+/// Query every function in the unstable `impl_trait_in_fn_trait_return` crate
+/// so each fixture example has an expected normalized signature here.
+#[test]
+fn unstable_impl_trait_in_fn_trait_return_normalized_type_signatures() {
+    get_test_data!(data, impl_trait_in_fn_trait_return);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Function {
+                name @output
+
+                return_value {
+                    normalized_type_signature {
+                        signature @output
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+    let variables: BTreeMap<&str, bool> = BTreeMap::default();
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        name: String,
+        signature: String,
+    }
+
+    let mut expected_results = vec![
+        Output {
+            name: "fn_bound_opaque_return".into(),
+            signature:
+                "impl ::core::clone::Clone + ::core::ops::function::Fn() -> (impl ::core::clone::Clone + ::core::marker::Copy)"
+                    .into(),
+        },
+        Output {
+            name: "fn_bound_opaque_return_first".into(),
+            signature:
+                "impl ::core::ops::function::Fn() -> (impl ::core::clone::Clone + ::core::marker::Copy) + ::impl_trait_in_fn_trait_return::Zed"
+                    .into(),
         },
     ];
     expected_results.sort_unstable();
@@ -12590,6 +12849,14 @@ fn method_normalized_type_signatures_include_parent_generics() {
         "inherent_owner" => "GenericExample".into(),
         "inherent_methods" => vec![FieldValue::String("combine".into()), FieldValue::String("pin_box_self".into())].into(),
     };
+    let generic_pair_variables: BTreeMap<&str, FieldValue> = btreemap! {
+        "inherent_owner" => "GenericPairExample".into(),
+        "inherent_methods" => vec![FieldValue::String("parent_and_method".into())].into(),
+    };
+    let lifetime_const_variables: BTreeMap<&str, FieldValue> = btreemap! {
+        "inherent_owner" => "LifetimeConstExample".into(),
+        "inherent_methods" => vec![FieldValue::String("parent_lifetime_const".into())].into(),
+    };
     let trait_variables = btreemap! {
         "trait_owner" => "GenericTrait",
         "trait_method" => "combine_trait",
@@ -12637,23 +12904,23 @@ fn method_normalized_type_signatures_include_parent_generics() {
             position: 1,
             param_name: "self".into(),
             param_signature: "&Self".into(),
-            return_signature: "(T1, T2)".into(),
+            return_signature: "(TO1, T1)".into(),
         },
         Output {
             owner: "GenericExample".into(),
             method_name: "combine".into(),
             position: 2,
             param_name: "owner".into(),
-            param_signature: "T1".into(),
-            return_signature: "(T1, T2)".into(),
+            param_signature: "TO1".into(),
+            return_signature: "(TO1, T1)".into(),
         },
         Output {
             owner: "GenericExample".into(),
             method_name: "combine".into(),
             position: 3,
             param_name: "method".into(),
-            param_signature: "T2".into(),
-            return_signature: "(T1, T2)".into(),
+            param_signature: "T1".into(),
+            return_signature: "(TO1, T1)".into(),
         },
         Output {
             owner: "GenericExample".into(),
@@ -12664,28 +12931,84 @@ fn method_normalized_type_signatures_include_parent_generics() {
             return_signature: "()".into(),
         },
         Output {
+            owner: "GenericPairExample".into(),
+            method_name: "parent_and_method".into(),
+            position: 1,
+            param_name: "self".into(),
+            param_signature: "&Self".into(),
+            return_signature: "(TO1, TO2, T1)".into(),
+        },
+        Output {
+            owner: "GenericPairExample".into(),
+            method_name: "parent_and_method".into(),
+            position: 2,
+            param_name: "owner".into(),
+            param_signature: "TO1".into(),
+            return_signature: "(TO1, TO2, T1)".into(),
+        },
+        Output {
+            owner: "GenericPairExample".into(),
+            method_name: "parent_and_method".into(),
+            position: 3,
+            param_name: "extra".into(),
+            param_signature: "TO2".into(),
+            return_signature: "(TO1, TO2, T1)".into(),
+        },
+        Output {
+            owner: "GenericPairExample".into(),
+            method_name: "parent_and_method".into(),
+            position: 4,
+            param_name: "method".into(),
+            param_signature: "T1".into(),
+            return_signature: "(TO1, TO2, T1)".into(),
+        },
+        Output {
+            owner: "LifetimeConstExample".into(),
+            method_name: "parent_lifetime_const".into(),
+            position: 1,
+            param_name: "self".into(),
+            param_signature: "&Self".into(),
+            return_signature: "(&'o1 [u8; CO1], T1)".into(),
+        },
+        Output {
+            owner: "LifetimeConstExample".into(),
+            method_name: "parent_lifetime_const".into(),
+            position: 2,
+            param_name: "owner".into(),
+            param_signature: "&'o1 [u8; CO1]".into(),
+            return_signature: "(&'o1 [u8; CO1], T1)".into(),
+        },
+        Output {
+            owner: "LifetimeConstExample".into(),
+            method_name: "parent_lifetime_const".into(),
+            position: 3,
+            param_name: "method".into(),
+            param_signature: "T1".into(),
+            return_signature: "(&'o1 [u8; CO1], T1)".into(),
+        },
+        Output {
             owner: "GenericTrait".into(),
             method_name: "combine_trait".into(),
             position: 1,
             param_name: "self".into(),
             param_signature: "&Self".into(),
-            return_signature: "(T1, T2)".into(),
+            return_signature: "(TO1, T1)".into(),
         },
         Output {
             owner: "GenericTrait".into(),
             method_name: "combine_trait".into(),
             position: 2,
             param_name: "owner".into(),
-            param_signature: "T1".into(),
-            return_signature: "(T1, T2)".into(),
+            param_signature: "TO1".into(),
+            return_signature: "(TO1, T1)".into(),
         },
         Output {
             owner: "GenericTrait".into(),
             method_name: "combine_trait".into(),
             position: 3,
             param_name: "method".into(),
-            param_signature: "T2".into(),
-            return_signature: "(T1, T2)".into(),
+            param_signature: "T1".into(),
+            return_signature: "(TO1, T1)".into(),
         },
         Output {
             owner: "Provider".into(),
@@ -12721,23 +13044,23 @@ fn method_normalized_type_signatures_include_parent_generics() {
             position: 1,
             param_name: "self".into(),
             param_signature: "&Self".into(),
-            return_signature: "(T1, T2)".into(),
+            return_signature: "(TO1, T1)".into(),
         },
         Output {
             owner: "ImplementsGenericTrait".into(),
             method_name: "combine_trait".into(),
             position: 2,
             param_name: "owner".into(),
-            param_signature: "T1".into(),
-            return_signature: "(T1, T2)".into(),
+            param_signature: "TO1".into(),
+            return_signature: "(TO1, T1)".into(),
         },
         Output {
             owner: "ImplementsGenericTrait".into(),
             method_name: "combine_trait".into(),
             position: 3,
             param_name: "method".into(),
-            param_signature: "T2".into(),
-            return_signature: "(T1, T2)".into(),
+            param_signature: "T1".into(),
+            return_signature: "(TO1, T1)".into(),
         },
         Output {
             owner: "UsesDefaultGenericTrait".into(),
@@ -12745,23 +13068,23 @@ fn method_normalized_type_signatures_include_parent_generics() {
             position: 1,
             param_name: "self".into(),
             param_signature: "&mut Self".into(),
-            return_signature: "(T1, T2)".into(),
+            return_signature: "(TO1, T1)".into(),
         },
         Output {
             owner: "UsesDefaultGenericTrait".into(),
             method_name: "default_combine".into(),
             position: 2,
             param_name: "owner".into(),
-            param_signature: "T1".into(),
-            return_signature: "(T1, T2)".into(),
+            param_signature: "TO1".into(),
+            return_signature: "(TO1, T1)".into(),
         },
         Output {
             owner: "UsesDefaultGenericTrait".into(),
             method_name: "default_combine".into(),
             position: 3,
             param_name: "method".into(),
-            param_signature: "T2".into(),
-            return_signature: "(T1, T2)".into(),
+            param_signature: "T1".into(),
+            return_signature: "(TO1, T1)".into(),
         },
     ];
     expected_results.sort_unstable();
@@ -12769,6 +13092,24 @@ fn method_normalized_type_signatures_include_parent_generics() {
     let mut results: Vec<Output> =
         trustfall::execute_query(&schema, adapter.clone(), inherent_query, inherent_variables)
             .expect("failed to run inherent method query")
+            .chain(
+                trustfall::execute_query(
+                    &schema,
+                    adapter.clone(),
+                    inherent_query,
+                    generic_pair_variables,
+                )
+                .expect("failed to run generic pair inherent method query"),
+            )
+            .chain(
+                trustfall::execute_query(
+                    &schema,
+                    adapter.clone(),
+                    inherent_query,
+                    lifetime_const_variables,
+                )
+                .expect("failed to run lifetime const inherent method query"),
+            )
             .chain(
                 trustfall::execute_query(&schema, adapter.clone(), trait_query, trait_variables)
                     .expect("failed to run trait method query"),

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -3174,5 +3174,38 @@ expected exactly one importable path for `Foo` items in this crate but got: {act
             assert_eq!(method_entries.len(), 1, "{method_entries:#?}");
             assert_ne!(method_entries[0].1, trait_provided_method);
         }
+
+        #[test]
+        fn provided_trait_method_index_ignores_same_named_associated_types() {
+            let test_crate = "defaulted_trait_items_overridden_in_impls";
+
+            let rustdoc = load_pregenerated_rustdoc(test_crate);
+            let indexed_crate = IndexedCrate::new(&rustdoc);
+
+            let impl_owner = indexed_crate
+                .inner
+                .index
+                .values()
+                .filter(|item| item.name.as_deref() == Some("SameNameExample"))
+                .exactly_one()
+                .expect("failed to find exactly one SameNameExample item");
+
+            let impl_index = indexed_crate
+                .impl_method_index
+                .as_ref()
+                .expect("no impl index was built");
+            let method_entries = impl_index
+                .get(&ImplEntry::new(&impl_owner.id, "method"))
+                .expect("no method entries found");
+
+            assert_eq!(method_entries.len(), 1, "{method_entries:#?}");
+            assert!(
+                matches!(
+                    method_entries[0].1.inner,
+                    rustdoc_types::ItemEnum::Function(..)
+                ),
+                "impl method index included a non-function item: {method_entries:#?}",
+            );
+        }
     }
 }

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -2116,12 +2116,20 @@ type NormalizedTypeSignature {
   """
   Canonical normalized string representation of one Rust type.
 
-  The signature is scoped to the item that contains the type.
-  Generic parameter names from that scope are normalized in declaration order:
-  lifetimes become `'a`, `'b`, and so on; non-synthetic type parameters
+  For free functions, generic parameter names are normalized in declaration
+  order: lifetimes become `'a`, `'b`, and so on; non-synthetic type parameters
   become `T1`, `T2`, and so on; const parameters become `C1`, `C2`, and so on.
-  For example, in `impl<A> Example<A> { fn f<B>(&self, a: A, b: B) }`,
-  parameter `a` has signature `T1` while parameter `b` has signature `T2`.
+
+  Method signatures distinguish generics in the method's own item scope from
+  generics inherited from the containing `trait` or `impl`. Method generics use
+  the same item-scope names as free functions. Parent `trait` or `impl` type
+  parameters become `TO1`, `TO2`, and so on; parent const parameters become
+  `CO1`, `CO2`, and so on; parent lifetimes become `'o1`, `'o2`, and so on.
+  For example, in `impl<A> Example<A> { fn f<B>(&self, x: A, y: B) }`,
+  parameter `x` has signature `TO1` while parameter `y` has signature `T1`.
+
+  Higher-ranked binder lifetimes use `'b1`, `'b2`, and so on. For example,
+  `for<'a> fn(&'a u8)` has signature `for<'b1> fn(&'b1 u8)`.
 
   A single function parameter may contain multiple parameter-position `impl Trait`
   uses, for example: `impl Iterator<Item = impl Into<String>>`.

--- a/test_crates/assoc_constraint_order/src/lib.rs
+++ b/test_crates/assoc_constraint_order/src/lib.rs
@@ -11,6 +11,11 @@ impl AssocConstraintOrder for ConcreteAssoc {
 }
 
 pub trait Takes<T> {}
+pub trait AlsoTakes<T> {}
+pub trait TakesConst<const N: usize> {}
+impl<T, U> Takes<T> for U {}
+impl<T, U> AlsoTakes<T> for U {}
+impl<T, const N: usize> TakesConst<N> for T {}
 
 pub trait TakesLifetimeConst<'a, const N: usize> {}
 
@@ -28,6 +33,10 @@ pub fn return_assoc_constraint_bound() -> impl AssocConstraintOrder<A: Clone + C
 
 pub trait HasItem {
     type Item;
+}
+
+impl HasItem for ConcreteAssoc {
+    type Item = u8;
 }
 
 pub trait HasGenericItem {
@@ -52,6 +61,38 @@ pub fn return_generic_assoc_constraint_bound() -> impl GenericAssoc<u8, A: Clone
 
 pub fn return_gat_assoc_constraint_bound() -> impl HasGenericItem<Item<u8>: Clone + Copy> {
     ConcreteAssoc
+}
+
+pub fn return_nested_opaque_bound_clone_then_copy(
+) -> impl HasItem<Item: Takes<impl Clone> + Takes<impl Copy>> {
+    ConcreteAssoc
+}
+
+pub fn return_nested_opaque_bound_copy_then_clone(
+) -> impl HasItem<Item: Takes<impl Copy> + Takes<impl Clone>> {
+    ConcreteAssoc
+}
+
+pub fn return_function_pointer_bound_safe_then_unsafe(
+) -> impl Takes<fn(u8) -> u8> + Takes<unsafe extern "C" fn(u8, ...) -> u8> {
+}
+
+pub fn return_function_pointer_bound_unsafe_then_safe(
+) -> impl Takes<unsafe extern "C" fn(u8, ...) -> u8> + Takes<fn(u8) -> u8> {
+}
+
+pub fn return_assoc_constraints_b_then_a() -> impl AssocConstraintOrder<B = u8, A = u8> {
+    ConcreteAssoc
+}
+
+pub fn return_const_arg_sort_key() -> impl TakesConst<2> + TakesConst<1> {}
+
+pub fn return_function_pointer_signature_sort_key() -> impl Takes<fn(u8)> + Takes<fn(u16)> {}
+
+pub fn return_function_pointer_header_sort_key() -> impl Takes<unsafe fn(u8)> + Takes<fn(u8)> {}
+
+pub fn return_function_pointer_abi_sort_key(
+) -> impl Takes<unsafe extern "C-unwind" fn(u8)> + Takes<unsafe extern "C" fn(u8)> {
 }
 
 pub trait Provider {
@@ -190,6 +231,17 @@ pub fn constraint_two_lifetime_function_pointer(
     let _ = value;
 }
 
+pub fn constraint_higher_ranked_two_constraints_b_then_a(
+    value: Box<
+        dyn AssocConstraintOrder<
+            B = for<'b> fn(&'b u16) -> &'b u16,
+            A = for<'a> fn(&'a u8) -> &'a u8,
+        >,
+    >,
+) {
+    let _ = value;
+}
+
 pub fn constraint_dyn_fn_trait_two_args(
     value: Box<dyn AssocConstraintOrder<A = Box<dyn Fn(u8, u16) -> u32>, B = impl Clone>>,
 ) {
@@ -241,6 +293,12 @@ pub fn constraint_single_tuple(
 
 pub fn constraint_dyn_multi_trait<'a>(
     value: Box<dyn AssocConstraintOrder<A = Box<dyn Send + Sync + 'a>, B = impl Clone>>,
+) {
+    let _ = value;
+}
+
+pub fn constraint_dyn_multi_trait_reverse<'a>(
+    value: Box<dyn AssocConstraintOrder<A = Box<dyn Sync + Send + 'a>, B = impl Clone>>,
 ) {
     let _ = value;
 }

--- a/test_crates/assoc_constraint_order/src/lib.rs
+++ b/test_crates/assoc_constraint_order/src/lib.rs
@@ -19,6 +19,10 @@ impl<T, const N: usize> TakesConst<N> for T {}
 
 pub trait TakesLifetimeConst<'a, const N: usize> {}
 
+pub trait RealTrait {
+    fn method(&self);
+}
+
 pub fn a_then_b(value: Box<dyn AssocConstraintOrder<A = impl Clone, B = impl Copy>>) {
     let _ = value;
 }
@@ -60,6 +64,12 @@ pub fn return_generic_assoc_constraint_bound() -> impl GenericAssoc<u8, A: Clone
 }
 
 pub fn return_gat_assoc_constraint_bound() -> impl HasGenericItem<Item<u8>: Clone + Copy> {
+    ConcreteAssoc
+}
+
+#[allow(unused_parens)]
+pub fn return_nested_dyn_bound(
+) -> impl HasItem<Item: Fn() -> (dyn RealTrait + Send) + Clone> {
     ConcreteAssoc
 }
 

--- a/test_crates/assoc_constraint_order/src/lib.rs
+++ b/test_crates/assoc_constraint_order/src/lib.rs
@@ -23,6 +23,10 @@ pub trait RealTrait {
     fn method(&self);
 }
 
+pub struct DynAssoc;
+
+pub struct DynPointerAssoc;
+
 pub fn a_then_b(value: Box<dyn AssocConstraintOrder<A = impl Clone, B = impl Copy>>) {
     let _ = value;
 }
@@ -36,11 +40,19 @@ pub fn return_assoc_constraint_bound() -> impl AssocConstraintOrder<A: Clone + C
 }
 
 pub trait HasItem {
-    type Item;
+    type Item: ?Sized;
 }
 
 impl HasItem for ConcreteAssoc {
     type Item = u8;
+}
+
+impl HasItem for DynAssoc {
+    type Item = dyn RealTrait + Send;
+}
+
+impl HasItem for DynPointerAssoc {
+    type Item = fn() -> *const (dyn RealTrait + Send);
 }
 
 pub trait HasGenericItem {
@@ -67,10 +79,13 @@ pub fn return_gat_assoc_constraint_bound() -> impl HasGenericItem<Item<u8>: Clon
     ConcreteAssoc
 }
 
-#[allow(unused_parens)]
-pub fn return_nested_dyn_bound(
-) -> impl HasItem<Item: Fn() -> (dyn RealTrait + Send) + Clone> {
-    ConcreteAssoc
+pub fn return_nested_dyn_bound() -> impl HasItem<Item = dyn RealTrait + Send> {
+    DynAssoc
+}
+
+pub fn return_nested_parenthesized_dyn_bound(
+) -> impl HasItem<Item = fn() -> *const (dyn RealTrait + Send)> {
+    DynPointerAssoc
 }
 
 pub fn return_nested_opaque_bound_clone_then_copy(

--- a/test_crates/defaulted_trait_items_overridden_in_impls/src/lib.rs
+++ b/test_crates/defaulted_trait_items_overridden_in_impls/src/lib.rs
@@ -31,3 +31,16 @@ impl Trait for Example {
         println!("hello world!");
     }
 }
+
+#[allow(non_camel_case_types)]
+pub trait SameNameTrait {
+    type method;
+
+    fn method() {}
+}
+
+struct SameNameExample;
+
+impl SameNameTrait for SameNameExample {
+    type method = u8;
+}

--- a/test_crates/function_params_and_return_value/src/lib.rs
+++ b/test_crates/function_params_and_return_value/src/lib.rs
@@ -8,6 +8,13 @@ pub struct PublicType<T>(pub T);
 
 pub struct LifetimeConst<'a, const N: usize>(pub &'a [u8; N]);
 
+pub trait BinderTraitA<T> {}
+pub trait BinderTraitB<T> {}
+pub struct BinderWitness;
+
+impl<'a> BinderTraitA<&'a ()> for BinderWitness {}
+impl<'a> BinderTraitB<&'a ()> for BinderWitness {}
+
 pub fn concrete_types(value: u64) -> bool {
     value > 0
 }
@@ -18,6 +25,13 @@ pub fn generic_identity<T>(value: T) -> T {
 
 pub fn lifetime_ref<'long>(value: &'long str) -> &'long str {
     value
+}
+
+pub fn two_lifetimes<'first, 'second>(
+    first: &'first u8,
+    second: &'second u8,
+) -> (&'first u8, &'second u8) {
+    (first, second)
 }
 
 pub fn const_array<const N: usize>(value: [u8; N]) -> [u8; N] {
@@ -159,6 +173,12 @@ pub fn higher_ranked_fn_pointer(callback: for<'a> fn(&'a u8) -> &'a u8) {
     let _ = callback;
 }
 
+pub fn nested_higher_ranked_fn_pointer(
+    callback: for<'outer> fn(&'outer (), for<'inner> fn(&'inner ())),
+) {
+    let _ = callback;
+}
+
 pub fn unsafe_c_variadic_pointer(callback: unsafe extern "C" fn(u8, ...) -> u8) {
     let _ = callback;
 }
@@ -197,6 +217,16 @@ pub fn fn_bound_pointer_to_dyn_return() -> impl Fn() -> *const (dyn Send + Sync)
         static VALUE: u8 = 0;
         &VALUE as &(dyn Send + Sync) as *const (dyn Send + Sync)
     }
+}
+
+pub fn sorted_higher_ranked_return_bounds(
+) -> impl for<'x> BinderTraitB<&'x ()> + for<'y> BinderTraitA<&'y ()> {
+    BinderWitness
+}
+
+pub fn repeated_higher_ranked_lifetime_name_return(
+) -> impl for<'a> BinderTraitB<&'a ()> + for<'a> BinderTraitA<&'a ()> {
+    BinderWitness
 }
 
 pub fn precise_capture_return<T: Clone>(value: T) -> impl Clone + use<T> {
@@ -247,6 +277,31 @@ impl<Owner> GenericExample<Owner> {
     }
 
     pub fn pin_box_self(self: std::pin::Pin<Box<Self>>) {}
+}
+
+pub struct GenericPairExample<Owner, Extra>(pub Owner, pub Extra);
+
+impl<Owner, Extra> GenericPairExample<Owner, Extra> {
+    pub fn parent_and_method<Method>(
+        &self,
+        owner: Owner,
+        extra: Extra,
+        method: Method,
+    ) -> (Owner, Extra, Method) {
+        (owner, extra, method)
+    }
+}
+
+pub struct LifetimeConstExample<'owner, const N: usize>(pub &'owner [u8; N]);
+
+impl<'owner, const N: usize> LifetimeConstExample<'owner, N> {
+    pub fn parent_lifetime_const<Method>(
+        &self,
+        owner: &'owner [u8; N],
+        method: Method,
+    ) -> (&'owner [u8; N], Method) {
+        (owner, method)
+    }
 }
 
 pub trait GenericTrait<TraitParam> {

--- a/test_crates/impl_trait_in_fn_trait_return/Cargo.toml
+++ b/test_crates/impl_trait_in_fn_trait_return/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "impl_trait_in_fn_trait_return"
+publish = false
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/test_crates/impl_trait_in_fn_trait_return/src/lib.rs
+++ b/test_crates/impl_trait_in_fn_trait_return/src/lib.rs
@@ -1,0 +1,12 @@
+#![feature(impl_trait_in_fn_trait_return)]
+
+pub trait Zed {}
+impl<T> Zed for T {}
+
+pub fn fn_bound_opaque_return() -> impl Fn() -> (impl Clone + Copy) + Clone {
+    || 1u8
+}
+
+pub fn fn_bound_opaque_return_first() -> impl Fn() -> (impl Clone + Copy) + Zed {
+    || 1u8
+}

--- a/test_crates/maybe_const_function_signature/src/lib.rs
+++ b/test_crates/maybe_const_function_signature/src/lib.rs
@@ -3,8 +3,22 @@
 
 pub const trait MaybeConst {}
 
+pub trait Plain {}
+
 pub const fn maybe_const_function_signature(
     arg: impl [const] MaybeConst,
 ) -> impl [const] MaybeConst {
+    arg
+}
+
+pub const fn maybe_const_return_bound_const_then_plain(
+    arg: impl [const] MaybeConst + Plain,
+) -> impl [const] MaybeConst + Plain {
+    arg
+}
+
+pub const fn maybe_const_return_bound_plain_then_const(
+    arg: impl Plain + [const] MaybeConst,
+) -> impl Plain + [const] MaybeConst {
     arg
 }


### PR DESCRIPTION
Previously, adding a generic param to a parent `impl` scope could cause the normalized generic params of functions in that `impl` to get renumbered, making it look like those functions' signatures had themselves changed as well.

This PR separates the normalization for parent, item, and higher-ranked generics so that they all use separate namespaces, and can grow and shrink independently. This will cut down on unnecessary (and expensive!) type checks and will make `cargo-semver-checks` lints more efficient.

Supersedes #1086 which was irreversibly closed due to what appears to be a GitHub bug.