### PR TITLE
Accept latest nightly tracer counts

### DIFF
--- a/src/adapter/tracer/tests.rs
+++ b/src/adapter/tracer/tests.rs
@@ -190,15 +190,16 @@ fn tracing_adapter() {
             1..=1,
         ),
         // Rust 1.96 nightly rustdoc emits a synthetic `impl UnsafeUnpin for Foo`,
-        // which adds one more top-level `Item` candidate and therefore one more
-        // attempted `Item -> Trait` coercion than older toolchains.
+        // and Rust 1.99 nightly rustdoc emits a synthetic blanket `SizeHint` impl.
+        // These add top-level `Item` candidates and therefore attempted
+        // `Item -> Trait` coercions compared to older toolchains.
         (
             FunctionCall::ResolveNeighborsInner(
                 Vid::new(NonZero::new(1).unwrap()),
                 "Crate".into(),
                 Eid::new(NonZero::new(1).unwrap()),
             ),
-            20..=21,
+            20..=22,
         ),
         (
             FunctionCall::ResolveNeighborsInner(
@@ -214,7 +215,7 @@ fn tracing_adapter() {
                 "Item".into(),
                 "Trait".into(),
             ),
-            20..=21,
+            20..=22,
         ),
     ];
 


### PR DESCRIPTION
## Summary

Updates the tracer test's accepted traversal count range for current nightly rustdoc output.

Rust 1.99 nightly now emits a synthetic blanket `SizeHint` impl in the `function_has_body` fixture. That adds one more crate-level `Item` candidate and one more attempted `Item -> Trait` coercion, similar to the previous `UnsafeUnpin` nightly drift.

## Validation

Ran from a temporary worktree with generated rustdoc fixtures copied in for local validation:

- `cargo fmt --check`
- `cargo test adapter::tracer::tests::tracing_adapter --lib`
- `cargo test`
- `cargo clippy --all-targets --no-deps -- -D warnings --allow deprecated`
- `env "RUSTDOCFLAGS=-D warnings" cargo doc --no-deps --document-private-items`