### PR TITLE
Add `generic_parameter` node to `AssociatedType`

### DIFF
--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -337,7 +337,7 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
                 edges::resolve_normalized_type_signature_edge(contexts, edge_name)
             }
             "GenericItem" | "ImplOwner" | "Struct" | "Enum" | "Union" | "Trait" | "Function"
-            | "Method" | "Impl"
+            | "Method" | "Impl" | "AssociatedType"
                 if matches!(edge_name.as_ref(), "generic_parameter") =>
             {
                 edges::resolve_generic_parameter_edge(contexts, edge_name)
@@ -405,7 +405,13 @@ impl<'a> Adapter<'a> for &'a RustdocAdapter<'a> {
                         ),
                         "GenericItem" => matches!(
                             actual_type_name,
-                            "Struct" | "Enum" | "Union" | "Trait" | "Function" | "Method"
+                            "Struct"
+                                | "Enum"
+                                | "Union"
+                                | "Trait"
+                                | "Function"
+                                | "Method"
+                                | "AssociatedType"
                         ),
                         "Variant" => matches!(
                             actual_type_name,

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -13236,3 +13236,156 @@ fn function_parameter_normalized_type_signature_lint_shape() {
 
     similar_asserts::assert_eq!(expected_results, results);
 }
+
+#[test]
+fn rustdoc_trait_has_generic_associated_types() {
+    get_test_data!(data, generic_associated_types);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+{
+    Crate {
+        item {
+            ... on Trait {
+                trait_name: name @output
+                associated_type {
+                    type_name: name @output
+                    generic_parameter {
+                        generic_name: name @output
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+
+    let variables: BTreeMap<&str, &str> = BTreeMap::default();
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        trait_name: String,
+        type_name: String,
+        generic_name: String,
+    }
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    similar_asserts::assert_eq!(
+        vec![
+            Output {
+                trait_name: "ConstGenericTrait".into(),
+                type_name: "ConstTrait".into(),
+                generic_name: "N".into(),
+            },
+            Output {
+                trait_name: "LifetimeGenericTrait".into(),
+                type_name: "Item".into(),
+                generic_name: "'a".into(),
+            },
+            Output {
+                trait_name: "TypeGenericTrait".into(),
+                type_name: "Item".into(),
+                generic_name: "T".into(),
+            },
+            Output {
+                trait_name: "TypeLifetimeGenericTrait".into(),
+                type_name: "Item".into(),
+                generic_name: "'a".into(),
+            },
+            Output {
+                trait_name: "TypeLifetimeGenericTrait".into(),
+                type_name: "Item".into(),
+                generic_name: "T".into(),
+            },
+        ],
+        results
+    );
+}
+
+#[test]
+fn rustdoc_item_has_generic_associated_types() {
+    get_test_data!(data, generic_associated_types);
+    let adapter = RustdocAdapter::new(&data, None);
+    let adapter = Arc::new(&adapter);
+
+    let query = r#"
+{
+    Crate {
+        item {
+        ... on GenericItem {
+                type_name: name @output
+                generic_parameter {
+                    generic_name: name @output
+                    generic_kind: __typename @output
+                }
+            }
+        }
+    }
+}
+"#;
+
+    let variables: BTreeMap<&str, &str> = BTreeMap::default();
+
+    let schema =
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema failed to parse");
+
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, serde::Deserialize)]
+    struct Output {
+        type_name: String,
+        generic_name: String,
+        generic_kind: String,
+    }
+
+    let mut results: Vec<_> =
+        trustfall::execute_query(&schema, adapter.clone(), query, variables.clone())
+            .expect("failed to run query")
+            .map(|row| row.try_into_struct().expect("shape mismatch"))
+            .collect();
+    results.sort_unstable();
+
+    similar_asserts::assert_eq!(
+        vec![
+            Output {
+                type_name: "ConstTrait".into(),
+                generic_name: "N".into(),
+                generic_kind: "GenericConstParameter".into(),
+            },
+            Output {
+                type_name: "ConstTrait".into(),
+                generic_name: "N".into(),
+                generic_kind: "GenericConstParameter".into(),
+            },
+            Output {
+                type_name: "Item".into(),
+                generic_name: "'a".into(),
+                generic_kind: "GenericLifetimeParameter".into(),
+            },
+            Output {
+                type_name: "Item".into(),
+                generic_name: "'a".into(),
+                generic_kind: "GenericLifetimeParameter".into(),
+            },
+            Output {
+                type_name: "Item".into(),
+                generic_name: "T".into(),
+                generic_kind: "GenericTypeParameter".into(),
+            },
+            Output {
+                type_name: "Item".into(),
+                generic_name: "T".into(),
+                generic_kind: "GenericTypeParameter".into(),
+            },
+        ],
+        results
+    );
+}

--- a/src/adapter/tests.rs
+++ b/src/adapter/tests.rs
@@ -13322,7 +13322,7 @@ fn rustdoc_item_has_generic_associated_types() {
 {
     Crate {
         item {
-        ... on GenericItem {
+            ... on GenericItem {
                 type_name: name @output
                 generic_parameter {
                     generic_name: name @output

--- a/src/adapter/vertex.rs
+++ b/src/adapter/vertex.rs
@@ -422,6 +422,7 @@ impl<'a> Vertex<'a> {
             rustdoc_types::ItemEnum::Trait(x) => Some(&x.generics),
             rustdoc_types::ItemEnum::Union(x) => Some(&x.generics),
             rustdoc_types::ItemEnum::Impl(x) => Some(&x.generics),
+            rustdoc_types::ItemEnum::AssocType { generics, .. } => Some(generics),
             _ => None,
         })
     }

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -2537,7 +2537,7 @@ type ImplementedTrait {
 https://docs.rs/rustdoc-types/0.11.0/rustdoc_types/struct.Item.html
 https://docs.rs/rustdoc-types/latest/rustdoc_types/enum.ItemEnum.html#variant.AssocType
 """
-type AssociatedType implements Item {
+type AssociatedType implements Item & GenericItem {
   # properties from Item
   id: String!
   crate_id: Int!
@@ -2606,6 +2606,12 @@ type AssociatedType implements Item {
   an unstable associated type default is reported as absent.
   """
   has_default: Boolean!
+
+  # edges from GenericItem
+  """
+  Generic type, lifetime, or const parameters by which this associated type is parameterized.
+  """
+  generic_parameter: [GenericParameter]
 
   # edges from Item
   span: Span

--- a/test_crates/generic_associated_types/Cargo.toml
+++ b/test_crates/generic_associated_types/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "generic_associated_types"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]

--- a/test_crates/generic_associated_types/src/lib.rs
+++ b/test_crates/generic_associated_types/src/lib.rs
@@ -1,0 +1,21 @@
+use std::ops::Deref;
+
+// Example adapted from <https://rust-lang.github.io/rfcs/1598-generic_associated_types.html>
+
+pub trait LifetimeGenericTrait {
+    type Item<'a>;
+}
+
+pub trait TypeGenericTrait {
+    type Item<T>: Deref<Target = T>;
+}
+
+pub trait TypeLifetimeGenericTrait {
+    type Item<'a, T>: Deref<Target = T>;
+}
+
+pub trait ConstTrait<const N: usize> {}
+
+pub trait ConstGenericTrait {
+    type ConstTrait<const N: usize>: ConstTrait<N>;
+}


### PR DESCRIPTION
For use with https://github.com/obi1kenobi/cargo-semver-checks/issues/1660 to lint against generic associated types on traits.

I've added a test for when the GAT contains lifetimes, types or a paramaterized const.